### PR TITLE
Исправления: help routing, ключевые слова «Питомцы», Boolean для QuizSession и таймаут игр

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -177,6 +177,7 @@ TOPIC_KEYWORDS: dict[str, list[str]] = {
         "продаю",
         "продается",
         "барахолка",
+        "объявление",
         "объявлен",
         "б/у",
     ],
@@ -185,30 +186,13 @@ TOPIC_KEYWORDS: dict[str, list[str]] = {
         "кошка",
         "котик",
         "котён",
-        "сломал",
-        "течёт",
-        "шум",
-        "грязно",
-        "холодно",
-    ],
-    "Барахолка": [
-        "продам",
-        "куплю",
-        "отдам",
-        "даром",
-        "обмен",
-        "продаю",
-        "барахолка",
-        "объявление",
-    ],
-    "Питомцы": [
-        "кот",
-        "кошка",
-        "котик",
         "собак",
         "пёс",
         "щенок",
         "ветеринар",
+        "питом",
+        "прививк",
+        "корм",
         "потерялся",
     ],
     "Мамы и папы": [
@@ -569,17 +553,13 @@ async def help_topic(callback: CallbackQuery) -> None:
         )
     await callback.message.edit_text(
         reply_text,
+        reply_markup=_back_keyboard(),
         parse_mode="HTML",
     )
     schedule_help_delete(
         callback.message.bot,
         callback.message.chat.id,
         callback.message.message_id,
-    )
-    await callback.message.edit_text(
-        description,
-        reply_markup=_back_keyboard(),
-        parse_mode="HTML",
     )
     await callback.answer()
 

--- a/app/models.py
+++ b/app/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db import Base
@@ -93,7 +93,7 @@ class QuizSession(Base):
     current_question_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     question_number: Mapped[int] = mapped_column(Integer, default=1)
     question_started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    is_active: Mapped[bool] = mapped_column(Integer, default=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     used_question_ids: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 

--- a/app/services/games.py
+++ b/app/services/games.py
@@ -244,7 +244,7 @@ def register_coin_grant(stats: UserStat, now: datetime, amount: int) -> None:
     stats.coins += amount
 
 
-GAME_TIMEOUT_MINUTES = 1
+GAME_TIMEOUT_MINUTES = 10
 
 
 async def get_all_active_games(


### PR DESCRIPTION
### Motivation
- Устранить некорректную классификацию тем и дублирование ключевых слов в подсказках, чтобы `help` корректно предлагал топики. 
- Избежать лишнего двойного редактирования сообщения в обработчике выбора темы, которое приводило к визуальным артефактам. 
- Привести модель сессии викторины в соответствие с логикой (`bool` для флага активности) и согласовать поведение таймаутов игр.

### Description
- Обновлён `TOPIC_KEYWORDS` в `app/handlers/help.py`: удалены дубли и нерелевантные ключи, добавлены целевые ключи для раздела "Питомцы" (`"питом"`, `"прививк"`, `"корм"`) для улучшения классификации.
- Исправлен обработчик `help_topic` в `app/handlers/help.py`, теперь сообщение редактируется один раз с `reply_markup=_back_keyboard()` и затем планируется удаление через `schedule_help_delete`, что убирает лишние двойные вызовы `edit_text`.
- В `app/models.py` поле `QuizSession.is_active` изменено с `Integer` на `Boolean` и импортирован `Boolean` из SQLAlchemy для корректного соответствия типу данных модели.
- В `app/services/games.py` константа `GAME_TIMEOUT_MINUTES` увеличена с `1` до `10` для более реалистичного таймаута активных игр и согласована с поведенческой логикой очистки просроченных игр.

### Testing
- Локальные автоматизированные тесты не запускались в ходе этого изменения (нет модульных тестов изменённых участков в репозитории); изменения проверены статическим просмотром кода и логикой вызовов в соответствующих обработчиках и сервисах. 
- Прогон линтера/форматирования не выполнялся как часть этого PR. 
- Рекомендуется после слияния запустить `pytest` и интеграционные проверки на тестовой среде с реальным `BOT_TOKEN` и БД, чтобы подтвердить поведение воркфлоу викторины и игрового таймаута.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983388826648326abfc22a896a315a4)