### PR TITLE
Поддержка пустых TOPIC_* и защита от битых ссылок

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -17,26 +18,55 @@ class Settings(BaseSettings):
     timezone: str = "Europe/Moscow"
     build_version: str = "dev"
 
-    topic_rules: int
-    topic_important: int
-    topic_buildings_41_42: int
-    topic_building_2: int
-    topic_building_3: int
-    topic_complaints: int
-    topic_rides: int
-    topic_smoke: int
-    topic_pets: int
-    topic_repair: int
-    topic_realty: int
-    topic_parents: int
-    topic_ads: int
-    topic_games: int
-    topic_gate: int
-    topic_services: int
-    topic_uk: int
-    topic_neighbors: int
-    topic_market: int
-    topic_duplex: int
+    topic_rules: int | None = None
+    topic_important: int | None = None
+    topic_buildings_41_42: int | None = None
+    topic_building_2: int | None = None
+    topic_building_3: int | None = None
+    topic_complaints: int | None = None
+    topic_rides: int | None = None
+    topic_smoke: int | None = None
+    topic_pets: int | None = None
+    topic_repair: int | None = None
+    topic_realty: int | None = None
+    topic_parents: int | None = None
+    topic_ads: int | None = None
+    topic_games: int | None = None
+    topic_gate: int | None = None
+    topic_services: int | None = None
+    topic_uk: int | None = None
+    topic_neighbors: int | None = None
+    topic_market: int | None = None
+    topic_duplex: int | None = None
+
+    @field_validator(
+        "topic_rules",
+        "topic_important",
+        "topic_buildings_41_42",
+        "topic_building_2",
+        "topic_building_3",
+        "topic_complaints",
+        "topic_rides",
+        "topic_smoke",
+        "topic_pets",
+        "topic_repair",
+        "topic_realty",
+        "topic_parents",
+        "topic_ads",
+        "topic_games",
+        "topic_gate",
+        "topic_services",
+        "topic_uk",
+        "topic_neighbors",
+        "topic_market",
+        "topic_duplex",
+        mode="before",
+    )
+    @classmethod
+    def _empty_to_none(cls, value: object) -> object:
+        if value == "":
+            return None
+        return value
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -254,7 +254,7 @@ TOPIC_KEYWORDS: dict[str, list[str]] = {
     "Правила": [],
 }
 
-TOPIC_THREADS: dict[str, int] = {
+TOPIC_THREADS: dict[str, int | None] = {
     "Шлагбаум": settings.topic_gate,
     "Ремонт": settings.topic_repair,
     "Жалобы": settings.topic_complaints,
@@ -283,7 +283,9 @@ def _chat_id_for_link(chat_id: int) -> str:
     return chat_id_str
 
 
-def _topic_link(title: str, thread_id: int) -> str:
+def _topic_link(title: str, thread_id: int | None) -> str:
+    if thread_id is None:
+        return title
     chat_id_str = _chat_id_for_link(settings.forum_chat_id)
     return f'<a href="https://t.me/c/{chat_id_str}/{thread_id}">{title}</a>'
 


### PR DESCRIPTION
### Motivation
- Предотвратить падение бота при частично заполненном `.env`, когда переменные TOPIC_* могут быть пустыми строками и приводить к ошибкам при генерации ссылок в справке.

### Description
- Сделаны поля `topic_*` опциональными (`int | None`) и добавлен `field_validator` `_empty_to_none` в `app/config.py`, который преобразует пустую строку в `None` для корректной загрузки из окружения.
- Обновлён `TOPIC_THREADS` и сигнатура функции `_topic_link` в `app/handlers/help.py` чтобы принимать `thread_id: int | None` и возвращать просто заголовок без ссылки, если ID топика отсутствует.

### Testing
- Автоматические тесты не запускались в этом PR, так как для полноценной проверки требуется заполненный `.env` с `BOT_TOKEN` и другими Telegram-параметрами; изменения небольшие и совместимы с текущим API приложения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983342d4d748326b51f90a8ca7d2712)