### PR TITLE
Обработка недоступности Telegram в `heartbeat_job` и регрессионный тест

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -326,11 +326,18 @@ async def heartbeat_job(bot: Bot) -> None:
                 now - last_notice > timedelta(days=1)
             )
             if should_notify:
-                await bot.send_message(
-                    settings.admin_log_chat_id,
-                    "Бот был недоступен. Сейчас снова онлайн.",
-                )
-                await update_notice(session, now)
+                try:
+                    await bot.send_message(
+                        settings.admin_log_chat_id,
+                        "Бот был недоступен. Сейчас снова онлайн.",
+                    )
+                except TelegramNetworkError as exc:
+                    logger.warning(
+                        "Не удалось отправить heartbeat-уведомление в Telegram: %s",
+                        exc,
+                    )
+                else:
+                    await update_notice(session, now)
         await update_heartbeat(session, now)
         await session.commit()
 

--- a/tests/test_startup_stability.py
+++ b/tests/test_startup_stability.py
@@ -11,7 +11,7 @@ from aiogram.exceptions import TelegramNetworkError, TelegramUnauthorizedError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.db import Base
-from app.main import on_startup
+from app.main import heartbeat_job, on_startup
 from app.services import quiz_loader
 
 
@@ -185,5 +185,44 @@ def test_main_does_not_raise_when_polling_api_error(monkeypatch) -> None:
         await main_module.main()
 
         bot.session.close.assert_awaited_once()
+
+    asyncio.run(_run())
+
+
+def test_heartbeat_job_does_not_crash_when_telegram_unavailable(monkeypatch) -> None:
+    async def _run() -> None:
+        bot = AsyncMock()
+        bot.send_message.side_effect = TelegramNetworkError(
+            method="sendMessage",
+            message="offline",
+        )
+
+        class DummyState:
+            def __init__(self) -> None:
+                from datetime import datetime, timedelta, timezone
+
+                self.last_heartbeat_at = datetime.now(timezone.utc) - timedelta(hours=1)
+                self.last_notice_at = None
+
+        class DummySession:
+            async def commit(self) -> None:
+                return None
+
+        session = DummySession()
+
+        async def _session_gen():
+            yield session
+
+        monkeypatch.setattr("app.main.get_session", _session_gen)
+        monkeypatch.setattr("app.main.get_health_state", AsyncMock(return_value=DummyState()))
+        update_notice_mock = AsyncMock()
+        monkeypatch.setattr("app.main.update_notice", update_notice_mock)
+        monkeypatch.setattr("app.main.update_heartbeat", AsyncMock())
+
+        await heartbeat_job(bot)
+
+        bot.send_message.assert_awaited_once()
+        update_notice_mock.assert_not_awaited()
+
 
     asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Устранить падение периодической задачи heartbeat при временной недоступности Telegram API, чтобы бот деградировал безопасно и задача не прерывалась.

### Description
- В `app/main.py` обёрнул отправку админ-уведомления в `heartbeat_job` в `try/except TelegramNetworkError` и логирую предупреждение вместо проброса исключения.
- Перенёс вызов `update_notice(session, now)` в `else:` блока, чтобы помечать уведомление как отправленное только при успешной отправке.
- Добавил регрессионный тест `test_heartbeat_job_does_not_crash_when_telegram_unavailable` в `tests/test_startup_stability.py`, который имитирует ошибку `TelegramNetworkError` и проверяет, что задача не падает и `update_notice` не вызывается.

### Testing
- Запуск целевого набора тестов: `pytest -q tests/test_startup_stability.py` — все тесты прошли (`8 passed`).
- Прогон полного тест‑сьюта: `pytest -q` — все тесты прошли (`79 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac3250c4a08326a968419d7e85a84f)