### PR TITLE
fix: включить viktorinavopros_QA.xlsx в Docker-образ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ ./app/
+COPY viktorinavopros_QA.xlsx ./viktorinavopros_QA.xlsx
 
 RUN mkdir -p /app/data
 


### PR DESCRIPTION
### Motivation
- Бот отвечал «Файл с вопросами не найден или пуст.», потому что загрузчик ожидает `viktorinavopros_QA.xlsx` в корне проекта, а в образ ранее копировалась только папка `app/`, поэтому файл отсутствовал в контейнере.

### Description
- Добавлено копирование файла `viktorinavopros_QA.xlsx` в Docker-образ путём добавления строки `COPY viktorinavopros_QA.xlsx ./viktorinavopros_QA.xlsx` в `Dockerfile`, чтобы путь `/app/viktorinavopros_QA.xlsx` был доступен в рантайме.

### Testing
- Локальная проверка чтения XLSX выполнена командой пробного скрипта `python - <<'PY'` и показала, что файл найден и парсер возвращает `1059` вопросов (успешно).
- Прогнанны автоматизированные тесты загрузчика вопроса командой `pytest -q tests/test_quiz_loader_xlsx.py tests/test_quiz_loader_text.py`, все тесты прошли: `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872e089fdc8326be1d857929d60fd0)