### PR TITLE
Update default AI model from qwen3-32b to qwen3.5-flash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ AI_API_URL=https://openrouter.ai/api/v1
 AI_KEY=
 # Альтернативное имя (поддерживается как алиас):
 OPENROUTER_API_KEY=
-AI_MODEL=qwen/qwen3-32b
+AI_MODEL=qwen/qwen3.5-flash
 AI_TIMEOUT_SECONDS=20
 AI_RETRIES=2
 

--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ python scripts/check_openrouter.py --api-key sk-or-...
 Или через переменные окружения:
 
 ```bash
-AI_KEY=sk-or-... AI_MODEL=qwen/qwen3-32b python scripts/check_openrouter.py
+AI_KEY=sk-or-... AI_MODEL=qwen/qwen3.5-flash python scripts/check_openrouter.py
 # или
-OPENROUTER_API_KEY=sk-or-... AI_MODEL=qwen/qwen3-32b python scripts/check_openrouter.py
+OPENROUTER_API_KEY=sk-or-... AI_MODEL=qwen/qwen3.5-flash python scripts/check_openrouter.py
 ```
 
 Скрипт вернет `ok/status_code/latency_ms/details` и завершится кодом:

--- a/app/config.py
+++ b/app/config.py
@@ -177,7 +177,7 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("AI_KEY", "OPENROUTER_API_KEY"),
     )
-    ai_model: str = "qwen/qwen3-32b"
+    ai_model: str = "qwen/qwen3.5-flash"
     ai_timeout_seconds: int = 20
     ai_retries: int = 2
     ai_daily_request_limit: int = 2000

--- a/scripts/check_openrouter.py
+++ b/scripts/check_openrouter.py
@@ -28,7 +28,7 @@ def build_parser() -> argparse.ArgumentParser:
         or env_values.get("AI_KEY")
         or env_values.get("OPENROUTER_API_KEY")
     )
-    default_model = os.getenv("AI_MODEL") or env_values.get("AI_MODEL") or "qwen/qwen3-32b"
+    default_model = os.getenv("AI_MODEL") or env_values.get("AI_MODEL") or "qwen/qwen3.5-flash"
     default_api_url = os.getenv("AI_API_URL") or env_values.get("AI_API_URL") or "https://openrouter.ai/api/v1"
 
     parser = argparse.ArgumentParser(description="Проверка OpenRouter Chat Completions API")

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -163,7 +163,7 @@ def test_inject_env_from_server_compose_overrides_existing(monkeypatch, tmp_path
       - BOT_TOKEN=from-compose
       - FORUM_CHAT_ID=-100123
       - ADMIN_LOG_CHAT_ID=-100456
-      - AI_MODEL=qwen/qwen3-32b
+      - AI_MODEL=qwen/qwen3.5-flash
 """,
         encoding="utf-8",
     )
@@ -179,4 +179,4 @@ def test_inject_env_from_server_compose_overrides_existing(monkeypatch, tmp_path
     assert os.environ["BOT_TOKEN"] == "from-compose"
     assert os.environ["FORUM_CHAT_ID"] == "-100123"
     assert os.environ["ADMIN_LOG_CHAT_ID"] == "-100456"
-    assert os.environ["AI_MODEL"] == "qwen/qwen3-32b"
+    assert os.environ["AI_MODEL"] == "qwen/qwen3.5-flash"


### PR DESCRIPTION
## Summary
Updates the default AI model across the codebase from `qwen/qwen3-32b` to `qwen/qwen3.5-flash`.

## Changes
- Updated default model in configuration (`app/config.py`)
- Updated example environment file (`.env.example`)
- Updated documentation examples in `README.md`
- Updated test fixtures in `tests/test_config_settings.py`
- Updated default model in OpenRouter check script (`scripts/check_openrouter.py`)

## Details
This change standardizes the default AI model used throughout the application to the newer `qwen3.5-flash` variant, which likely offers improved performance or cost efficiency compared to the previous `qwen3-32b` model. All references to the old model have been consistently updated across configuration files, documentation, tests, and utility scripts.

https://claude.ai/code/session_015tdx6Y5K5iY4cwjnPgzT5q