### PR TITLE
Have server compose env override existing env vars and update tests

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -92,11 +92,9 @@ def _extract_compose_bot_env(compose_path: Path) -> dict[str, str]:
 
 
 def _inject_env_from_server_compose() -> None:
-    """Подхватывает env из /opt/alexbot/docker-compose.yaml, не перезаписывая текущие."""
+    """Подхватывает env из /opt/alexbot/docker-compose.yaml как источник истины."""
     compose_env = _extract_compose_bot_env(SERVER_COMPOSE_PATH)
     for key, value in compose_env.items():
-        if os.getenv(key):
-            continue
         os.environ[key] = value
 
 

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -105,7 +105,7 @@ def test_extract_compose_bot_env_from_env_file(tmp_path) -> None:
     assert env["ADMIN_LOG_CHAT_ID"] == "-100222"
 
 
-def test_inject_env_from_server_compose_does_not_override_existing(monkeypatch, tmp_path) -> None:
+def test_inject_env_from_server_compose_overrides_existing(monkeypatch, tmp_path) -> None:
     compose = tmp_path / "docker-compose.yaml"
     compose.write_text(
         """services:
@@ -128,7 +128,7 @@ def test_inject_env_from_server_compose_does_not_override_existing(monkeypatch, 
 
     _inject_env_from_server_compose()
 
-    assert os.environ["BOT_TOKEN"] == "from-env"
+    assert os.environ["BOT_TOKEN"] == "from-compose"
     assert os.environ["FORUM_CHAT_ID"] == "-100123"
     assert os.environ["ADMIN_LOG_CHAT_ID"] == "-100456"
     assert os.environ["AI_MODEL"] == "qwen/qwen3-32b"

--- a/tests/test_db_maintenance.py
+++ b/tests/test_db_maintenance.py
@@ -82,4 +82,7 @@ def test_cleanup_old_data_removes_outdated_rows() -> None:
         "topic_stats": 1,
         "ai_usage": 1,
         "rag_expired": 0,
+        "chat_history": 0,
+        "ai_feedback": 0,
+        "frequent_questions": 0,
     }


### PR DESCRIPTION
### Motivation

- Treat the server `docker-compose.yaml` as the source of truth for environment variables so deployed compose values always take effect.

### Description

- Remove the guard that skipped setting an environment variable when it already existed so `_inject_env_from_server_compose` now overwrites existing env vars.
- Update the `_inject_env_from_server_compose` docstring to reflect the new overwrite behavior.
- Rename and adjust the config test to `test_inject_env_from_server_compose_overrides_existing` and change assertions to expect that compose values override pre-existing env vars.
- Extend the expected removal summary in `test_cleanup_old_data_removes_outdated_rows` to include `chat_history`, `ai_feedback`, and `frequent_questions` keys with `0` values.

### Testing

- Ran the modified tests via `pytest -q` including `tests/test_config_settings.py::test_inject_env_from_server_compose_overrides_existing`, and the test passed.
- Ran `tests/test_db_maintenance.py::test_cleanup_old_data_removes_outdated_rows` as part of the suite, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac1e3ddeb8832682605dbc6a62d8d3)