### PR TITLE
Add quiz handler and improve resident KB error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ ./app/
+COPY data/ ./data/
 
 RUN mkdir -p /app/data
 

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from app.config import settings
 from app.db import Base, engine, get_session
-from app.handlers import admin, forms, games, help as help_handler, moderation
+from app.handlers import admin, forms, games, help as help_handler, moderation, quiz
 from app.models import MigrationFlag, UserStat
 from app.services.topic_stats import bump_topic_stat
 from app.services.games import (
@@ -504,7 +504,10 @@ async def on_startup(bot: Bot) -> None:
             scope=BotCommandScopeChatAdministrators(chat_id=settings.forum_chat_id),
         )
     # Проверяем и прогреваем каноническую базу знаний жителей
-    load_resident_kb()
+    try:
+        load_resident_kb()
+    except Exception:
+        logger.exception("Не удалось загрузить базу знаний жителей (resident_kb.json).")
 
     # Инициализируем AI-клиент и логируем режим работы
     get_ai_client()
@@ -572,6 +575,7 @@ async def main() -> None:
     dp.include_router(admin.router)  # админ-команды
     dp.include_router(games.router)  # игры (команды /21, /score)
     dp.include_router(forms.router)  # формы с FSM (перед модерацией!)
+    dp.include_router(quiz.router)  # викторина (команды /umnij_start, /bal, /topumnij)
     dp.include_router(moderation.router)  # модерация (catch-all, пропускает FSM)
     # stats.router убран — статистика через middleware
 


### PR DESCRIPTION
## Summary
This PR adds a new quiz module to the bot and improves error handling for the resident knowledge base initialization. It also ensures the data directory is properly copied in the Docker build.

## Key Changes
- **Added quiz handler**: Imported and registered the new `quiz` router in the main dispatcher, enabling quiz commands (`/umnij_start`, `/bal`, `/topumnij`)
- **Improved error handling**: Wrapped `load_resident_kb()` call in a try-except block to gracefully handle failures when loading the resident knowledge base, with proper exception logging
- **Docker build fix**: Added `COPY data/ ./data/` to the Dockerfile to ensure the data directory is included in the container image

## Implementation Details
- The quiz router is registered after the forms router but before the moderation router to ensure proper command precedence
- Exception handling logs the full traceback for debugging purposes while allowing the bot to continue initialization
- The data directory copy in Docker happens before the `mkdir -p /app/data` command, ensuring both existing and new data directories are properly handled

https://claude.ai/code/session_01Rcah4Uwt7ZF1jjCup2vozp