### PR TITLE
Remove redundant environment variables from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,6 @@ services:
       - ./data:/app/data
     env_file:
       - .env
-    environment:
-      - BOT_TOKEN=${BOT_TOKEN}
-      - FORUM_CHAT_ID=${FORUM_CHAT_ID}
-      - ADMIN_LOG_CHAT_ID=${ADMIN_LOG_CHAT_ID}
-      - AI_KEY=${AI_KEY}
 
   watchtower:
     image: containrrr/watchtower


### PR DESCRIPTION
## Summary
Removed redundant environment variable declarations from the docker-compose.yml file since they are already being loaded via the `.env` file.

## Key Changes
- Removed explicit `environment` section that was duplicating variables already defined in `.env`:
  - `BOT_TOKEN`
  - `FORUM_CHAT_ID`
  - `ADMIN_LOG_CHAT_ID`
  - `AI_KEY`

## Details
The `env_file: .env` directive already loads all environment variables from the `.env` file, making the explicit `environment` section redundant. This change simplifies the configuration and reduces duplication while maintaining the same functionality.

https://claude.ai/code/session_01ExtVhp2kSA7ncBKKDvYNJX