### PR TITLE
Разрешить ответ на упоминание бота даже в сообщениях-командах

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -94,8 +94,6 @@ def _is_bot_mentioned(message: Message, bot_user: object) -> bool:
 @router.message()
 async def mention_help(message: Message, bot: Bot) -> None:
     logger.info(f"HANDLER: mention_help called, text={message.text!r}")
-    if message.text and message.text.startswith("/"):
-        return
     me = await bot.get_me()
     if _is_bot_mentioned(message, me):
         username = getattr(me, "username", None)


### PR DESCRIPTION
### Motivation
- Исправить поведение, при котором обработчик упоминаний игнорировал сообщения, начинающиеся с `/`, чтобы бот отвечал на любое упоминание своего юзернейма.

### Description
- Удалён ранний выход из `mention_help` в `app/handlers/help.py` (убрана проверка `if message.text and message.text.startswith("/"):`), теперь функция отвечает на упоминания независимо от того, начинается ли сообщение с команды.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983059f785c83268a02cf804185b7e8)