### PR TITLE
Fix SQLite database path resolution in Docker environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ FORUM_CHAT_ID=-1002127934225
 ADMIN_LOG_CHAT_ID=-1003697662870
 
 # База и системные
+# Относительный путь автоматически конвертируется в абсолютный внутри Docker
 DATABASE_URL=sqlite+aiosqlite:///app/data/bot.db
 TIMEZONE=Europe/Moscow
 BUILD_VERSION=dev

--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,23 @@ class Settings(BaseSettings):
     forum_chat_id: int
     admin_log_chat_id: int
     database_url: str = "sqlite+aiosqlite:///app/data/bot.db"
+
+    @field_validator("database_url", mode="before")
+    @classmethod
+    def _fix_sqlite_relative_path(cls, value: object) -> object:
+        """В Docker WORKDIR=/app относительный путь app/data/ резолвится
+        в /app/app/data/, минуя том /app/data/. Конвертируем в абсолютный."""
+        if not isinstance(value, str):
+            return value
+        old = "sqlite+aiosqlite:///app/data/"
+        if not value.startswith(old):
+            return value
+        # Конвертируем только в Docker (WORKDIR=/app)
+        if Path.cwd() == Path("/app"):
+            new = "sqlite+aiosqlite:////app/data/"
+            return new + value[len(old):]
+        return value
+
     timezone: str = "Europe/Moscow"
     build_version: str = "dev"
     ai_enabled: bool = True


### PR DESCRIPTION
## Summary
This PR fixes an issue where SQLite database paths were incorrectly resolved in Docker containers, causing the database to be created in the wrong location and bypassing mounted volumes.

## Key Changes
- Added a `@field_validator` to the `Settings` class that automatically converts relative SQLite paths to absolute paths when running inside Docker
- The validator detects when the application is running in Docker (by checking if `cwd() == /app`) and converts `sqlite+aiosqlite:///app/data/` to `sqlite+aiosqlite:////app/data/` (absolute path)
- Updated `.env.example` with a comment explaining that relative database paths are automatically converted to absolute paths in Docker

## Implementation Details
The issue occurred because Docker's `WORKDIR=/app` caused relative paths like `app/data/` to resolve to `/app/app/data/` instead of the intended `/app/data/` volume mount. The validator:
- Only processes string values
- Only applies the conversion when running in Docker (detected by checking current working directory)
- Preserves the original behavior for non-Docker environments and other database URL formats
- Maintains backward compatibility with existing configurations

https://claude.ai/code/session_017TNqWcbfyWU5FV5vBuP4wP