### PR TITLE
Adjust quiz availability end time to 21:00 MSK

### DIFF
--- a/app/services/quiz.py
+++ b/app/services/quiz.py
@@ -41,9 +41,9 @@ async def can_start_quiz(
 
     Возвращает (можно_ли, причина_отказа).
     """
-    # Проверка времени: 10:00-00:00 МСК
-    if not is_game_time_allowed(10, 24):
-        return False, "Викторина доступна с 10:00 до 00:00 по Москве."
+    # Проверка времени: 10:00-21:00 МСК
+    if not is_game_time_allowed(10, 21):
+        return False, "Викторина доступна с 10:00 до 21:00 по Москве."
 
     # Проверка активной сессии
     active = await session.execute(


### PR DESCRIPTION
### Motivation
- Ограничить окно доступности викторины согласно новому требованию: завершение в 21:00 МСК вместо 00:00.

### Description
- В файле `app/services/quiz.py` обновлён проверочный вызов `can_start_quiz`: заменено `is_game_time_allowed(10, 24)` на `is_game_time_allowed(10, 21)` и скорректировано пользовательское сообщение на «Викторина доступна с 10:00 до 21:00 по Москве.».

### Testing
- Автоматические тесты не запускались для этого изменения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cb7c795888332b2ddeab87dddfe5b)