### PR TITLE
Load required env from docker-compose and improve config diagnostics

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,10 +3,103 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
+from dotenv import dotenv_values
 from pydantic import AliasChoices, Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+REQUIRED_ENV_FIELDS: tuple[str, ...] = (
+    "BOT_TOKEN",
+    "FORUM_CHAT_ID",
+    "ADMIN_LOG_CHAT_ID",
+)
+
+
+def _extract_compose_bot_env(compose_path: Path) -> dict[str, str]:
+    """Извлекает environment/env_file для сервиса bot из docker-compose.yaml."""
+    if not compose_path.exists():
+        return {}
+
+    lines = compose_path.read_text(encoding="utf-8").splitlines()
+    result: dict[str, str] = {}
+
+    in_bot = False
+    in_environment = False
+    in_env_file = False
+
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if stripped == "bot:" and indent == 2:
+            in_bot = True
+            in_environment = False
+            in_env_file = False
+            continue
+
+        if in_bot and indent <= 2 and stripped.endswith(":") and stripped != "bot:":
+            in_bot = False
+            in_environment = False
+            in_env_file = False
+
+        if not in_bot:
+            continue
+
+        if stripped == "environment:" and indent == 4:
+            in_environment = True
+            in_env_file = False
+            continue
+
+        if stripped == "env_file:" and indent == 4:
+            in_env_file = True
+            in_environment = False
+            continue
+
+        if indent == 4 and stripped.endswith(":"):
+            in_environment = False
+            in_env_file = False
+
+        if in_environment:
+            if indent == 6 and "=" in stripped and stripped.startswith("-"):
+                item = stripped.removeprefix("-").strip()
+                key, value = item.split("=", 1)
+                result[key.strip()] = value.strip().strip("'\"")
+                continue
+            if indent == 6 and ":" in stripped and not stripped.startswith("-"):
+                key, value = stripped.split(":", 1)
+                result[key.strip()] = value.strip().strip("'\"")
+                continue
+
+        if in_env_file and indent == 6 and stripped.startswith("-"):
+            env_file_item = stripped.removeprefix("-").strip().strip("'\"")
+            env_file_path = (compose_path.parent / env_file_item).resolve()
+            if env_file_path.exists():
+                env_values = dotenv_values(env_file_path)
+                for key, value in env_values.items():
+                    if value is None:
+                        continue
+                    result[str(key)] = str(value)
+
+    return result
+
+
+def _inject_required_env_from_server_compose() -> None:
+    """Подхватывает обязательные env из /opt/alexbot/docker-compose.yaml, если их нет."""
+    compose_path = Path("/opt/alexbot/docker-compose.yaml")
+    compose_env = _extract_compose_bot_env(compose_path)
+    for key in REQUIRED_ENV_FIELDS:
+        if os.getenv(key):
+            continue
+        value = compose_env.get(key)
+        if value:
+            os.environ[key] = value
 
 
 class Settings(BaseSettings):
@@ -142,15 +235,23 @@ class Settings(BaseSettings):
 
 
 def _load_settings() -> Settings:
+    _inject_required_env_from_server_compose()
     try:
         return Settings()  # type: ignore[call-arg]
     except ValidationError as exc:
+        env_file_path = Path(".env").resolve()
         logging.basicConfig(
             level=logging.ERROR,
             format="%(asctime)s | %(levelname)s | %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
         logger = logging.getLogger(__name__)
+        logger.error(
+            "Проверка .env: path=%s exists=%s cwd=%s",
+            env_file_path,
+            env_file_path.exists(),
+            Path.cwd(),
+        )
         missing = []
         for err in exc.errors():
             if err.get("type") != "missing":

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import ValidationError
 
-from app.config import Settings
+from app.config import Settings, _extract_compose_bot_env
 
 
 BASE_ENV: dict[str, str] = {
@@ -52,3 +52,48 @@ def test_settings_reads_openrouter_api_key_alias() -> None:
     )
 
     assert settings.ai_key == "or-test-key"
+
+
+def test_extract_compose_bot_env_from_environment_block(tmp_path) -> None:
+    compose = tmp_path / "docker-compose.yaml"
+    compose.write_text(
+        """services:
+  bot:
+    image: test
+    environment:
+      - BOT_TOKEN=from-compose
+      - FORUM_CHAT_ID=-100123
+      - ADMIN_LOG_CHAT_ID=-100456
+""",
+        encoding="utf-8",
+    )
+
+    env = _extract_compose_bot_env(compose)
+
+    assert env["BOT_TOKEN"] == "from-compose"
+    assert env["FORUM_CHAT_ID"] == "-100123"
+    assert env["ADMIN_LOG_CHAT_ID"] == "-100456"
+
+
+def test_extract_compose_bot_env_from_env_file(tmp_path) -> None:
+    compose = tmp_path / "docker-compose.yaml"
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "BOT_TOKEN=from-env-file\nFORUM_CHAT_ID=-100111\nADMIN_LOG_CHAT_ID=-100222\n",
+        encoding="utf-8",
+    )
+    compose.write_text(
+        """services:
+  bot:
+    image: test
+    env_file:
+      - .env
+""",
+        encoding="utf-8",
+    )
+
+    env = _extract_compose_bot_env(compose)
+
+    assert env["BOT_TOKEN"] == "from-env-file"
+    assert env["FORUM_CHAT_ID"] == "-100111"
+    assert env["ADMIN_LOG_CHAT_ID"] == "-100222"


### PR DESCRIPTION
### Motivation
- Ensure the app can pick up critical environment variables when running on the server where they may be provided via `/opt/alexbot/docker-compose.yaml` or referenced env files, and improve diagnostics when settings validation fails.

### Description
- Add `_extract_compose_bot_env` to parse `services: bot:` `environment:` and `env_file:` sections from a `docker-compose.yaml` and read referenced `.env` files via `dotenv_values`.
- Introduce `_inject_required_env_from_server_compose` which sets missing critical env vars (`BOT_TOKEN`, `FORUM_CHAT_ID`, `ADMIN_LOG_CHAT_ID`) from `/opt/alexbot/docker-compose.yaml` into `os.environ` before settings load.
- Call the injector from `_load_settings()` and improve validation error logging to include resolved `.env` path and current working directory to aid debugging.
- Add tests for compose parsing: `test_extract_compose_bot_env_from_environment_block` and `test_extract_compose_bot_env_from_env_file` and import the new extractor in tests.

### Testing
- Ran the test suite with `pytest -q` focusing on `tests/test_config_settings.py`, and all tests passed.
- The two new unit tests `test_extract_compose_bot_env_from_environment_block` and `test_extract_compose_bot_env_from_env_file` executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aabbd32e34832687dbabceca9e755f)