### PR TITLE
Стабилизация SQLite: очистка старых данных, PRAGMA и устойчивость к OperationalError

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -42,6 +42,8 @@ class Settings(BaseSettings):
     ai_summary_hour: int = 21
     ai_summary_minute: int = 0
     ai_summary_topic_id: int | None = None
+    db_logs_retention_days: int = 14
+    db_stats_retention_days: int = 45
 
     topic_rules: int | None = None
     topic_important: int | None = None

--- a/app/db.py
+++ b/app/db.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -20,6 +21,22 @@ class Base(DeclarativeBase):
 
 
 engine: AsyncEngine = create_async_engine(settings.database_url, echo=False)
+
+
+@event.listens_for(engine.sync_engine, "connect")
+def _configure_sqlite_pragmas(dbapi_connection: object, _connection_record: object) -> None:
+    """Почему: уменьшаем риск деградации SQLite при долгой работе и росте данных."""
+    if not settings.database_url.startswith("sqlite+"):
+        return
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL;")
+    cursor.execute("PRAGMA synchronous=NORMAL;")
+    cursor.execute("PRAGMA busy_timeout=5000;")
+    cursor.execute("PRAGMA temp_store=MEMORY;")
+    cursor.execute("PRAGMA auto_vacuum=INCREMENTAL;")
+    cursor.close()
+
+
 SessionFactory = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from aiogram.types import (
 )
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlalchemy import Integer, inspect, text, update
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from app.config import settings
@@ -38,6 +39,7 @@ from app.services.games import (
     is_game_timed_out,
 )
 from app.services.health import get_health_state, update_heartbeat, update_notice
+from app.services.db_maintenance import cleanup_old_data, optimize_sqlite
 from app.utils.time import now_tz
 from app.services.ai_module import close_ai_client, get_ai_client, set_ai_admin_notifier
 from app.services.daily_summary import build_daily_summary, render_daily_summary
@@ -77,14 +79,18 @@ class LoggingMiddleware(BaseMiddleware):
             ):
                 date_key = now_tz().date().isoformat()
                 async for session in get_session():
-                    await bump_topic_stat(
-                        session,
-                        settings.forum_chat_id,
-                        msg.message_thread_id,
-                        date_key,
-                        msg.text,
-                    )
-                    await session.commit()
+                    try:
+                        await bump_topic_stat(
+                            session,
+                            settings.forum_chat_id,
+                            msg.message_thread_id,
+                            date_key,
+                            msg.text,
+                        )
+                        await session.commit()
+                    except OperationalError as exc:
+                        logger.warning("Не удалось обновить статистику тем: %s", exc)
+                        await session.rollback()
         return await handler(event, data)
 
 
@@ -324,6 +330,23 @@ async def cleanup_blackjack_commands(bot: Bot) -> None:
             pass
 
 
+async def cleanup_database() -> None:
+    """Удаляет старые техданные и уменьшает размер SQLite-файла."""
+    stats: dict[str, int] | None = None
+    async for session in get_session():
+        stats = await cleanup_old_data(session)
+        await optimize_sqlite(session)
+    if stats is None:
+        return
+    logger.info(
+        "Очистка БД завершена: message_logs=%s moderation_events=%s topic_stats=%s ai_usage=%s",
+        stats["message_logs"],
+        stats["moderation_events"],
+        stats["topic_stats"],
+        stats["ai_usage"],
+    )
+
+
 async def schedule_jobs(bot: Bot) -> AsyncIOScheduler:
     scheduler = AsyncIOScheduler(timezone=settings.timezone)
     scheduler.add_job(
@@ -402,6 +425,12 @@ async def schedule_jobs(bot: Bot) -> AsyncIOScheduler:
         minute=0,
         args=[bot],
     )
+    scheduler.add_job(
+        cleanup_database,
+        "cron",
+        hour=4,
+        minute=20,
+    )
     scheduler.start()
     return scheduler
 
@@ -430,6 +459,7 @@ async def on_startup(bot: Bot) -> None:
             )
             await asyncio.sleep(5)
     await init_db(engine)
+    await cleanup_database()
     # Применяем миграции
     async for session in get_session():
         await apply_v11_stats_reset(session)

--- a/app/services/ai_usage.py
+++ b/app/services/ai_usage.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from datetime import datetime, timedelta
 
 from sqlalchemy import delete
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import AiUsage
 from app.utils.time import now_tz
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -65,12 +69,20 @@ async def add_usage(
     chat_id: int,
     tokens_used: int,
 ) -> AiUsageStats:
