### PR TITLE
Защитить RAG-базу от очистки командой /reset_stats

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -15,14 +15,7 @@ from sqlalchemy import delete, update
 
 from app.config import settings
 from app.db import get_session
-from app.models import (
-    GameState,
-    QuizDailyLimit,
-    QuizSession,
-    QuizUsedQuestion,
-    QuizUserStat,
-    UserStat,
-)
+from app.models import GameState, QuizSession
 from app.services.games import can_grant_coins, get_or_create_stats, register_coin_grant
 from app.services.strikes import add_strike, clear_strikes
 from app.utils.admin import extract_target_user, is_admin
@@ -33,6 +26,7 @@ from app.services.ai_module import get_ai_runtime_status, get_ai_usage_for_today
 from app.services.ai_module import get_ai_diagnostics
 from app.services.ai_usage import next_reset_delta, reset_ai_usage
 from app.services.rag import add_rag_message, get_rag_count
+from app.services.admin_stats_reset import reset_runtime_statistics
 from app.utils.profanity import load_profanity, load_profanity_exceptions
 
 router = Router()
@@ -378,7 +372,7 @@ async def load_quiz_questions(message: Message, bot: Bot) -> None:
 
 @router.message(Command("reset_stats"))
 async def reset_stats(message: Message, bot: Bot) -> None:
-    """Обнуляет статистику игр и викторины, сбрасывая сессию."""
+    """Обнуляет статистику игр/викторины, не затрагивая базу знаний RAG."""
     if not await _ensure_admin(message, bot):
         return
 
@@ -394,44 +388,28 @@ async def reset_stats(message: Message, bot: Bot) -> None:
         cleared.append("таймауты викторины")
 
     async for session in get_session():
-        game_stats_result = await session.execute(delete(UserStat))
-        game_stats_rows = game_stats_result.rowcount or 0
-        if game_stats_rows > 0:
-            cleared.append(f"статистика игры 21 ({game_stats_rows})")
-
-        game_states_result = await session.execute(delete(GameState))
-        game_states_rows = game_states_result.rowcount or 0
-        if game_states_rows > 0:
-            cleared.append(f"активные игры 21 ({game_states_rows})")
-
-        quiz_stats_result = await session.execute(delete(QuizUserStat))
-        quiz_stats_rows = quiz_stats_result.rowcount or 0
-        if quiz_stats_rows > 0:
-            cleared.append(f"статистика викторины ({quiz_stats_rows})")
-
-        quiz_limits_result = await session.execute(delete(QuizDailyLimit))
-        quiz_limits_rows = quiz_limits_result.rowcount or 0
-        if quiz_limits_rows > 0:
-            cleared.append(f"лимиты запусков викторины ({quiz_limits_rows})")
-
-        used_questions_result = await session.execute(delete(QuizUsedQuestion))
-        used_questions_rows = used_questions_result.rowcount or 0
-        if used_questions_rows > 0:
-            cleared.append(f"глобальная история вопросов ({used_questions_rows})")
-
-        quiz_sessions_result = await session.execute(delete(QuizSession))
-        quiz_sessions_rows = quiz_sessions_result.rowcount or 0
-        if quiz_sessions_rows > 0:
-            cleared.append(f"сессии викторины ({quiz_sessions_rows})")
+        deleted_rows = await reset_runtime_statistics(session)
+        if deleted_rows["user_stats"] > 0:
+            cleared.append(f"статистика игры 21 ({deleted_rows['user_stats']})")
+        if deleted_rows["game_states"] > 0:
+            cleared.append(f"активные игры 21 ({deleted_rows['game_states']})")
+        if deleted_rows["quiz_user_stats"] > 0:
+            cleared.append(f"статистика викторины ({deleted_rows['quiz_user_stats']})")
+        if deleted_rows["quiz_daily_limits"] > 0:
+            cleared.append(f"лимиты запусков викторины ({deleted_rows['quiz_daily_limits']})")
+        if deleted_rows["quiz_used_questions"] > 0:
+            cleared.append(f"глобальная история вопросов ({deleted_rows['quiz_used_questions']})")
+        if deleted_rows["quiz_sessions"] > 0:
+            cleared.append(f"сессии викторины ({deleted_rows['quiz_sessions']})")
 
         await session.commit()
 
     _session_results.clear()
 
     if cleared:
-        await message.reply("Статистика и сессии сброшены: " + ", ".join(cleared))
+        await message.reply("Статистика и сессии сброшены: " + ", ".join(cleared) + "\nRAG-база не изменялась.")
     else:
