### PR TITLE
Пропуск автоматических задач при отсутствии `topic_*`

### DIFF
--- a/app/handlers/quiz.py
+++ b/app/handlers/quiz.py
@@ -86,6 +86,9 @@ def _display_name_from_user(user: object) -> str | None:
 
 async def announce_quiz_soon(bot: Bot) -> None:
     """Анонсирует старт викторины за 5 минут."""
+    if settings.topic_games is None:
+        logger.info("Анонс викторины пропущен: topic_games не задан.")
+        return
     await bot.send_message(
         settings.forum_chat_id,
         "уважаемые соседи через 5 минут начнется викторина в топике "
@@ -100,6 +103,9 @@ async def announce_quiz_soon(bot: Bot) -> None:
 
 async def start_quiz_auto(bot: Bot) -> None:
     """Автоматически запускает викторину."""
+    if settings.topic_games is None:
+        logger.info("Авто-викторина пропущена: topic_games не задан.")
+        return
     chat_id = settings.forum_chat_id
     topic_id = settings.topic_games
 

--- a/app/main.py
+++ b/app/main.py
@@ -139,6 +139,9 @@ async def load_initial_quiz_questions(session: AsyncSession) -> None:
 
 
 async def send_daily_summary(bot: Bot) -> None:
+    if settings.topic_smoke is None:
+        logger.info("Ежедневная сводка пропущена: topic_smoke не задан.")
+        return
     date_key = now_tz().date().isoformat()
     async for session in get_session():
         stats_rows = await get_daily_stats(session, settings.forum_chat_id, date_key)
@@ -161,6 +164,9 @@ async def send_daily_summary(bot: Bot) -> None:
 
 
 async def send_weekly_leaderboard(bot: Bot) -> None:
+    if settings.topic_games is None:
+        logger.info("Еженедельный рейтинг игр пропущен: topic_games не задан.")
+        return
     async for session in get_session():
         top_coins, top_games = await get_weekly_leaderboard(
             session, settings.forum_chat_id
@@ -210,6 +216,9 @@ async def heartbeat_job(bot: Bot) -> None:
 
 async def check_game_timeouts(bot: Bot) -> None:
     """Проверяет и отменяет просроченные игры (таймаут 10 минут)."""
+    if settings.topic_games is None:
+        logger.info("Проверка таймаутов игр пропущена: topic_games не задан.")
+        return
     now = datetime.now(timezone.utc)
     async for session in get_session():
         games = await get_all_active_games(session)


### PR DESCRIPTION
### Motivation
- После того как `topic_*` стал опциональным (пустые переменные загружаются как `None`), автоматические задачи и объявления продолжали передавать эти значения как `message_thread_id`, что приводило к отправке в основной чат или к ошибкам API; нужно явно пропускать отправку или планирование, если соответствующая `topic` не задана.

### Description
- Добавлены ранние проверки и логирование в `app/main.py` для `send_daily_summary`, `send_weekly_leaderboard` и `check_game_timeouts`, чтобы возвращаться без отправки, если `settings.topic_smoke`/`settings.topic_games` равны `None`.
- Добавлены ранние проверки и логирование в `app/handlers/quiz.py` для `announce_quiz_soon` и `start_quiz_auto`, чтобы пропускать автоматические анонсы/старт викторины при отсутствии `settings.topic_games`.
- Изменения минимальны и локализованы в `app/main.py` и `app/handlers/quiz.py` и не затрагивают публичные контракты.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698335ec8cd883268bdbaa2fe8380213)