### PR TITLE
Prioritize infrastructure database in assistant replies

### DIFF
--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -339,7 +339,8 @@ class StubAiProvider:
         safe_prompt = mask_personal_data(prompt)[:1000]
         if not is_assistant_topic_allowed(safe_prompt):
             return random.choice(_FORBIDDEN_TOPIC_REPLIES)
-        return f"{_USER_FALLBACK} {build_local_assistant_reply(safe_prompt, context=context)}"
+        places_context = await _get_places_context(safe_prompt)
+        return f"{_USER_FALLBACK} {build_local_assistant_reply(safe_prompt, context=context, places_hint=places_context)}"
 
     async def evaluate_quiz_answer(
         self,
@@ -670,7 +671,8 @@ class AiModuleClient:
                 "AI assistant timeout after %s seconds; using local fallback.",
                 _ASSISTANT_SOFT_TIMEOUT_SECONDS,
             )
-            return f"{_USER_FALLBACK} {build_local_assistant_reply(prompt, context=context)}"
+            places_context = await _get_places_context(prompt)
+            return f"{_USER_FALLBACK} {build_local_assistant_reply(prompt, context=context, places_hint=places_context)}"
 
     async def assistant_reply_with_history(
         self,
@@ -931,6 +933,10 @@ def build_local_assistant_reply(
     if not normalized_prompt:
         return random.choice(_EMPTY_PROMPT_REPLIES)
 
+    # Данные из БД инфраструктуры приоритетнее статичной базы знаний
+    if places_hint:
+        return f"Вот что нашёл в базе инфраструктуры:\n{places_hint[:700]}"
+
     resident_answer = build_resident_answer(normalized_prompt, context=context)
     if resident_answer:
         return resident_answer
@@ -938,9 +944,6 @@ def build_local_assistant_reply(
     rule_reply = _assistant_rule_reply(normalized_prompt)
     if rule_reply:
         return rule_reply
-
-    if places_hint:
-        return f"Вот что нашёл в базе инфраструктуры:\n{places_hint[:700]}"
 
     return _pick_fallback_variant(normalized_prompt)
 


### PR DESCRIPTION
## Summary
This change reorders the response priority in the local assistant reply builder to prioritize results from the infrastructure database over static knowledge base responses.

## Key Changes
- Added `places_context` retrieval via `_get_places_context()` in two locations where `build_local_assistant_reply()` is called (normal flow and timeout fallback)
- Passed `places_hint` parameter to `build_local_assistant_reply()` function calls
- Reordered response priority logic in `build_local_assistant_reply()`:
  - Infrastructure database results (`places_hint`) now checked first and returned immediately if available
  - Resident answers and rule-based replies checked second
  - Generic fallback responses used last
- Added Russian language comment explaining the priority order

## Implementation Details
- The infrastructure database context is fetched asynchronously before building the reply
- Results are truncated to 700 characters to maintain reasonable response length
- This ensures users get location/infrastructure-specific information when available, falling back to general knowledge only when needed

https://claude.ai/code/session_018JvmgWMhFruMzwrTd1D3ix