### PR TITLE
Исправить проверку админов и обработку ответов викторины

### DIFF
--- a/app/utils/admin.py
+++ b/app/utils/admin.py
@@ -2,13 +2,28 @@
 
 from __future__ import annotations
 
+import logging
+
 from aiogram import Bot
 from aiogram.types import Message
+
+logger = logging.getLogger(__name__)
 
 
 async def is_admin(bot: Bot, chat_id: int, user_id: int) -> bool:
     member = await bot.get_chat_member(chat_id, user_id)
     return member.status in {"administrator", "creator"}
+
+
+async def is_admin_message(bot: Bot, chat_id: int, message: Message) -> bool:
+    """Проверяет права администратора для сообщения, включая анонимных админов."""
+    if message.from_user is None:
+        return bool(message.sender_chat and message.sender_chat.id == chat_id)
+    try:
+        return await is_admin(bot, chat_id, message.from_user.id)
+    except Exception:  # noqa: BLE001 - не выдаём доступ при ошибке проверки
+        logger.exception("Не удалось проверить права администратора.")
+        return False
 
 
 def extract_target_user(message: Message) -> tuple[int | None, str | None]:


### PR DESCRIPTION
### Motivation
- Исправить ситуацию, когда админские команды (например, `/bal`) не работали для анонимных админов и при ошибках проверки прав Telegram API.
- Обеспечить корректную фиксацию ответов викторины, включая ответы в подписях (caption), и начисление баллов при распознанном ответе.

### Description
- Добавлена функция `is_admin_message` в `app/utils/admin.py` с поддержкой анонимных админов и логированием ошибок при проверке прав вместо падения приложения.
- В `app/handlers/quiz.py` команда `/bal` теперь использует `is_admin_message` для проверки прав, что позволяет работать с анонимными админами.
- Обновлён обработчик ответов викторины: декоратор теперь принимает `(F.text | F.caption)`, введена переменная `message_text = message.text or message.caption`, и проверка ответа выполняется через `check_answer(question, message_text)` с ранними возвратами при отсутствии текста или при командах.
- Небольшие импорт/логические правки и добавление логирования для устойчивости при ошибках API; затронуты файлы `app/utils/admin.py` и `app/handlers/quiz.py`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983853274288326b79305e3d80c7f36)