### PR TITLE
Remove redundant message_thread_id parameter in roulette handler

### DIFF
--- a/app/handlers/roulette.py
+++ b/app/handlers/roulette.py
@@ -242,11 +242,11 @@ async def handle_start_bet(callback: CallbackQuery) -> None:
 
     display = callback.from_user.username or callback.from_user.full_name
     # Отправляем персональное сообщение в тот же тред (НЕ редактируем общее)
+    # message_thread_id копируется автоматически из callback.message в answer()
     await callback.message.answer(
         f"@{display}, выберите тип ставки\n"
         f"Баланс: {balance} монет",
         reply_markup=_type_keyboard(uid),
-        message_thread_id=callback.message.message_thread_id,
     )
     await callback.answer()
 


### PR DESCRIPTION
## Summary
Simplified the roulette bet handler by removing an explicit `message_thread_id` parameter that is now automatically copied from the callback message.

## Key Changes
- Removed the explicit `message_thread_id=callback.message.message_thread_id` parameter from the `callback.message.answer()` call
- Added clarifying comment explaining that `message_thread_id` is now automatically copied from `callback.message` in the `answer()` method

## Implementation Details
The Telegram bot API's `answer()` method now automatically inherits the `message_thread_id` from the callback message, eliminating the need for manual parameter passing. This reduces code duplication and makes the intent clearer through the added comment.

https://claude.ai/code/session_01S38MQ3wmpKbDziU1an4d6C