### PR TITLE
Пропускать игры/викторину при отсутствии `topic_*` и считать пустые env как None

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -64,7 +64,7 @@ class Settings(BaseSettings):
     )
     @classmethod
     def _empty_to_none(cls, value: object) -> object:
-        if value == "":
+        if isinstance(value, str) and value.strip() == "":
             return None
         return value
 

--- a/app/handlers/games.py
+++ b/app/handlers/games.py
@@ -94,6 +94,8 @@ def format_game_state(
 
 @router.message(Command("21"))
 async def start_blackjack(message: Message) -> None:
+    if settings.topic_games is None:
+        return
     if (
         message.chat.id != settings.forum_chat_id
         or message.message_thread_id != settings.topic_games
@@ -133,6 +135,8 @@ async def start_blackjack(message: Message) -> None:
 
 @router.message(Command("score"))
 async def show_score(message: Message) -> None:
+    if settings.topic_games is None:
+        return
     if (
         message.chat.id != settings.forum_chat_id
         or message.message_thread_id != settings.topic_games
@@ -156,6 +160,8 @@ async def show_score(message: Message) -> None:
 
 @router.message(Command("21top"))
 async def show_leaderboard(message: Message) -> None:
+    if settings.topic_games is None:
+        return
     if (
         message.chat.id != settings.forum_chat_id
         or message.message_thread_id != settings.topic_games

--- a/app/handlers/quiz.py
+++ b/app/handlers/quiz.py
@@ -86,6 +86,9 @@ def _display_name_from_user(user: object) -> str | None:
 
 async def announce_quiz_soon(bot: Bot) -> None:
     """Анонсирует старт викторины за 5 минут."""
+    if settings.topic_games is None:
+        logger.info("Анонс викторины пропущен: topic_games не задан.")
+        return
     await bot.send_message(
         settings.forum_chat_id,
         "уважаемые соседи через 5 минут начнется викторина в топике "
@@ -100,6 +103,9 @@ async def announce_quiz_soon(bot: Bot) -> None:
 
 async def start_quiz_auto(bot: Bot) -> None:
     """Автоматически запускает викторину."""
+    if settings.topic_games is None:
+        logger.info("Авто-викторина пропущена: topic_games не задан.")
+        return
     chat_id = settings.forum_chat_id
     topic_id = settings.topic_games
 
@@ -235,6 +241,8 @@ async def start_quiz(message: Message, bot: Bot) -> None:
     """Команда /umnij для запуска викторины."""
     if message.chat.id != settings.forum_chat_id:
         return
+    if settings.topic_games is None:
+        return
 
     if message.message_thread_id != settings.topic_games:
         await message.reply("Эта команда доступна только в топике Игры.")
@@ -278,6 +286,8 @@ async def start_quiz(message: Message, bot: Bot) -> None:
 async def add_quiz_point_admin(message: Message, bot: Bot) -> None:
     """Админская команда для добавления +1 балла в викторине."""
     if message.from_user is None:
+        return
+    if settings.topic_games is None:
         return
     if not await is_admin(bot, settings.forum_chat_id, message.from_user.id):
         return
@@ -326,6 +336,8 @@ async def show_quiz_leaderboard(message: Message) -> None:
     """Команда /topumnij для показа рейтинга."""
     if message.chat.id != settings.forum_chat_id:
         return
+    if settings.topic_games is None:
+        return
 
     if message.message_thread_id != settings.topic_games:
         await message.reply("Эта команда доступна только в топике Игры.")
@@ -354,6 +366,8 @@ async def show_quiz_leaderboard(message: Message) -> None:
 async def check_quiz_answer(message: Message, bot: Bot) -> None:
     """Проверяет ответы на вопросы викторины."""
     if message.from_user is None:
+        return
+    if settings.topic_games is None:
         return
 
     # Пропускаем команды

--- a/app/main.py
+++ b/app/main.py
@@ -139,6 +139,9 @@ async def load_initial_quiz_questions(session: AsyncSession) -> None:
 
 
 async def send_daily_summary(bot: Bot) -> None:
+    if settings.topic_smoke is None:
+        logger.info("Ежедневная сводка пропущена: topic_smoke не задан.")
+        return
     date_key = now_tz().date().isoformat()
     async for session in get_session():
         stats_rows = await get_daily_stats(session, settings.forum_chat_id, date_key)
@@ -161,6 +164,9 @@ async def send_daily_summary(bot: Bot) -> None:
 
 
 async def send_weekly_leaderboard(bot: Bot) -> None:
+    if settings.topic_games is None:
+        logger.info("Еженедельный рейтинг игр пропущен: topic_games не задан.")
+        return
     async for session in get_session():
         top_coins, top_games = await get_weekly_leaderboard(
             session, settings.forum_chat_id
@@ -210,6 +216,9 @@ async def heartbeat_job(bot: Bot) -> None:
 
 async def check_game_timeouts(bot: Bot) -> None:
     """Проверяет и отменяет просроченные игры (таймаут 10 минут)."""
+    if settings.topic_games is None:
+        logger.info("Проверка таймаутов игр пропущена: topic_games не задан.")
+        return
     now = datetime.now(timezone.utc)
     async for session in get_session():
         games = await get_all_active_games(session)


### PR DESCRIPTION
### Motivation
- Исправить падения и некорректную отправку сообщений, когда переменные `topic_*` отсутствуют или заданы пустыми/пробельными строками, из‑за чего `message_thread_id` получал некорректные значения.
- Избежать автоматических запусков/анонсов викторины и задач по играм в основном чате при отсутствии настроенного топика.

### Description
- В `app/config.py` обновлён валидатор `Settings._empty_to_none`, чтобы считать пустые или состоящие только из пробелов строковые переменные окружения за `None` (замена `value == ""` на `isinstance(value, str) and value.strip() == ""`).
- В `app/handlers/quiz.py` добавлены ранние проверки `if settings.topic_games is None` и логирование в автоматических задачах `announce_quiz_soon` и `start_quiz_auto`, а также в командах/обработчиках `start_quiz`, `add_quiz_point_admin`, `show_quiz_leaderboard` и `check_quiz_answer`, чтобы не выполнять логику без `topic_games`.
- В `app/handlers/games.py` добавлены guard‑условия `if settings.topic_games is None` в командах `start_blackjack`, `show_score` и `show_leaderboard`, чтобы предотвратить работу игровых команд вне настроенного топика.
- В `app/main.py` добавлены ранние возвраты и логирование для `send_daily_summary`, `send_weekly_leaderboard` и `check_game_timeouts`, чтобы пропускать отправку/планирование при отсутствии соответствующих `topic_*` (`topic_smoke` / `topic_games`).

### Testing
- Автоматические тесты не запускались; изменений немного и они локальны, гарантирующие ранние возвраты и уменьшение случаев передачи `None` в `message_thread_id`.
- Локальная сборка/коммит выполнены (без тестов); дальнейшее покрытие рекомендовано через `pytest` на сценариях отправки сообщений при unset/blank `topic_*` и через интеграционные тесты для cron‑тасков.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698335ec8cd883268bdbaa2fe8380213)