### PR TITLE
Improve RAG ranking with token normalization, fuzzy matching and semantic overlap; add tests

### DIFF
--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -54,6 +54,7 @@ _STOP_WORDS = {
     "есть",
     "нет",
 }
+_NORMALIZED_STOP_WORDS = {word.replace("ё", "е") for word in _STOP_WORDS}
 
 _CATEGORY_RULES: list[tuple[str, tuple[str, ...]]] = [
     ("парковка", ("парков", "шлагбаум", "машин", "мест")),
@@ -73,9 +74,85 @@ def _tokenize(text: str) -> list[str]:
     return [w for w in re.findall(r"[а-яёa-z0-9]+", text.lower()) if len(w) >= 3]
 
 
+def _normalize_token(token: str) -> str:
+    return token.replace("ё", "е")
+
+
 def _content_tokens(text: str) -> list[str]:
     """Токены без стоп-слов — для TF-IDF."""
-    return [w for w in _tokenize(text) if w not in _STOP_WORDS]
+    normalized_tokens = [_normalize_token(word) for word in _tokenize(text)]
+    return [word for word in normalized_tokens if word not in _NORMALIZED_STOP_WORDS]
+
+
+def _bounded_levenshtein(first: str, second: str, max_distance: int = 1) -> int:
+    if first == second:
+        return 0
+    if abs(len(first) - len(second)) > max_distance:
+        return max_distance + 1
+
+    previous = list(range(len(second) + 1))
+    for i, char_first in enumerate(first, 1):
+        current = [i]
+        min_row = i
+        for j, char_second in enumerate(second, 1):
+            cost = 0 if char_first == char_second else 1
+            current.append(
+                min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + cost,
+                )
+            )
+            min_row = min(min_row, current[-1])
+        if min_row > max_distance:
+            return max_distance + 1
+        previous = current
+    return previous[-1]
+
+
+def _common_prefix_len(first: str, second: str) -> int:
+    max_len = min(len(first), len(second))
+    idx = 0
+    while idx < max_len and first[idx] == second[idx]:
+        idx += 1
+    return idx
+
+
+def _token_similarity(first: str, second: str) -> float:
+    """Оценивает близость токенов: exact > typo > common prefix."""
+    if first == second:
+        return 1.0
+
+    if len(first) >= 5 and len(second) >= 5:
+        if _bounded_levenshtein(first, second, max_distance=1) <= 1:
+            return 0.92
+
+        prefix_len = _common_prefix_len(first, second)
+        if prefix_len >= 5:
+            shorter = min(len(first), len(second))
+            return 0.65 + 0.3 * (prefix_len / shorter)
+
+    return 0.0
+
+
+def _semantic_overlap_score(query_tokens: list[str], doc_tokens: list[str]) -> float:
+    """Мягкий overlap: учитывает словоформы и мелкие опечатки между query/doc."""
+    if not query_tokens or not doc_tokens:
+        return 0.0
+
+    doc_terms = set(doc_tokens)
+    matched = 0.0
+    for query_token in set(query_tokens):
+        best = 0.0
+        for doc_term in doc_terms:
+            similarity = _token_similarity(query_token, doc_term)
+            if similarity > best:
+                best = similarity
+                if best == 1.0:
+                    break
+        matched += best
+
+    return matched / max(len(set(query_tokens)), 1)
 
 
 def _token_set(text: str) -> set[str]:
