### PR TITLE
Перевёл викторину на загрузку только из текстового файла и исключение повторов

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -268,7 +268,7 @@ async def load_quiz_questions(message: Message, bot: Bot) -> None:
 
     from app.services.quiz_loader import (
         load_questions_from_text,
-        save_questions_to_db,
+        sync_questions_from_text,
     )
 
     status_msg = await message.reply("Начинаю загрузку вопросов...")
@@ -312,15 +312,15 @@ async def load_quiz_questions(message: Message, bot: Bot) -> None:
         await status_msg.edit_text("Вопросы не найдены ни в одном источнике.")
         return
 
-    # Сохраняем в БД
+    # Полностью пересобираем БД викторины из текстового файла
     async for session in get_session():
-        added = await save_questions_to_db(session, questions)
+        total, unique = await sync_questions_from_text(session)
 
     details = "\n".join(f"• {name}: найдено {count}" for name, count in source_stats)
     await status_msg.edit_text(
         f"Загрузка завершена!\n"
-        f"Найдено вопросов: {len(questions)}\n"
-        f"Добавлено новых: {added}\n"
+        f"Прочитано вопросов: {total}\n"
+        f"Уникальных в БД: {unique}\n"
         f"{details}"
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -84,6 +84,13 @@ class QuizQuestion(Base):
     answer: Mapped[str] = mapped_column(Text)
 
 
+class QuizUsedQuestion(Base):
+    __tablename__ = "quiz_used_questions"
+
+    question_normalized: Mapped[str] = mapped_column(Text, primary_key=True)
+    used_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
 class QuizSession(Base):
     __tablename__ = "quiz_sessions"
 

--- a/tests/test_quiz_used_questions.py
+++ b/tests/test_quiz_used_questions.py
@@ -1,0 +1,52 @@
+"""Почему: гарантируем глобальное исключение уже использованных вопросов викторины."""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.models import QuizQuestion, QuizSession
+from app.services.quiz import get_random_question, set_current_question
+
+
+def test_get_random_question_ignores_globally_used() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with session_factory() as session:
+            q1 = QuizQuestion(question="Вопрос 1", answer="Ответ 1")
+            q2 = QuizQuestion(question="Вопрос 2", answer="Ответ 2")
+            quiz_session = QuizSession(
+                chat_id=1,
+                topic_id=1,
+                is_active=True,
+                question_number=0,
+            )
+            session.add_all([q1, q2, quiz_session])
+            await session.commit()
+            await session.refresh(quiz_session)
+
+            first = await get_random_question(session, quiz_session)
+            assert first is not None
+            await set_current_question(session, quiz_session, first)
+            await session.commit()
+
+            second = await get_random_question(session, quiz_session)
+            assert second is not None
+            assert second.question != first.question
+
+            await set_current_question(session, quiz_session, second)
+            await session.commit()
+
+            third = await get_random_question(session, quiz_session)
+            assert third is None
+
+        await engine.dispose()
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Убрать использование внешних/старых источников вопросов и гарантировать, что в базу попадают только вопросы из локального текстового файла. 
- Обеспечить невозможность повторного использования одного и того же вопроса между сессиями и после перезапуска бота.

### Description
- Перевёл стартовую загрузку на синхронизацию из `app/data/quiz_questions.txt` вызовом `sync_questions_from_text` в `load_initial_quiz_questions` (удалён XLSX-фоллбэк). 
- Добавил функцию `sync_questions_from_text` в `app/services/quiz_loader.py`, которая читает файл, дедуплицирует вопросы по нормализованному тексту, очищает таблицу `quiz_questions` и наполняет её актуальными записями. 
- Вынес глобальную историю использованных вопросов в новую модель `QuizUsedQuestion` (`app/models.py`) и сохраняю нормализованный вопрос при установке текущего вопроса в `set_current_question`. 
- Изменил `get_random_question` в `app/services/quiz.py`, чтобы исключать вопросы как из текущей сессии, так и из глобальной истории `quiz_used_questions`, и обновил админ-команду `/load_quiz` в `app/handlers/admin.py` и автозагрузку `auto_load_quiz_questions` для работы только с текстовым файлом.
- Добавлен тест `tests/test_quiz_used_questions.py`, проверяющий, что вопросы не повторяются при последовательной выдаче на in-memory SQLite.

### Testing
- Запущены unit-тесты командой `PYTHONPATH=. pytest -q`, результат: `3 passed`.
- Добавлен и прогнан тест `tests/test_quiz_used_questions.py`, который успешно проверяет поведение исключения повторов в памяти SQLite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864d877be88326843e8d8f22db2e31)