### PR TITLE
Fix resident KB loading when data volume is mounted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app/ ./app/
 COPY data/ ./data/
 
+# Копируем KB в отдельную директорию, чтобы bind mount data/ не перекрывал его
+COPY data/resident_kb.json ./kb/resident_kb.json
+
 RUN mkdir -p /app/data
 
 VOLUME ["/app/data"]

--- a/app/services/resident_kb.py
+++ b/app/services/resident_kb.py
@@ -130,7 +130,14 @@ def _is_exact_match(normalized_query: str, entry: ResidentKbEntry) -> bool:
 
 @lru_cache(maxsize=1)
 def load_resident_kb() -> tuple[ResidentKbEntry, ...]:
-    kb_path = Path(__file__).resolve().parents[2] / "data" / "resident_kb.json"
+    project_root = Path(__file__).resolve().parents[2]
+    kb_path = project_root / "data" / "resident_kb.json"
+    if not kb_path.exists():
+        # Fallback: файл может лежать в неперекрытом каталоге kb/ внутри образа
+        kb_path = project_root / "kb" / "resident_kb.json"
+    if not kb_path.exists():
+        logger.warning("Файл базы знаний не найден: %s", kb_path)
+        return ()
     raw = json.loads(kb_path.read_text(encoding="utf-8"))
     entries: list[ResidentKbEntry] = []
     for item in raw:


### PR DESCRIPTION
## Summary
This PR fixes an issue where the resident knowledge base file becomes inaccessible when the `/app/data` directory is mounted as a volume in Docker. The solution implements a fallback mechanism to locate the KB file and handles cases where it cannot be found.

## Key Changes
- **Dockerfile**: Added a separate `COPY` instruction to place `resident_kb.json` in a `./kb/` directory that won't be overridden by volume mounts
- **resident_kb.py**: Enhanced `load_resident_kb()` function with:
  - Explicit project root path resolution for clarity
  - Fallback logic to check `kb/resident_kb.json` if the primary path doesn't exist
  - Graceful error handling that logs a warning and returns an empty tuple instead of crashing when the KB file is not found

## Implementation Details
The issue occurs because when `data/` is bind-mounted as a volume, it shadows the `resident_kb.json` file that was copied during the Docker build. By copying the file to a separate `kb/` directory and implementing a fallback lookup, the application can now find the KB file regardless of volume mount configuration. The warning log provides visibility into cases where the KB file is missing entirely.

https://claude.ai/code/session_01U6X4asEXgBvKtG4dyAwF7d