@@ -240,9 +317,11 @@ def rank_rag_messages(
     scored: list[tuple[RagMessage, float]] = []
     for msg, doc_tokens in zip(messages, doc_tokens_list):
         tfidf_score = ranker.score(doc_tokens, query_tokens)
+        overlap_score = _semantic_overlap_score(query_tokens, doc_tokens)
         decay = _time_decay_factor(msg.created_at)
-        # Итоговый score: TF-IDF * time_decay (свежие записи приоритетнее)
-        final_score = tfidf_score * (0.7 + 0.3 * decay)
+        # Итоговый score: tfidf + мягкое совпадение токенов, затем time_decay
+        lexical_score = 0.75 * tfidf_score + 0.25 * overlap_score
+        final_score = lexical_score * (0.7 + 0.3 * decay)
         scored.append((msg, final_score))
 
     scored.sort(key=lambda item: item[1], reverse=True)

--- a/tests/test_rag_knowledge_base.py
+++ b/tests/test_rag_knowledge_base.py
@@ -96,3 +96,69 @@ def test_rag_systematization_merges_similar_messages_in_context() -> None:
     assert "(парковка)" in context
     assert "Шлагбаум открывается через приложение УК." in context
     assert "Шлагбаум можно открыть через приложение УК и номер квартиры." in context
+
+
+async def _prepare_parking_messages() -> list[str]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        await add_rag_message(
+            session,
+            chat_id=102,
+            message_text="Парковка оформляется через управляющую компанию по заявлению.",
+            added_by_user_id=1,
+        )
+        await add_rag_message(
+            session,
+            chat_id=102,
+            message_text="По вопросам лифта пишите в тему Жалобы.",
+            added_by_user_id=1,
+        )
+        await session.commit()
+
+        all_messages = await get_all_rag_messages(session, 102)
+        ranked = rank_rag_messages(all_messages, query="Как оформить паковку?")
+
+    await engine.dispose()
+    return [msg.message_text for msg in ranked]
+
+
+def test_rag_ranking_handles_word_forms_and_minor_typos() -> None:
+    messages = asyncio.run(_prepare_parking_messages())
+    assert messages[0] == "Парковка оформляется через управляющую компанию по заявлению."
+
+
+async def _prepare_mixed_domain_messages() -> list[str]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        await add_rag_message(
+            session,
+            chat_id=103,
+            message_text="Для оформления пропуска в паркинг обратитесь в диспетчерскую УК.",
+            added_by_user_id=1,
+        )
+        await add_rag_message(
+            session,
+            chat_id=103,
+            message_text="По шуму после 23:00 пишите в тему Жалобы.",
+            added_by_user_id=1,
+        )
+        await session.commit()
+
+        all_messages = await get_all_rag_messages(session, 103)
+        ranked = rank_rag_messages(all_messages, query="Как оформить пропуск в паркинг через диспечерскую?")
+
+    await engine.dispose()
+    return [msg.message_text for msg in ranked]
+
+
+def test_rag_ranking_works_for_all_rag_topics_not_only_parking_examples() -> None:
+    messages = asyncio.run(_prepare_mixed_domain_messages())
+    assert messages[0] == "Для оформления пропуска в паркинг обратитесь в диспетчерскую УК."


### PR DESCRIPTION
### Motivation
- Improve relevance of RAG search by handling Cyrillic "ё/е" variants and minor typos/word-form differences. 
- Make ranking more robust to lexical variation beyond strict TF-IDF exact matches. 
- Add tests that cover word-form/typo robustness and mixed-domain queries.

### Description
- Add token normalization for `ё -> е` and normalized stop-word set, and use it in content extraction via `_normalize_token` and `_NORMALIZED_STOP_WORDS`. 
- Implement fuzzy token utilities: `_bounded_levenshtein`, `_common_prefix_len`, and `_token_similarity` to score near-matches and common prefixes. 
- Introduce `_semantic_overlap_score` that computes a soft overlap between query and document tokens and combine it with TF-IDF in `rank_rag_messages` as a weighted lexical score before applying time decay. 
- Keep existing time-decay and TF-IDF pipeline but change final score aggregation to `lexical_score = 0.75 * tfidf_score + 0.25 * overlap_score` and then apply decay. 
- Add new tests and helpers to `tests/test_rag_knowledge_base.py` that assert ranking handles word forms, minor typos, and mixed-domain queries.

### Testing
- Ran `pytest tests/test_rag_knowledge_base.py` which exercised existing tests `test_rag_message_is_available_immediately_after_save`, `test_rag_ranking_keeps_all_knowledge_base_records`, and `test_rag_systematization_merges_similar_messages_in_context`, plus the new tests `test_rag_ranking_handles_word_forms_and_minor_typos` and `test_rag_ranking_works_for_all_rag_topics_not_only_parking_examples`.
- All tests in the file completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d2c612cc83268cb370842f8a5996)