### PR TITLE
Resume roulette rounds after bot restart during game hours

### DIFF
--- a/app/handlers/roulette.py
+++ b/app/handlers/roulette.py
@@ -651,6 +651,24 @@ async def start_roulette_round(bot: Bot) -> None:
     )
 
 
+async def resume_roulette_if_needed(bot: Bot) -> None:
+    """Возобновляет рулетку после перезагрузки бота, если сейчас время игры (21-22)."""
+    if not _is_roulette_time():
+        return
+    if settings.topic_games is None:
+        return
+    # Закрываем зависший раунд (если бот упал посреди раунда)
+    async for session in get_session():
+        stale = await get_active_round(session, settings.forum_chat_id, settings.topic_games)
+        if stale is not None:
+            logger.info("Рулетка: закрываем зависший раунд #%s после перезагрузки.", stale.id)
+            await close_round(session, stale, -1)  # -1 = раунд отменён
+            await session.commit()
+        break
+    logger.info("Рулетка: время игры (21-22), возобновляем раунды после перезагрузки.")
+    await start_roulette_round(bot)
+
+
 async def _run_roulette_round(bot: Bot, chat_id: int, topic_id: int) -> None:
     """Полный цикл одного раунда рулетки."""
     try:

--- a/app/main.py
+++ b/app/main.py
@@ -610,6 +610,9 @@ async def on_startup(bot: Bot) -> None:
     # Импорт инфраструктуры из Google Sheets (если настроен сервисный аккаунт)
     await _sync_places_from_sheets()
 
+    # Возобновляем рулетку, если бот перезагрузился в игровое время
+    await roulette.resume_roulette_if_needed(bot)
+
     # Инициализируем AI-клиент и логируем режим работы
     get_ai_client()
     if settings.ai_enabled and settings.ai_key:


### PR DESCRIPTION
## Summary
Added functionality to automatically resume roulette rounds after bot restart if the current time falls within game hours (21-22). This prevents game interruptions and ensures stale rounds from crashed sessions are properly cleaned up.

## Key Changes
- **New function `resume_roulette_if_needed()`** in `app/handlers/roulette.py`:
  - Checks if current time is within roulette game hours (21-22)
  - Detects and closes any stale/hanging rounds from previous bot session
  - Marks stale rounds as cancelled (-1 status)
  - Resumes normal roulette round scheduling if conditions are met

- **Bot startup integration** in `app/main.py`:
  - Calls `resume_roulette_if_needed()` during bot initialization
  - Executes after infrastructure sync but before AI client initialization
  - Ensures roulette recovery happens early in startup sequence

## Implementation Details
- Uses existing `get_active_round()` and `close_round()` utilities for consistency
- Gracefully handles missing configuration (returns early if topic_games not set)
- Includes logging for debugging stale round detection and recovery
- Leverages existing `_is_roulette_time()` check to respect game schedule

https://claude.ai/code/session_01Y5q5RC5hEKYXei8E9a8u1m