### PR TITLE
Remove scripts directory from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ ./app/
-COPY scripts/ ./scripts/
 COPY data/ ./data/
 
 # Копируем KB и seed в отдельную директорию, чтобы bind mount data/ не перекрывал их


### PR DESCRIPTION
## Summary
Removed the `scripts/` directory from being copied into the Docker image during the build process.

## Changes
- Removed `COPY scripts/ ./scripts/` line from Dockerfile

## Details
The scripts directory is no longer needed in the Docker image. This reduces the image size and simplifies the container structure by removing unused files from the build context.

https://claude.ai/code/session_01SYvxAKyG5MdKJUuvfaAGHv