### PR TITLE
chore: switch default OpenRouter model to qwen/qwen3-32b

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ AI_API_URL=https://openrouter.ai/api/v1
 AI_KEY=
 # Альтернативное имя (поддерживается как алиас):
 OPENROUTER_API_KEY=
-AI_MODEL=qwen/qwen3-14b
+AI_MODEL=qwen/qwen3-32b
 AI_TIMEOUT_SECONDS=20
 AI_RETRIES=2
 

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ python scripts/check_openrouter.py --api-key sk-or-...
 Или через переменные окружения:
 
 ```bash
-AI_KEY=sk-or-... AI_MODEL=qwen/qwen3-14b python scripts/check_openrouter.py
+AI_KEY=sk-or-... AI_MODEL=qwen/qwen3-32b python scripts/check_openrouter.py
 # или
-OPENROUTER_API_KEY=sk-or-... AI_MODEL=qwen/qwen3-14b python scripts/check_openrouter.py
+OPENROUTER_API_KEY=sk-or-... AI_MODEL=qwen/qwen3-32b python scripts/check_openrouter.py
 ```
 
 Скрипт вернет `ok/status_code/latency_ms/details` и завершится кодом:

--- a/app/config.py
+++ b/app/config.py
@@ -140,7 +140,7 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("AI_KEY", "OPENROUTER_API_KEY"),
     )
-    ai_model: str = "qwen/qwen3-14b"
+    ai_model: str = "qwen/qwen3-32b"
     ai_timeout_seconds: int = 20
     ai_retries: int = 2
     ai_daily_request_limit: int = 2000

--- a/scripts/check_openrouter.py
+++ b/scripts/check_openrouter.py
@@ -28,7 +28,7 @@ def build_parser() -> argparse.ArgumentParser:
         or env_values.get("AI_KEY")
         or env_values.get("OPENROUTER_API_KEY")
     )
-    default_model = os.getenv("AI_MODEL") or env_values.get("AI_MODEL") or "qwen/qwen3-14b"
+    default_model = os.getenv("AI_MODEL") or env_values.get("AI_MODEL") or "qwen/qwen3-32b"
     default_api_url = os.getenv("AI_API_URL") or env_values.get("AI_API_URL") or "https://openrouter.ai/api/v1"
 
     parser = argparse.ArgumentParser(description="Проверка OpenRouter Chat Completions API")


### PR DESCRIPTION
### Motivation

- Обновить дефолтную модель OpenRouter в проекте с `qwen/qwen3-14b` на более мощную `qwen/qwen3-32b` без изменения поведения AI-модуля.

### Description

- Поменяно значение по умолчанию `ai_model` в `app/config.py` на `qwen/qwen3-32b`.
- Обновлён пример переменной окружения `AI_MODEL` в `.env.example` на `qwen/qwen3-32b`.
- Обновлено дефолтное значение модели в скрипте `scripts/check_openrouter.py` и примеры запуска в `README.md` на `qwen/qwen3-32b`.
- Никакой другой логики AI-модуля (включая `OpenRouterProvider`, `_chat_completion`, fallback, лимиты и runtime toggle) не менялась.

### Testing

- Запущены тесты `pytest -q tests/test_check_openrouter.py tests/test_config_settings.py`, все тесты прошли (`9 passed`).
- Проверен вывод помощи скрипта `python scripts/check_openrouter.py --help`, возвращает корректные опции.
- Запуск `python scripts/check_openrouter.py` без ключа возвращает ожидаемую ошибку о не заданном API-ключе (код возврата 2).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae2c90acc83269977c3940dc871ff)