### PR TITLE
Поддержать OPENROUTER_API_KEY как алиас для AI_KEY (health-check, конфиг, тесты, docs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ BUILD_VERSION=dev
 AI_ENABLED=true
 AI_API_URL=https://openrouter.ai/api/v1
 AI_KEY=your_openrouter_api_key
+# Альтернативное имя (поддерживается как алиас):
+OPENROUTER_API_KEY=
 AI_MODEL=qwen/qwen3-14b
 AI_TIMEOUT_SECONDS=20
 AI_RETRIES=2

--- a/README.md
+++ b/README.md
@@ -126,13 +126,15 @@ python -m app.main
 python scripts/check_openrouter.py --api-key sk-or-...
 ```
 
-Если аргументы не переданы, скрипт берёт `AI_KEY`, `AI_MODEL`, `AI_API_URL`
+Если аргументы не переданы, скрипт берёт `AI_KEY` (или `OPENROUTER_API_KEY`), `AI_MODEL`, `AI_API_URL`
 сначала из переменных окружения процесса, затем из локального файла `.env`.
 
 Или через переменные окружения:
 
 ```bash
 AI_KEY=sk-or-... AI_MODEL=qwen/qwen3-14b python scripts/check_openrouter.py
+# или
+OPENROUTER_API_KEY=sk-or-... AI_MODEL=qwen/qwen3-14b python scripts/check_openrouter.py
 ```
 
 Скрипт вернет `ok/status_code/latency_ms/details` и завершится кодом:

--- a/app/config.py
+++ b/app/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from pydantic import ValidationError, field_validator
+from pydantic import AliasChoices, Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -26,7 +26,10 @@ class Settings(BaseSettings):
     build_version: str = "dev"
     ai_enabled: bool = True
     ai_api_url: str | None = None
-    ai_key: str | None = None
+    ai_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("AI_KEY", "OPENROUTER_API_KEY"),
+    )
     ai_model: str = "qwen/qwen3-14b"
     ai_timeout_seconds: int = 20
     ai_retries: int = 2

--- a/scripts/check_openrouter.py
+++ b/scripts/check_openrouter.py
@@ -22,7 +22,12 @@ class ProbeResult:
 
 def build_parser() -> argparse.ArgumentParser:
     env_values = dotenv_values(".env")
-    default_api_key = os.getenv("AI_KEY") or env_values.get("AI_KEY")
+    default_api_key = (
+        os.getenv("AI_KEY")
+        or os.getenv("OPENROUTER_API_KEY")
+        or env_values.get("AI_KEY")
+        or env_values.get("OPENROUTER_API_KEY")
+    )
     default_model = os.getenv("AI_MODEL") or env_values.get("AI_MODEL") or "qwen/qwen3-14b"
     default_api_url = os.getenv("AI_API_URL") or env_values.get("AI_API_URL") or "https://openrouter.ai/api/v1"
 
@@ -79,7 +84,7 @@ def main() -> int:
     args = parser.parse_args()
 
     if not args.api_key:
-        print("ERROR: не задан API ключ. Передайте --api-key или переменную AI_KEY.")
+        print("ERROR: не задан API ключ. Передайте --api-key или переменную AI_KEY/OPENROUTER_API_KEY.")
         return 2
 
     result = asyncio.run(

--- a/tests/test_check_openrouter.py
+++ b/tests/test_check_openrouter.py
@@ -34,3 +34,25 @@ def test_build_parser_prefers_process_env_over_dotenv(tmp_path: Path, monkeypatc
     args = parser.parse_args([])
 
     assert args.api_key == "process-key"
+
+
+def test_build_parser_reads_openrouter_alias_from_dotenv(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("OPENROUTER_API_KEY=dotenv-openrouter-key\n", encoding="utf-8")
+    monkeypatch.delenv("AI_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    parser = check_openrouter.build_parser()
+    args = parser.parse_args([])
+
+    assert args.api_key == "dotenv-openrouter-key"
+
+
+def test_build_parser_prefers_ai_key_over_openrouter_alias(monkeypatch) -> None:
+    monkeypatch.setenv("AI_KEY", "ai-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
+
+    parser = check_openrouter.build_parser()
+    args = parser.parse_args([])
+
+    assert args.api_key == "ai-key"

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -42,3 +42,13 @@ def test_settings_rejects_empty_bot_token(monkeypatch) -> None:
         assert "BOT_TOKEN не задан или пуст" in str(exc)
     else:
         raise AssertionError("Expected ValidationError for empty BOT_TOKEN")
+
+
+def test_settings_reads_openrouter_api_key_alias() -> None:
+    settings = Settings(
+        **BASE_ENV,
+        _env_file=None,
+        OPENROUTER_API_KEY="or-test-key",
+    )
+
+    assert settings.ai_key == "or-test-key"


### PR DESCRIPTION
### Motivation
- В коде часть логики и документации читала только `AI_KEY`, хотя в окружениях иногда используется `OPENROUTER_API_KEY`, что мешало диагностике и включению AI‑фич. 
- Нужно обеспечить единообразную обработку ключа (бот, health‑check, тесты и документация) без нарушения обратной совместимости.

### Description
- В `app/config.py` поле `ai_key` теперь использует `Field(..., validation_alias=AliasChoices("AI_KEY", "OPENROUTER_API_KEY"))` для поддержки обоих имён переменных. 
- В `scripts/check_openrouter.py` функция `build_parser` стала искать ключ сначала в `AI_KEY`, затем в `OPENROUTER_API_KEY` (и в `.env`), а текст ошибки при отсутствии ключа обновлён для упоминания обоих вариантов. 
- Добавлены тесты: в `tests/test_check_openrouter.py` проверки чтения `OPENROUTER_API_KEY` из `.env` и приоритета `AI_KEY` над алиасом, а в `tests/test_config_settings.py` — тест на чтение алиаса в `Settings`. 
- Обновлены документация и пример конфигурации: добавлен `OPENROUTER_API_KEY` в `.env.example` и инструкции в `README.md` с примером запуска через алиас.

### Testing
- Запущено `pytest -q tests/test_check_openrouter.py tests/test_config_settings.py`, результат: `7 passed`.
- Прогон полного набора тестов через `pytest -q` дал `41 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923c4374248326835bd7d8f26ebc1b)