### PR TITLE
fix: явно помечать дефолтную AI-модель при старте

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -233,6 +233,11 @@ class Settings(BaseSettings):
             return db_path.expanduser().resolve().parent
         return Path("/app/data")
 
+    @property
+    def ai_model_is_default(self) -> bool:
+        """Показывает, был ли AI_MODEL задан явно через окружение/.env."""
+        return "ai_model" not in self.model_fields_set
+
 
 def _load_settings() -> Settings:
     _inject_required_env_from_server_compose()

--- a/app/main.py
+++ b/app/main.py
@@ -570,7 +570,8 @@ async def on_startup(bot: Bot) -> None:
     # Инициализируем AI-клиент и логируем режим работы
     get_ai_client()
     if settings.ai_enabled and settings.ai_key:
-        ai_mode = f"AI: OpenRouter ({settings.ai_model})"
+        source_note = " (по умолчанию, AI_MODEL не задан)" if settings.ai_model_is_default else ""
+        ai_mode = f"AI: OpenRouter ({settings.ai_model}){source_note}"
     elif not settings.ai_enabled:
         ai_mode = "AI: отключен (AI_ENABLED=false)"
     else:


### PR DESCRIPTION
### Motivation
- Сделать видимым в логах/уведомлении при запуске, используется ли значение `AI_MODEL` из окружения или берётся дефолтное значение из настроек, чтобы убрать неясность при сообщении «модель осталась прежней». 

### Description
- Добавлено свойство `Settings.ai_model_is_default` в `app/config.py`, которое определяет, был ли `AI_MODEL` задан явно; при старте в `on_startup` (`app/main.py`) в сообщение о режиме AI добавляется пометка ` (по умолчанию, AI_MODEL не задан)` если модель используется по умолчанию. 

### Testing
- Запущена компиляция файлов: `python -m compileall app/config.py app/main.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae40dd6588326ae5f484787cfe234)