### PR TITLE
Повторы при старте Telegram, миграция is_active→BOOLEAN, правки /help и таймаута игр

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -177,6 +177,7 @@ TOPIC_KEYWORDS: dict[str, list[str]] = {
         "продаю",
         "продается",
         "барахолка",
+        "объявление",
         "объявлен",
         "б/у",
     ],
@@ -185,30 +186,13 @@ TOPIC_KEYWORDS: dict[str, list[str]] = {
         "кошка",
         "котик",
         "котён",
-        "сломал",
-        "течёт",
-        "шум",
-        "грязно",
-        "холодно",
-    ],
-    "Барахолка": [
-        "продам",
-        "куплю",
-        "отдам",
-        "даром",
-        "обмен",
-        "продаю",
-        "барахолка",
-        "объявление",
-    ],
-    "Питомцы": [
-        "кот",
-        "кошка",
-        "котик",
         "собак",
         "пёс",
         "щенок",
         "ветеринар",
+        "питом",
+        "прививк",
+        "корм",
         "потерялся",
     ],
     "Мамы и папы": [
@@ -444,7 +428,6 @@ async def help_command(message: Message) -> None:
         key = _state_key(message.chat.id, message.from_user.id)
         _clear_waiting_state(key)
     response = await message.answer(
-    await message.answer(
         HELP_MENU_TEXT,
         reply_markup=_menu_keyboard(),
         parse_mode="HTML",
@@ -569,17 +552,13 @@ async def help_topic(callback: CallbackQuery) -> None:
         )
     await callback.message.edit_text(
         reply_text,
+        reply_markup=_back_keyboard(),
         parse_mode="HTML",
     )
     schedule_help_delete(
         callback.message.bot,
         callback.message.chat.id,
         callback.message.message_id,
-    )
-    await callback.message.edit_text(
-        description,
-        reply_markup=_back_keyboard(),
-        parse_mode="HTML",
     )
     await callback.answer()
 

--- a/app/models.py
+++ b/app/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db import Base
@@ -93,7 +93,7 @@ class QuizSession(Base):
     current_question_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     question_number: Mapped[int] = mapped_column(Integer, default=1)
     question_started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    is_active: Mapped[bool] = mapped_column(Integer, default=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     used_question_ids: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 

--- a/app/services/games.py
+++ b/app/services/games.py
@@ -244,7 +244,7 @@ def register_coin_grant(stats: UserStat, now: datetime, amount: int) -> None:
     stats.coins += amount
 
 
-GAME_TIMEOUT_MINUTES = 1
+GAME_TIMEOUT_MINUTES = 10
 
 
 async def get_all_active_games(


### PR DESCRIPTION
### Motivation
- Исправить проблему падения бота при кратковременных сетевых сбоях при старте и закрывать ресурсы корректно. 
- Привести модель `QuizSession.is_active` в соответствие с ожидаемым булевым типом и обеспечить безопасную миграцию для PostgreSQL. 
- Устранить логические/синтаксические ошибки в обработчике помощи и снизить количество ложных таймаутов игровых сессий.

### Description
- Добавлен цикл повторных попыток вокруг `await bot.get_me()` с перехватом `TelegramNetworkError`, логированием и паузой в 5 секунд, максимум 3 попытки, после чего ошибка пробрасывается; это в `app/main.py` (функция `on_startup`).
- Обеспечено безопасное завершение: переменная `scheduler` инициализируется как `AsyncIOScheduler | None`, в `finally` выполняется `scheduler.shutdown()` только если планировщик создан, и всегда закрывается `bot.session` (в `app/main.py`).
- В `app/models.py` поле `QuizSession.is_active` приведено к `Boolean` через `mapped_column(Boolean, default=True)`, а в `app/main.py` в `init_db` добавлена логика: при наличии таблицы `quiz_sessions` добавляется колонка `used_question_ids`, и для PostgreSQL при обнаружении старого `Integer` типа выполняется `ALTER TABLE ... TYPE BOOLEAN USING is_active::boolean` (инспекция колонок исправлена для доступа к метаданным).
- Исправлена логика обработчика помощи в `app/handlers/help.py`: удалён дублированный `await message.answer`, удалено повторное `edit_text`, скорректированы и упорядочены ключевые слова тем и добавлено `reply_markup=_back_keyboard()` при показе темы.
- Увеличен таймаут игр: константа `GAME_TIMEOUT_MINUTES` в `app/services/games.py` изменена с `1` на `10` минут, и функция `is_game_timed_out` использует эту константу.

### Testing
- Выполнена статическая проверка компиляции пакета командой `python -m compileall app`, которая прошла успешно. 
- Попытка запустить приложение `BOT_TOKEN=123:ABC FORUM_CHAT_ID=1 ADMIN_LOG_CHAT_ID=1 python -m app.main` показала корректные логи повторных попыток к Telegram API (две/три попытки), но завершилась неуспехом из-за отсутствия сетевого доступа в окружении (`Network is unreachable`), что подтверждает срабатывание новых обработок повторов и логов.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983388826648326abfc22a896a315a4)