-    usage = await get_or_create_usage(session, date_key=date_key, chat_id=chat_id)
-    usage.request_count += 1
-    usage.tokens_used += max(0, tokens_used)
-    usage.updated_at = datetime.utcnow()
-    await session.commit()
-    return AiUsageStats(requests_used=usage.request_count, tokens_used=usage.tokens_used)
+    try:
+        usage = await get_or_create_usage(session, date_key=date_key, chat_id=chat_id)
+        usage.request_count += 1
+        usage.tokens_used += max(0, tokens_used)
+        usage.updated_at = datetime.utcnow()
+        await session.commit()
+        return AiUsageStats(requests_used=usage.request_count, tokens_used=usage.tokens_used)
+    except OperationalError as exc:
+        logger.warning("Не удалось записать usage ИИ: %s", exc)
+        await session.rollback()
+        usage = await session.get(AiUsage, {"date_key": date_key, "chat_id": chat_id})
+        if usage is None:
+            return AiUsageStats(requests_used=0, tokens_used=0)
+        return AiUsageStats(requests_used=usage.request_count, tokens_used=usage.tokens_used)
 
 
 async def reset_ai_usage(session: AsyncSession, *, chat_id: int | None = None) -> int:

--- a/app/services/db_maintenance.py
+++ b/app/services/db_maintenance.py
@@ -1,0 +1,65 @@
+"""Почему: удерживаем размер SQLite под контролем без изменения бизнес-логики модулей."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import delete, text
+from sqlalchemy.sql.dml import Delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models import AiUsage, MessageLog, ModerationEvent, TopicStat
+
+
+
+async def cleanup_old_data(session: AsyncSession, *, now_utc: datetime | None = None) -> dict[str, int]:
+    """Удаляет устаревшие записи из сервисных таблиц.
+
+    Храним только окна, реально нужные для ежедневной аналитики и диагностики.
+    """
+    now = now_utc or datetime.utcnow()
+    logs_cutoff = now - timedelta(days=max(1, settings.db_logs_retention_days))
+    stats_cutoff = now - timedelta(days=max(1, settings.db_stats_retention_days))
+    logs_cutoff_key = logs_cutoff.date().isoformat()
+    stats_cutoff_key = stats_cutoff.date().isoformat()
+
+    removed_message_logs = await _delete_and_count(
+        session,
+        delete(MessageLog).where(MessageLog.created_at < logs_cutoff),
+    )
+    removed_moderation_events = await _delete_and_count(
+        session,
+        delete(ModerationEvent).where(ModerationEvent.created_at < logs_cutoff),
+    )
+    removed_topic_stats = await _delete_and_count(
+        session,
+        delete(TopicStat).where(TopicStat.date_key < stats_cutoff_key),
+    )
+    removed_ai_usage = await _delete_and_count(
+        session,
+        delete(AiUsage).where(AiUsage.date_key < stats_cutoff_key),
+    )
+
+    await session.commit()
+
+    return {
+        "message_logs": removed_message_logs,
+        "moderation_events": removed_moderation_events,
+        "topic_stats": removed_topic_stats,
+        "ai_usage": removed_ai_usage,
+    }
+
+
+async def optimize_sqlite(session: AsyncSession) -> None:
+    """Выполняет щадящую оптимизацию SQLite после очистки."""
+    if not settings.database_url.startswith("sqlite+"):
+        return
+    await session.execute(text("PRAGMA wal_checkpoint(TRUNCATE);"))
+    await session.execute(text("PRAGMA incremental_vacuum(2000);"))
+    await session.commit()
+
+
+async def _delete_and_count(session: AsyncSession, query: Delete) -> int:
+    result = await session.execute(query)
+    return int(result.rowcount or 0)

--- a/tests/test_db_maintenance.py
+++ b/tests/test_db_maintenance.py
@@ -1,0 +1,84 @@
+import asyncio
+from datetime import datetime, timedelta
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.models import AiUsage, MessageLog, ModerationEvent, TopicStat
+from app.services.db_maintenance import cleanup_old_data
+
+
+async def _run_cleanup_old_data_check() -> dict[str, int]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    now = datetime(2026, 3, 3, 12, 0, 0)
+    old_log_time = now - timedelta(days=11)
+    fresh_log_time = now - timedelta(days=5)
+
+    async with session_factory() as session:
+        session.add_all(
+            [
+                MessageLog(
+                    chat_id=1,
+                    topic_id=1,
+                    user_id=1,
+                    text="old",
+                    severity=0,
+                    created_at=old_log_time,
+                ),
+                MessageLog(
+                    chat_id=1,
+                    topic_id=1,
+                    user_id=2,
+                    text="new",
+                    severity=0,
+                    created_at=fresh_log_time,
+                ),
+                ModerationEvent(
+                    chat_id=1,
+                    user_id=1,
+                    event_type="warn",
+                    severity=1,
+                    created_at=old_log_time,
+                ),
+                ModerationEvent(
+                    chat_id=1,
+                    user_id=1,
+                    event_type="warn",
+                    severity=1,
+                    created_at=fresh_log_time,
+                ),
+                TopicStat(chat_id=1, topic_id=1, date_key="2026-01-01", messages_count=1),
+                TopicStat(chat_id=1, topic_id=1, date_key="2026-03-01", messages_count=2),
+                AiUsage(date_key="2026-01-01", chat_id=1, request_count=1, tokens_used=10),
+                AiUsage(date_key="2026-03-01", chat_id=1, request_count=1, tokens_used=10),
+            ]
+        )
+        await session.commit()
+
+    from app.services import db_maintenance
+
+    db_maintenance.settings.db_logs_retention_days = 10
+    db_maintenance.settings.db_stats_retention_days = 20
+
+    async with session_factory() as session:
+        removed = await cleanup_old_data(session, now_utc=now)
+        assert await session.get(AiUsage, {"date_key": "2026-03-01", "chat_id": 1}) is not None
+        assert await session.get(AiUsage, {"date_key": "2026-01-01", "chat_id": 1}) is None
+
+    await engine.dispose()
+    return removed
+
+
+def test_cleanup_old_data_removes_outdated_rows() -> None:
+    removed = asyncio.run(_run_cleanup_old_data_check())
+    assert removed == {
+        "message_logs": 1,
+        "moderation_events": 1,
+        "topic_stats": 1,
+        "ai_usage": 1,
+    }


### PR DESCRIPTION
### Motivation
- Исправить падения и нестабильность из-за ошибок SQLite вида `database or disk is full` обусловленные ростом служебных таблиц и журнальных файлов при длительной работе.
- Сохранить существующую логику подсчёта статистики и учёта AI, но сделать её отказоустойчивой при временных проблемах с БД.

### Description
- Добавлены параметры ретеншена в конфигурацию: `db_logs_retention_days` и `db_stats_retention_days` для настройки окон хранения техданных в `app/config.py`.
- При подключении к движку добавлены SQLite PRAGMA (`WAL`, `synchronous=NORMAL`, `busy_timeout`, `temp_store=MEMORY`, `auto_vacuum=INCREMENTAL`) в `app/db.py` для уменьшения риска деградации и блокировок.
- Добавлен сервис `app/services/db_maintenance.py`, который удаляет устаревшие записи из `message_logs`, `moderation_events`, `topic_stats`, `ai_usage` и выполняет `wal_checkpoint(TRUNCATE)` + `incremental_vacuum` для освобождения места.
- Интеграция обслуживания в `app/main.py`: запуск очистки при старте и ежедневный cron-джоб (04:20), а также обработка `OperationalError` при обновлении `topic_stats` с `rollback`, чтобы ошибки БД не прерывали поток обработки сообщений.
- В `app/services/ai_usage.py` добавлена безопасная обработка `OperationalError` при записи usage с `rollback` и возвратом текущих значений вместо аварийного падения, а также логирование ошибок.
- Добавлен тест `tests/test_db_maintenance.py`, покрывающий корректное удаление устаревших записей; мелкие защитные фиксы в `app/main.py` чтобы избежать UnboundLocalError при отсутствии сессии.

### Testing
- Запуск автотестов `pytest -q tests/test_db_maintenance.py tests/test_startup_stability.py` завершился успешно: `4 passed`.
- Локально проверено, что новый тест `tests/test_db_maintenance.py` воспроизводит поведение удаления и не затрагивает свежие записи.
- При вводных проверках обработка `OperationalError` предотвращает падение потока обработки сообщений и вызовов записи usage (логирование предупреждений).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a692d920648326a3079516e561d550)