-        await message.reply("Статистика уже пустая, сессия сброшена.")
+        await message.reply("Статистика уже пустая, сессия сброшена. RAG-база не изменялась.")
 
 
 @router.message(Command("restart_jobs"))

--- a/app/services/admin_stats_reset.py
+++ b/app/services/admin_stats_reset.py
@@ -1,0 +1,33 @@
+"""Почему: централизуем безопасный сброс статистики без удаления базы знаний RAG."""
+
+from __future__ import annotations
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import GameState, QuizDailyLimit, QuizSession, QuizUsedQuestion, QuizUserStat, UserStat
+
+
+async def reset_runtime_statistics(session: AsyncSession) -> dict[str, int]:
+    """Сбрасывает только оперативную статистику игр/викторины и оставляет RAG неизменным."""
+    deleted_rows: dict[str, int] = {}
+
+    game_stats_result = await session.execute(delete(UserStat))
+    deleted_rows["user_stats"] = game_stats_result.rowcount or 0
+
+    game_states_result = await session.execute(delete(GameState))
+    deleted_rows["game_states"] = game_states_result.rowcount or 0
+
+    quiz_stats_result = await session.execute(delete(QuizUserStat))
+    deleted_rows["quiz_user_stats"] = quiz_stats_result.rowcount or 0
+
+    quiz_limits_result = await session.execute(delete(QuizDailyLimit))
+    deleted_rows["quiz_daily_limits"] = quiz_limits_result.rowcount or 0
+
+    used_questions_result = await session.execute(delete(QuizUsedQuestion))
+    deleted_rows["quiz_used_questions"] = used_questions_result.rowcount or 0
+
+    quiz_sessions_result = await session.execute(delete(QuizSession))
+    deleted_rows["quiz_sessions"] = quiz_sessions_result.rowcount or 0
+
+    return deleted_rows

--- a/tests/test_admin_stats_reset.py
+++ b/tests/test_admin_stats_reset.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.models import RagMessage, UserStat
+from app.services.admin_stats_reset import reset_runtime_statistics
+
+
+async def _run_reset_and_check_rag() -> tuple[int, int]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        session.add(UserStat(chat_id=1, user_id=10, coins=120, games_played=5, wins=2))
+        session.add(
+            RagMessage(
+                chat_id=1,
+                message_text="Шлагбаум открывается из приложения.",
+                added_by_user_id=1,
+            )
+        )
+        await session.commit()
+
+        deleted = await reset_runtime_statistics(session)
+        await session.commit()
+
+        rag_count = len((await session.execute(RagMessage.__table__.select())).all())
+
+    await engine.dispose()
+    return deleted["user_stats"], rag_count
+
+
+def test_reset_runtime_statistics_does_not_touch_rag() -> None:
+    deleted_user_stats, rag_count = asyncio.run(_run_reset_and_check_rag())
+    assert deleted_user_stats == 1
+    assert rag_count == 1


### PR DESCRIPTION
### Motivation
- Требование: никогда не обнулять базу знаний RAG без отдельного явного задания, поэтому сброс статистики должен оставлять `rag_messages` нетронутой.
- Сделать поведение явным и централизованным, чтобы исключить случайные удаления при админских операциях.

### Description
- Добавлен новый сервис `app/services/admin_stats_reset.py` с функцией `reset_runtime_statistics`, которая удаляет только оперативную статистику игр/викторины и возвращает количество удалённых строк по таблицам. (`reset_runtime_statistics`) 
- Обновлён обработчик `/reset_stats` в `app/handlers/admin.py`, теперь он использует `reset_runtime_statistics` вместо явных `DELETE`-запросов и в ответе явно указывает, что `RAG` не изменялась. 
- Добавлен тест `tests/test_admin_stats_reset.py`, который проверяет, что после выполнения сброса статистики записи `rag_messages` сохраняются. 
- Импорты и сообщения адаптированы: удалён прямой код удаления статистики из хэндлера, добавлен вызов нового сервиса; пути изменения: `app/services/admin_stats_reset.py`, `app/handlers/admin.py`, `tests/test_admin_stats_reset.py`.

### Testing
- Запуск компиляции файлов: `python -m py_compile app/handlers/admin.py app/services/admin_stats_reset.py tests/test_admin_stats_reset.py` — успешно.
- Запуск тестов: `pytest -q tests/test_admin_stats_reset.py tests/test_rag_knowledge_base.py` — все тесты прошли (`3 passed`).
- Изменения покрыты новым юнит-тестом `test_reset_runtime_statistics_does_not_touch_rag` и существующими тестами RAG-базы.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ef7d8ef88326bc25e25d34b78a30)