### PR TITLE
Add fallback path for places seed file in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ ./app/
+COPY scripts/ ./scripts/
 COPY data/ ./data/
 
-# Копируем KB в отдельную директорию, чтобы bind mount data/ не перекрывал его
+# Копируем KB и seed в отдельную директорию, чтобы bind mount data/ не перекрывал их
 COPY data/resident_kb.json ./kb/resident_kb.json
+COPY data/places_seed.json ./kb/places_seed.json
 
 RUN mkdir -p /app/data
 

--- a/scripts/seed_places.py
+++ b/scripts/seed_places.py
@@ -14,13 +14,18 @@ from app.models import Place
 logger = logging.getLogger(__name__)
 
 SEED_FILE = Path(__file__).resolve().parent.parent / "data" / "places_seed.json"
+# Fallback: bind mount data/ может перекрывать файл, но kb/ всегда доступен в образе
+SEED_FILE_FALLBACK = Path(__file__).resolve().parent.parent / "kb" / "places_seed.json"
 
 
 def _load_seed_data() -> list[dict[str, object]]:
-    if not SEED_FILE.exists():
-        logger.warning("Файл %s не найден, seed пропущен.", SEED_FILE)
+    path = SEED_FILE
+    if not path.exists():
+        path = SEED_FILE_FALLBACK
+    if not path.exists():
+        logger.warning("Файл %s не найден, seed пропущен.", path)
         return []
-    with open(SEED_FILE, encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 


### PR DESCRIPTION
## Summary
This PR adds resilience to the seed data loading mechanism by implementing a fallback path for the `places_seed.json` file. This ensures the seed data is accessible even when the `data/` directory is mounted as a bind mount in Docker, which would otherwise shadow the file.

## Key Changes
- Added `SEED_FILE_FALLBACK` constant pointing to `kb/places_seed.json` as a fallback location
- Updated `_load_seed_data()` function to check the fallback path if the primary path doesn't exist
- Modified Dockerfile to:
  - Copy `scripts/` directory into the image
  - Copy `places_seed.json` to the `kb/` directory alongside the existing `resident_kb.json`
  - Updated comments to reflect that both KB and seed files are now protected from bind mount shadowing

## Implementation Details
The solution follows the existing pattern used for `resident_kb.json`, where critical files are copied to a separate `kb/` directory that remains accessible even when `data/` is mounted as a bind mount. The seed loading logic gracefully falls back to this alternate location, maintaining backward compatibility while improving reliability in containerized environments.

https://claude.ai/code/session_011cMd7tdtU3fnMbruXo7BGx