### PR TITLE
Блокировать старт викторины при недостатке новых (неиспользованных) вопросов

### DIFF
--- a/tests/test_quiz_used_questions.py
+++ b/tests/test_quiz_used_questions.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.db import Base
 from app.models import QuizQuestion, QuizSession
-from app.services.quiz import get_random_question, set_current_question
+from app.services.quiz import can_start_quiz, get_random_question, set_current_question
 
 
 def test_get_random_question_ignores_globally_used() -> None:
@@ -46,6 +46,46 @@ def test_get_random_question_ignores_globally_used() -> None:
 
             third = await get_random_question(session, quiz_session)
             assert third is None
+
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_can_start_quiz_checks_available_questions_only() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with session_factory() as session:
+            session.add_all(
+                [
+                    QuizQuestion(question=f"Вопрос {index}", answer=f"Ответ {index}")
+                    for index in range(1, 11)
+                ]
+            )
+            await session.commit()
+
+            quiz_session = QuizSession(chat_id=1, topic_id=1, is_active=True, question_number=0)
+            session.add(quiz_session)
+            await session.commit()
+            await session.refresh(quiz_session)
+
+            for _ in range(10):
+                question = await get_random_question(session, quiz_session)
+                assert question is not None
+                await set_current_question(session, quiz_session, question)
+                await session.commit()
+
+            quiz_session.is_active = False
+            await session.commit()
+
+            can_start, reason = await can_start_quiz(session, 1, 1)
+            assert can_start is False
+            assert "Недостаточно новых вопросов" in reason
 
         await engine.dispose()
 


### PR DESCRIPTION
### Motivation
- Админ запускал `/umnij_start`, команда подтверждалась, но вопросов не приходило из-за рассогласования: логика старта смотрела на общее число строк в БД, а выдача вопросов учитывала только неиспользованные (глобально исключённые) записи.
- Надо гарантировать, что ручной/автостарт запрещается, если в базе нет минимум `10` новых вопросов (не считая уже использованных), и дать понятную причину отмены.

### Description
- Добавлена функция `get_available_questions_count(session: AsyncSession)` в `app/services/quiz.py`, которая считает именно доступные (неиспользованные) вопросы по данным из `quiz_used_questions` и `quiz_questions`.
- Переписана логика проверки старта викторины — теперь `can_start_quiz` использует `get_available_questions_count` вместо общего счёта строк, и возвращает понятное сообщение о нехватке новых вопросов.
- `get_questions_left` теперь возвращает количество реально доступных вопросов (через `get_available_questions_count`).
- Добавлен тест `test_can_start_quiz_checks_available_questions_only` в `tests/test_quiz_used_questions.py`, воспроизводящий сценарий, когда в таблице есть 10 записей, но все они уже помечены как использованные, и ожидающий блокировку старта.

### Testing
- Запущены тесты: `pytest -q tests/test_quiz_loader_xlsx.py tests/test_quiz_used_questions.py tests/test_quiz_answer_format.py tests/test_quiz_loader_text.py` и все тесты прошли успешно (`10 passed`).
- Добавленный тест `test_can_start_quiz_checks_available_questions_only` проходит и покрывает регрессию, связанную с проверкой доступности вопросов.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872ab82ed08326889b7ed82efc636b)