### PR TITLE
Добавить трехслойную AI probe-диагностику

### DIFF
--- a/app/utils/admin_help.py
+++ b/app/utils/admin_help.py
@@ -15,6 +15,7 @@ ADMIN_HELP = (
     "/ai_off — локальный режим (заглушка ИИ)\n"
     "/ai_status — статус заглушки ИИ\n"
     "/ai_ping — проверка stub-провайдера\n"
+    "/ai_probe — проверка ИИ в 3 слоя (конфиг/API/usage)\n"
     "/ai_reset — очистить будущие AI-счетчики\n"
     "/reload_profanity\n"
     "/load_quiz — загрузить вопросы викторины из viktorinavopros_QA.xlsx\n"

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -7,6 +7,7 @@ from app.services.ai_module import (
     OpenRouterProvider,
     build_local_assistant_reply,
     detect_profanity,
+    get_ai_diagnostics,
     is_assistant_topic_allowed,
     local_quiz_answer_decision,
     mask_personal_data,
@@ -93,3 +94,13 @@ def test_openrouter_summary_fallback_on_runtime_error(monkeypatch) -> None:
     result = asyncio.run(provider.generate_daily_summary("ctx", chat_id=1))
     assert result is None
     asyncio.run(provider.aclose())
+
+
+def test_get_ai_diagnostics_for_stub(monkeypatch) -> None:
+    async def _fake_usage(chat_id: int) -> tuple[int, int]:
+        return (0, 0)
+
+    monkeypatch.setattr("app.services.ai_module.get_ai_usage_for_today", _fake_usage)
+    report = asyncio.run(get_ai_diagnostics(chat_id=1))
+    assert report.provider_mode == "stub"
+    assert report.probe_ok is False


### PR DESCRIPTION
### Motivation
- Нужен быстрый и однозначный способ проверить, работает ли бот в remote-режиме или в stub-режиме через единую команду (конфиг → реальный вызов → подтверждение по учёту). 
- Логирование вызовов AI и простая диагностическая точка помогут оперативно подтверждать обращения к внешнему AI по логам/БД.

### Description
- Добавлен `AiDiagnosticsReport` и сервис `get_ai_diagnostics(chat_id)` в `app/services/ai_module.py` для агрегирования трёх слоёв диагностики (конфиг, `probe()`, usage за день). 
- В `OpenRouterProvider._chat_completion()` добавлены информационные лог-записи перед и после HTTP-вызова: `logger.info("AI request -> model=%s chat_id=%s", ...)` и `logger.info("AI response <- tokens=%s chat_id=%s", ...)`. 
- Добавлена админ-команда `/ai_probe` в `app/handlers/admin.py`, которая администратору возвращает: конфиг (ai_enabled/ai_key/provider/api_url), результат реального вызова с latency и сегодняшние `requests/tokens`. 
- Обновлена справка админа `app/utils/admin_help.py` и добавлен тест `test_get_ai_diagnostics_for_stub` в `tests/test_ai_module.py`.

### Testing
- Запущены целевые тесты командой `pytest -q tests/test_ai_module.py tests/test_config_settings.py`, все тесты прошли успешно. 
- Запущена полная тестовая база командой `pytest -q` и тест-сьют завершился успешно (`32 passed`). 
- В тестах покрыт сценарий stub-режима для `get_ai_diagnostics` через `test_get_ai_diagnostics_for_stub`, который проходит.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922d6181f48326b78dee63402dc50e)