### PR TITLE
Улучшить обработку упоминаний @jabchat_bot во всех топиках

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -91,9 +91,22 @@ def _is_bot_mentioned(message: Message, bot_user: object) -> bool:
     return False
 
 
-@router.message()
+@router.message(flags={"block": False})
 async def mention_help(message: Message, bot: Bot) -> None:
     logger.info(f"HANDLER: mention_help called, text={message.text!r}")
+    if message.from_user and message.from_user.is_bot:
+        return
+
+    text = _get_message_text(message)
+    entities = _get_message_entities(message)
+    has_possible_mention = False
+    if text and "@" in text:
+        has_possible_mention = True
+    if any(entity.type in {"mention", "text_mention"} for entity in entities):
+        has_possible_mention = True
+    if not has_possible_mention:
+        return
+
     me = await bot.get_me()
     if _is_bot_mentioned(message, me):
         username = getattr(me, "username", None)

--- a/app/main.py
+++ b/app/main.py
@@ -357,13 +357,13 @@ async def main() -> None:
     dp.update.outer_middleware(LoggingMiddleware())
     dp.error.register(error_handler)
 
-    # Порядок важен! Catch-all роутеры должны быть в конце
+    # Порядок важен: упоминания должны ловиться до остальных обработчиков
+    dp.include_router(help_handler.router)  # mention-help (catch-all, не блокирует)
     dp.include_router(admin.router)  # админ-команды
     dp.include_router(games.router)  # игры (команды /21, /score)
     dp.include_router(quiz.router)  # викторина (перед forms, т.к. есть catch-all)
     dp.include_router(forms.router)  # формы с FSM (перед модерацией!)
     dp.include_router(moderation.router)  # модерация (catch-all, пропускает FSM)
-    dp.include_router(help_handler.router)  # mention-help (catch-all) последним
     # stats.router убран — статистика через middleware
 
     await on_startup(bot)


### PR DESCRIPTION
### Motivation
- Пользователи ожидали, что при любом упоминании бота `@jabchat_bot` в любом контексте бот будет отвечать заранее подготовленными смешными фразами, но текущая реализация не срабатывала во всех случаях. 
- Нужно минимально вмешаться в порядок роутеров и обработчик упоминаний, не ломая существующую логику модерации и форм.

### Description
- Обновлён обработчик упоминаний `mention_help` в `app/handlers/help.py`: добавлен флаг `flags={"block": False}` чтобы не блокировать другие хендлеры, добавлена проверка и игнорирование сообщений от ботов, а также быстрые пред-проверки наличия `@` или сущностей перед вызовом `await bot.get_me()` чтобы избежать лишних API-вызовов. 
- Переставлен порядок включения роутеров в `app/main.py` так, что `help_handler.router` подключается перед остальными роутерами чтобы ловить упоминания до срабатывания других catch-all обработчиков. 
- Изменения минимальны и локализованы в двух файлах: `app/handlers/help.py` и `app/main.py`.

### Testing
- Запущена автоматическая проверка тестов командой `python -m pytest`, по результатам тест-коллекция не нашла тестов (0 collected) и процесс завершился без ошибок.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698307884c448326bdc895940387a0fb)