### PR TITLE
Исправить /help (Bad Request) и добавить контекст диалога для ИИ

### DIFF
--- a/tests/test_help_ai_context.py
+++ b/tests/test_help_ai_context.py
@@ -1,0 +1,35 @@
+from app.handlers.help import (
+    AI_CHAT_HISTORY,
+    AI_CHAT_HISTORY_LIMIT,
+    _get_ai_context,
+    _remember_ai_exchange,
+)
+
+
+def setup_function() -> None:
+    AI_CHAT_HISTORY.clear()
+
+
+def test_ai_context_remembers_previous_messages() -> None:
+    _remember_ai_exchange(1, 2, "Первый вопрос", "Первый ответ")
+    _remember_ai_exchange(1, 2, "Второй вопрос", "Второй ответ")
+
+    context = _get_ai_context(1, 2)
+
+    assert context == [
+        "user: Первый вопрос",
+        "assistant: Первый ответ",
+        "user: Второй вопрос",
+        "assistant: Второй ответ",
+    ]
+
+
+def test_ai_context_is_limited() -> None:
+    for index in range(AI_CHAT_HISTORY_LIMIT):
+        _remember_ai_exchange(10, 20, f"q{index}", f"a{index}")
+
+    context = _get_ai_context(10, 20)
+
+    assert len(context) == AI_CHAT_HISTORY_LIMIT
+    assert context[0] == "user: q10"
+    assert context[-1] == "assistant: a19"


### PR DESCRIPTION
### Motivation
- `/help` иногда падал с `Bad Request` при вставке текста с символами `<...>` из админ-справки из-за указания `parse_mode="HTML"` в местах без HTML-разметки.
- ИИ-ответы не учитывали предыдущие сообщения пользователя в чате, поэтому ассистент часто отвечал как на «первое» сообщение.

### Description
- Убрана явная передача `parse_mode="HTML"` в местах, где выводятся обычные тексты меню/ожидания/rate-limit/timeout, чтобы избежать `Bad Request` при наличии символов `<` и `>`; при этом HTML всё ещё используется там, где нужен (ссылки в теме).
- Добавлено простое хранение истории разговоров в `help`-хендлере через `AI_CHAT_HISTORY` (словарь `tuple(chat_id, user_id)` → `deque[str]`) и константа `AI_CHAT_HISTORY_LIMIT = 20`.
- Добавлены вспомогательные функции ` _get_ai_context`, `_remember_ai_exchange` и `_ai_key`, контекст теперь передаётся в `get_ai_client().assistant_reply(...)` для команд `/ai` и ответов на упоминания бота, а после ответа пара `user/assistant` сохраняется (с усечением по длине).
- Добавлен unit-тест `tests/test_help_ai_context.py` для проверки запоминания реплик и ограничения длины истории.

### Testing
- Запущены тесты через `pytest -q`, все тесты прошли успешно (`20 passed`).
- Добавлен и прогнан новый тест `tests/test_help_ai_context.py`, проверка контекста и лимита истории прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d73d1d8c832693e65ccab56198cb)