### PR TITLE
Add retry logic to Docker build step in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,17 +24,36 @@ jobs:
         id: sha
         run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: satamanchuk/alexbot:latest
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILD_VERSION=#${{ github.run_number }} (${{ steps.sha.outputs.short }})
+      - name: Build and push with retry
+        env:
+          BUILD_VERSION: "#${{ github.run_number }} (${{ steps.sha.outputs.short }})"
+        run: |
+          set -euo pipefail
+
+          for attempt in 1 2; do
+            echo "Build attempt ${attempt}/2"
+
+            if docker buildx build \
+              --file Dockerfile \
+              --platform linux/amd64 \
+              --tag satamanchuk/alexbot:latest \
+              --push \
+              --cache-from type=gha \
+              --cache-to type=gha,mode=max \
+              --build-arg "BUILD_VERSION=${BUILD_VERSION}" \
+              .; then
+              echo "Build and push succeeded on attempt ${attempt}."
+              exit 0
+            fi
+
+            if [ "${attempt}" -eq 1 ]; then
+              echo "First attempt failed due to a transient error, retrying in 15 seconds..."
+              sleep 15
+            fi
+          done
+
+          echo "Build and push failed after 2 attempts."
+          exit 1
 
       - name: Deploy to server
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
### Motivation

- Reduce intermittent CI failures during the Docker build/push step by retrying on transient errors.  
- Preserve build metadata via the `BUILD_VERSION` build-arg while taking direct control of the `docker buildx build` invocation.

### Description

- Replaced the `docker/build-push-action@v6` step with a custom `run` step named `Build and push with retry` that uses `docker buildx build` directly.  
- The new step exports `BUILD_VERSION` and runs a loop to attempt the build up to 2 times with `set -euo pipefail` and a `sleep 15` between attempts on first failure.  
- The `docker buildx build` invocation preserves the previous flags: `--file Dockerfile`, `--platform linux/amd64`, `--tag satamanchuk/alexbot:latest`, `--push`, `--cache-from type=gha`, `--cache-to type=gha,mode=max`, and `--build-arg "BUILD_VERSION=${BUILD_VERSION}"`.  
- The step prints success/failure messages and exits with a non-zero code if both attempts fail.

### Testing

- No automated tests were executed as part of this PR since the change updates the CI workflow itself and will be validated on the next workflow run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b75887648326bb1419b4149b5df8)