### PR TITLE
Добавить `python-dotenv` в `requirements.txt` для корректной загрузки `.env`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic==2.5.3
 APScheduler==3.10.4
 httpx==0.27.0
 beautifulsoup4==4.12.3
+python-dotenv==1.0.1


### PR DESCRIPTION
### Motivation
- В чистом окружении `pydantic-settings` может не уметь читать `env_file` без `python-dotenv`, что может приводить к ошибкам при старте/деплое, поэтому добавляю явную зависимость.

### Description
- Добавлена зависимость `python-dotenv==1.0.1` в файл `requirements.txt`.

### Testing
- Запущены тесты командой `pytest -q`, результат: `49 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a698dab7888326be5aa3faea500b73)