### PR TITLE
Включить AI-ответы для `/ai` и упоминаний + антиспам для упоминаний

### DIFF
--- a/tests/test_help_ai_context.py
+++ b/tests/test_help_ai_context.py
@@ -1,13 +1,27 @@
+from datetime import datetime, timedelta, timezone
+
 from app.handlers.help import (
     AI_CHAT_HISTORY,
     AI_CHAT_HISTORY_LIMIT,
+    LAST_AI_REPLY_TIME,
     _get_ai_context,
+    _is_ai_reply_rate_limited,
+    _extract_ai_prompt,
     _remember_ai_exchange,
 )
 
 
+class _DummyMessage:
+    def __init__(self, text: str | None = None, caption: str | None = None) -> None:
+        self.text = text
+        self.caption = caption
+        self.entities = None
+        self.caption_entities = None
+
+
 def setup_function() -> None:
     AI_CHAT_HISTORY.clear()
+    LAST_AI_REPLY_TIME.clear()
 
 
 def test_ai_context_remembers_previous_messages() -> None:
@@ -33,3 +47,21 @@ def test_ai_context_is_limited() -> None:
     assert len(context) == AI_CHAT_HISTORY_LIMIT
     assert context[0] == "user: q10"
     assert context[-1] == "assistant: a19"
+
+
+def test_extract_ai_prompt_from_command() -> None:
+    message = _DummyMessage(text="/ai Как открыть шлагбаум?")
+    assert _extract_ai_prompt(message) == "Как открыть шлагбаум?"
+
+
+def test_extract_ai_prompt_from_plain_text() -> None:
+    message = _DummyMessage(text="@alexbot помоги с подъездом")
+    assert _extract_ai_prompt(message) == "@alexbot помоги с подъездом"
+
+
+def test_ai_reply_rate_limit_blocks_fast_repeat() -> None:
+    assert _is_ai_reply_rate_limited(1, 2) is False
+    assert _is_ai_reply_rate_limited(1, 2) is True
+
+    LAST_AI_REPLY_TIME[(1, 2)] = datetime.now(timezone.utc) - timedelta(seconds=21)
+    assert _is_ai_reply_rate_limited(1, 2) is False


### PR DESCRIPTION
### Motivation
- Исправить поведение, при котором `/ai` был заглушен и при упоминаниях бот возвращал только рандомные фразы, в результате чего пользователи видели «бот не отвечает». 
- Подключить существующий AI-фасад так, чтобы при недоступности remote-провайдера работал локальный fallback без падений.

### Description
- В `app/handlers/help.py` включена реальная обработка команды `/ai`: извлечение промпта, вызов `get_ai_client().assistant_reply(...)`, сохранение контекста диалога через историю и возврат ответа пользователю. 
- Обработчик упоминаний (`BotMentionFilter`) теперь при наличии осмысленного текста отправляет запрос в AI/fallback, а при пустом упоминании оставляет локальную шутку; добавлена функция `_extract_ai_prompt` для корректного извлечения текста запроса. 
- Добавлен мягкий антиспам: per-user cooldown `AI_MENTION_COOLDOWN = 20s` для упоминаний, реализованный через `LAST_AI_REPLY_TIME` и `_is_ai_reply_rate_limited`. 
- Добавлены и обновлены юнит-тесты в `tests/test_help_ai_context.py` для `_extract_ai_prompt` и rate-limit логики; изменён файл `app/handlers/help.py` (AI-поток и rate-limit).

### Testing
- Запущены unit-тесты через `pytest -q`, результат: `30 passed`. 
- Выполнена проверка компиляции через `python -m compileall app tests`, результат: успешно. 
- Локальная логика fallback и защитные guard-clauses покрыты тестами и ручным просмотром кода (нет падений при отсутствии `AI_KEY`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922ab175708326aa807d32a231457a)