### PR TITLE
Add is_admin column migration to rag_messages table

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -218,6 +218,10 @@ async def init_db(async_engine: AsyncEngine) -> None:
                     sync_conn.execute(
                         text("ALTER TABLE rag_messages ADD COLUMN expires_at DATETIME")
                     )
+                if "is_admin" not in columns:
+                    sync_conn.execute(
+                        text("ALTER TABLE rag_messages ADD COLUMN is_admin BOOLEAN DEFAULT 0 NOT NULL")
+                    )
 
             # Миграция message_logs: sentiment
             if inspector.has_table("message_logs"):


### PR DESCRIPTION
## Summary
Added a database migration to introduce an `is_admin` boolean column to the `rag_messages` table with a default value of 0 (false).

## Key Changes
- Added conditional migration logic in `_ensure_columns()` to check if the `is_admin` column exists in the `rag_messages` table
- If the column is missing, it will be created as a `BOOLEAN` type with `DEFAULT 0 NOT NULL` constraints
- This ensures backward compatibility with existing databases by only adding the column if it doesn't already exist

## Implementation Details
- The migration follows the existing pattern used for other column additions (e.g., `expires_at`)
- Uses SQLAlchemy's `text()` for raw SQL execution
- The `NOT NULL` constraint with a default value of 0 ensures data integrity for existing and new records

https://claude.ai/code/session_01G7sRujswYD7j3oTkdqW8wU