### PR TITLE
Improve Docker env guidance, make polling resilient to Telegram network errors, add compose env vars and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ OPENROUTER_API_KEY=sk-or-... AI_MODEL=qwen/qwen3-14b python scripts/check_openro
 ## Почему бот может не запускаться
 
 1. Не заполнен `.env` (минимум `BOT_TOKEN`, `FORUM_CHAT_ID`, `ADMIN_LOG_CHAT_ID`).
+   Если используете Docker Compose без `.env`, эти переменные должны быть явно переданы в `docker-compose.yml` или `docker-compose.yaml` в секции `environment`.
 2. Бот был остановлен командой `/shutdown_bot` и остался файл-флаг `.stopped` в каталоге данных (`/app/data` или рядом с SQLite-файлом из `DATABASE_URL`).
 3. Неверный `BOT_TOKEN` или нет доступа к Telegram API (на старте есть 3 попытки `get_me`).
 

--- a/app/config.py
+++ b/app/config.py
@@ -137,6 +137,9 @@ def _load_settings() -> Settings:
                 "Не заданы обязательные переменные окружения: %s",
                 ", ".join(missing),
             )
+            logger.error(
+                "Проверьте, что переменные переданы в контейнер через .env или docker-compose.yml/docker-compose.yaml (секция environment/env_file).",
+            )
         logger.error("Ошибка конфигурации: %s", exc)
         raise SystemExit(1) from exc
 

--- a/app/main.py
+++ b/app/main.py
@@ -582,7 +582,13 @@ async def main() -> None:
     try:
         await on_startup(bot)
         scheduler = await schedule_jobs(bot)
-        await dp.start_polling(bot)
+        try:
+            await dp.start_polling(bot)
+        except TelegramNetworkError as exc:
+            logger.error(
+                "Не удалось запустить polling: нет доступа к Telegram API (%s)",
+                exc,
+            )
     finally:
         if scheduler is not None:
             scheduler.shutdown()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - .env
     environment:
       - BOT_TOKEN=${BOT_TOKEN}
+      - FORUM_CHAT_ID=${FORUM_CHAT_ID}
+      - ADMIN_LOG_CHAT_ID=${ADMIN_LOG_CHAT_ID}
       - AI_KEY=${AI_KEY}
 
   watchtower:

--- a/tests/test_startup_stability.py
+++ b/tests/test_startup_stability.py
@@ -89,3 +89,39 @@ def test_on_startup_does_not_crash_when_cleanup_fails(monkeypatch) -> None:
         bot.set_my_commands.assert_called_once()
 
     asyncio.run(_run())
+
+
+def test_main_does_not_raise_when_polling_network_error(monkeypatch) -> None:
+    async def _run() -> None:
+        from app import main as main_module
+
+        bot = AsyncMock()
+        bot.session.close = AsyncMock()
+
+        class DummyDispatcher:
+            def __init__(self, *_args, **_kwargs) -> None:
+                update_obj = type("UpdateObj", (), {})()
+                update_obj.outer_middleware = lambda *_a, **_k: None
+                error_obj = type("ErrorObj", (), {})()
+                error_obj.register = lambda *_a, **_k: None
+                self.update = update_obj
+                self.error = error_obj
+
+            def include_router(self, *_args, **_kwargs) -> None:
+                return None
+
+            async def start_polling(self, _bot) -> None:
+                raise TelegramNetworkError(method="getMe", message="offline")
+
+        monkeypatch.setattr(main_module, "STOP_FLAG", Path("/tmp/nonexistent-flag"))
+        monkeypatch.setattr(main_module, "Bot", lambda *_a, **_k: bot)
+        monkeypatch.setattr(main_module, "Dispatcher", DummyDispatcher)
+        monkeypatch.setattr(main_module, "on_startup", AsyncMock())
+        monkeypatch.setattr(main_module, "schedule_jobs", AsyncMock(return_value=None))
+        monkeypatch.setattr(main_module, "close_ai_client", AsyncMock())
+
+        await main_module.main()
+
+        bot.session.close.assert_awaited_once()
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation

- Make configuration errors clearer for containerized deployments by pointing out how to pass env vars into Docker Compose. 
- Avoid whole-process crash on transient Telegram network errors during `start_polling` so shutdown/cleanup runs reliably. 
- Ensure `docker-compose.yml` documents required chat-related environment variables so users deploying with Compose do not miss them. 

### Description

- Enhanced error logging in `app/config.py` to suggest passing environment variables via `.env` or `docker-compose.yml/docker-compose.yaml` (section `environment`/`env_file`).
- Wrapped `await dp.start_polling(bot)` in a `try/except` that catches `TelegramNetworkError` and logs a clear error in `app/main.py` so startup failures due to Telegram being unreachable do not skip cleanup. 
- Added `FORUM_CHAT_ID` and `ADMIN_LOG_CHAT_ID` to the `environment` section in `docker-compose.yml` to surface required vars for Compose deployments. 
- Added `test_main_does_not_raise_when_polling_network_error` to `tests/test_startup_stability.py` which simulates `TelegramNetworkError` from the dispatcher and verifies cleanup (`bot.session.close`) still runs. 

### Testing

- Ran `pytest tests/test_startup_stability.py` which includes the new `test_main_does_not_raise_when_polling_network_error`, and the test passed. 
- Existing startup stability tests in `tests/test_startup_stability.py` were executed and passed. 
- No integration tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b1162f4883269b8ddd30403f0a83)