### PR TITLE
Improve content moderation with context-aware severity levels

### DIFF
--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -73,14 +73,17 @@ async def _store_message_log(message: Message, severity: int, sentiment: str | N
         await session.commit()
 
 
-async def _get_topic_context(chat_id: int, topic_id: int | None, limit: int = 5) -> list[str]:
-    """Возвращает последние сообщения из того же топика для контекстной модерации."""
+async def _get_topic_context(chat_id: int, topic_id: int | None, limit: int = 10) -> list[str]:
+    """Возвращает последние сообщения из того же топика для контекстной модерации.
+
+    Формат: «[user_NNNN]: текст» — чтобы AI видел, кто что написал.
+    """
     if topic_id is None:
         return []
     try:
         async for session in get_session():
             result = await session.execute(
-                select(MessageLog.text)
+                select(MessageLog.user_id, MessageLog.text)
                 .where(
                     and_(
                         MessageLog.chat_id == chat_id,
@@ -91,8 +94,8 @@ async def _get_topic_context(chat_id: int, topic_id: int | None, limit: int = 5)
                 .order_by(MessageLog.created_at.desc())
                 .limit(limit)
             )
-            rows = result.scalars().all()
-            return list(reversed(rows))
+            rows = result.all()
+            return [f"[user_{uid}]: {txt}" for uid, txt in reversed(rows)]
     except Exception:
         logger.warning("Не удалось загрузить контекст топика для модерации")
         return []
@@ -161,7 +164,11 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
     topic_context = await _get_topic_context(chat_id, message.message_thread_id)
 
     ai_client = get_ai_client()
-    decision = await ai_client.moderate(text, chat_id=chat_id, context=topic_context)
+    # Добавляем текущее сообщение с user_id для полного контекста
+    current_msg = f"[user_{user_id}]: {text}"
+    decision = await ai_client.moderate(
+        current_msg, chat_id=chat_id, context=topic_context,
+    )
     severity = decision.severity
     violation_type = getattr(decision, "violation_type", None)
     confidence = getattr(decision, "confidence", None)

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -84,35 +84,46 @@ _MODERATION_SYSTEM_PROMPT = (
     '{"violation_type":"none|profanity|rude|aggression","severity":0-3,'
     '"confidence":0..1,"action":"none|warn|delete_warn|delete_strike",'
     '"sentiment":"positive|neutral|negative"}.\n\n'
-    "ГЛАВНОЕ ПРАВИЛО: анализируй КОНТЕКСТ и НАМЕРЕНИЕ сообщения, а не отдельные слова.\n"
-    "Если перед сообщением приведён контекст беседы — используй его для оценки тона.\n"
-    "Дружеская перепалка (взаимные ответы с шутками/смайлами) — НЕ нарушение.\n"
-    "Матерные и грубые слова в дружеском или нейтральном контексте — НЕ нарушение.\n"
-    "Например: «блин, опять лифт сломался» или «ну нифига себе цены» — это severity 0.\n"
-    "Лёгкая грубость в бытовом общении между соседями — НЕ повод для наказания.\n\n"
+    "ГЛАВНОЕ ПРАВИЛО: анализируй КОНТЕКСТ, НАМЕРЕНИЕ и АДРЕСАТА сообщения.\n"
+    "Контекст беседы передаётся в формате «[user_NNNN]: текст» — используй его, "
+    "чтобы понять, кто кому отвечает и нарастает ли конфликт.\n\n"
+    "ОПРЕДЕЛЕНИЕ SEVERITY:\n"
+    "severity 0 — всё в порядке, нарушения нет:\n"
+    "  • бытовой мат без адресата («блин, опять лифт сломался», «ну нифига себе цены»)\n"
+    "  • эмоциональные жалобы на ситуацию, УК, застройщика (даже грубые)\n"
+    "  • дружеская перепалка (взаимные шутки, смайлы, ирония)\n"
+    "  • цитирование или пересказ чужих слов\n"
+    "  • сарказм, грубоватый юмор\n\n"
+    "severity 1 — мягкое предупреждение (грубоватый тон, направленный на соседа):\n"
+    "  • пренебрежительный или уничижительный тон к конкретному человеку\n"
+    "  • пассивная агрессия с переходом на личности («может хватит чушь нести»)\n"
+    "  • снисходительные замечания, высмеивание конкретного человека\n"
+    "  • грубая критика адресно («ты вообще адекватный?», «вам лечиться надо»)\n\n"
+    "severity 2 — жёсткое предупреждение + счётчик:\n"
+    "  • прямые оскорбления конкретного человека (дебил, идиот, тупой, мразь и т.п.)\n"
+    "  • агрессивные нападки на соседа с матом в его адрес\n"
+    "  • повторная грубость к тому же человеку (видно из контекста)\n"
+    "  • спам и реклама\n\n"
+    "severity 3 — удаление + мут + уведомление админа:\n"
+    "  • угрозы физической расправой\n"
+    "  • прямые оскорбления с матом и агрессией, направленные на человека\n"
+    "  • доксинг — публикация чужих персональных данных\n"
+    "  • целенаправленная травля или буллинг\n\n"
     "КОНТЕКСТНЫЙ АНАЛИЗ:\n"
-    "- Если идёт шутливая перепалка между знакомыми — severity 0.\n"
-    "- Если человек жалуется на ситуацию (а не на конкретного соседа) — severity 0.\n"
-    "- Если грубость направлена на организацию (УК, застройщик) — severity 0.\n"
-    "- Если используется цитирование или пересказ чужих слов — severity 0.\n"
-    "- Если сообщение содержит смайлы/эмодзи вместе с грубым словом — скорее всего юмор.\n"
-    "- Эскалация: если в контексте видно нарастание агрессии между двумя людьми, "
-    "оценивай строже (severity +1 к обычной оценке).\n\n"
-    "Удаление и бан ТОЛЬКО за:\n"
-    "- Прямые оскорбления конкретного человека с агрессией (severity 3)\n"
-    "- Угрозы физической расправой (severity 3)\n"
-    "- Доксинг — публикация чужих персональных данных (severity 3)\n"
-    "- Целенаправленная травля или буллинг (severity 3)\n"
-    "- Спам и реклама (severity 2)\n\n"
-    "НЕ наказывай за:\n"
-    "- Мат без агрессии и без адресата (бытовой мат): severity 0\n"
-    "- Эмоциональные высказывания без оскорблений конкретных людей: severity 0\n"
-    "- Жалобы на соседей, УК, сервисы (даже в грубой форме): severity 0\n"
-    "- Сарказм и ирония: severity 0\n"
-    "- Грубоватый юмор: severity 0\n\n"
+    "- Смотри на историю: если человек уже грубил в предыдущих сообщениях — оценивай строже.\n"
+    "- Если в контексте видно нарастание конфликта между людьми — severity +1.\n"
+    "- Если грубость направлена на конкретного соседа (по имени, реплаем, «ты/вы» + оскорбление) — "
+    "это ВАЖНЕЕ, чем наличие/отсутствие мата.\n"
+    "- Оскорбление без мата, но адресно («дурак», «тупой», «неадекват») — это severity 1-2.\n"
+    "- Мат + адресное оскорбление конкретного человека — severity 2-3.\n"
+    "- Если сообщение содержит смайлы вместе с грубостью — проверь, юмор это или сарказм с агрессией.\n\n"
+    "ВАЖНО: не путай жалобы на ситуацию с нападками на человека.\n"
+    "«УК — дебилы» → severity 0 (жалоба на организацию).\n"
+    "«Ты дебил» → severity 2 (оскорбление конкретного человека).\n\n"
     "Поле sentiment: оцени общий тон сообщения (positive/neutral/negative).\n"
-    "При ЛЮБОМ сомнении — severity 0 (не наказывать). "
-    "Лучше пропустить 10 грубых сообщений, чем наказать 1 невиновного."
+    "При сомнении между severity 0 и 1 — ставь 0. "
+    "При сомнении между severity 1 и 2 — ставь 1. "
+    "Но НЕ ставь severity 0 на явные оскорбления конкретных людей."
 )
 
 _ASSISTANT_SYSTEM_PROMPT = (
@@ -236,6 +247,14 @@ _RUDE_PATTERNS = (
     "сдохни",
     "уничтож",
     "калечить",
+    "зарежу",
+    "задушу",
+    "прибью",
+    "порву",
+    "голову оторв",
+    "башку оторв",
+    "закопаю",
+    "урою",
 )
 _FORBIDDEN_TOPIC_REPLIES = (
     "С этим лучше к профильному специалисту 🙌 Я тут больше про жизнь дома.",
@@ -256,6 +275,58 @@ _AGGRESSIVE_INSULT_PATTERNS = (
     "мразь",
     "тварь",
     "ублюд",
+    "дурак",
+    "дура ",
+    "тупой",
+    "тупая",
+    "тупица",
+    "кретин",
+    "придурок",
+    "придурошн",
+    "неадекват",
+    "чмо",
+    "лох",
+    "лошар",
+    "чушка",
+    "свинья",
+    "скотин",
+    "отброс",
+    "конченн",
+    "конч ",
+    "быдло",
+    "шлюх",
+    "шалав",
+)
+
+# Паттерны мягкой грубости — пассивная агрессия, снисходительность (severity 1)
+_SOFT_AGGRESSION_PATTERNS = (
+    "рот закрой",
+    "заткнись",
+    "завали",
+    "чушь нес",
+    "бред нес",
+    "не лезь",
+    "тебя не спраш",
+    "тебя не просили",
+    "вас не спраш",
+    "вас не просили",
+    "иди отсюда",
+    "иди лесом",
+    "иди нафиг",
+    "пошёл вон",
+    "пошла вон",
+    "пошёл нах",
+    "пошла нах",
+    "отвали",
+    "вали отсюда",
+    "лечись",
+    "лечиться надо",
+    "к врачу сходи",
+    "к психиатру",
+    "к психологу сходи",
+    "ты больной",
+    "ты больная",
+    "ты бешен",
 )
 _LATIN_TO_CYR = str.maketrans({
     "a": "а",
@@ -479,7 +550,7 @@ class OpenRouterProvider:
             user_content = ""
             if context:
                 user_content = "Контекст беседы (последние сообщения):\n"
-                user_content += "\n".join(context[-5:]) + "\n\n"
+                user_content += "\n".join(context[-8:]) + "\n\n"
             user_content += f"Сообщение для проверки:\n{text[:2000]}"
 
             content, _ = await self._chat_completion(
@@ -808,10 +879,32 @@ class AiModuleClient:
 
 
 def _has_aggressive_target(text: str) -> bool:
-    """Проверяет, направлена ли грубость на конкретного человека."""
+    """Проверяет, направлена ли грубость на конкретного человека.
+
+    Ищет комбинацию обращения (ты/вы/@) вместе с оскорбительным контекстом,
+    а не просто наличие местоимений (они есть почти в каждом сообщении).
+    """
     lowered = text.lower()
-    target_markers = ("ты ", "тебя ", "тебе ", "вы ", "вас ", "вам ", "@")
-    return any(marker in lowered for marker in target_markers)
+    # Прямое упоминание через @ — всегда адресно
+    if "@" in lowered:
+        return True
+    # Проверяем связки: местоимение + оскорбительное слово рядом
+    direct_patterns = (
+        "ты ", "тебя ", "тебе ", "тебой ",
+        "вы ", "вас ", "вам ", "вами ",
+    )
+    has_pronoun = any(marker in lowered or lowered.startswith(marker.strip()) for marker in direct_patterns)
+    if not has_pronoun:
+        return False
+    # Есть местоимение — проверяем наличие оскорбительных слов или агрессивных конструкций
+    aggression_markers = (
+        "идиот", "дебил", "даун", "тупой", "тупая", "дурак", "дура ",
+        "мразь", "тварь", "ублюд", "кретин", "придурок", "неадекват",
+        "чмо", "лох", "быдло", "скотин", "отброс",
+        "заткнись", "завали", "отвали", "рот закрой",
+        "больной", "больная", "бешен", "лечись",
+    )
+    return any(marker in lowered for marker in aggression_markers)
 
 
 def local_moderation(text: str) -> ModerationDecision:
@@ -825,22 +918,36 @@ def local_moderation(text: str) -> ModerationDecision:
 
     has_profanity = detect_profanity(normalized)
     has_insult = any(pattern in lowered for pattern in _AGGRESSIVE_INSULT_PATTERNS)
+    has_soft_aggression = any(pattern in lowered for pattern in _SOFT_AGGRESSION_PATTERNS)
+    has_target = _has_aggressive_target(text)
 
     # Прямое оскорбление конкретного человека с матом — severity 3
-    if has_profanity and has_insult and _has_aggressive_target(text):
+    if has_profanity and has_insult and has_target:
         return ModerationDecision("aggression", 3, 0.85, "delete_strike", False)
 
-    # Агрессия средней силы — предупреждение без удаления
-    if has_profanity and _has_aggressive_target(text) and aggression_level == "low":
+    # Оскорбление конкретного человека (без мата, но адресно) — severity 2
+    if has_insult and has_target:
+        return ModerationDecision("rude", 2, 0.8, "warn", False)
+
+    # Мат с адресатом, но без прямого оскорбления — severity 2
+    if has_profanity and has_target and aggression_level == "high":
+        return ModerationDecision("profanity", 2, 0.75, "warn", False)
+
+    # Мат с адресатом, низкая агрессия — severity 1
+    if has_profanity and has_target:
         return ModerationDecision("profanity", 1, 0.7, "warn", False)
+
+    # Пассивная агрессия / грубые команды адресно — severity 1
+    if has_soft_aggression:
+        return ModerationDecision("rude", 1, 0.7, "warn", False)
 
     # Мат без агрессии и адресата (бытовой мат) — severity 0, не наказываем
     if has_profanity:
         return ModerationDecision("none", 0, 0.6, "none", False)
 
-    # Оскорбление без мата, направленное на человека — severity 1
-    if has_insult and _has_aggressive_target(text):
-        return ModerationDecision("rude", 1, 0.7, "warn", False)
+    # Оскорбительные слова без адресата (жалоба на ситуацию) — severity 0
+    if has_insult:
+        return ModerationDecision("none", 0, 0.5, "none", False)
 
     return ModerationDecision("none", 0, 0.99, "none", False)
 
@@ -865,10 +972,15 @@ def detect_aggression_level(text: str) -> Literal["low", "high"]:
     lowered = text.lower()
     has_threat = any(pattern in lowered for pattern in _RUDE_PATTERNS)
     has_insult = any(pattern in lowered for pattern in _AGGRESSIVE_INSULT_PATTERNS)
+    has_soft_aggression = any(pattern in lowered for pattern in _SOFT_AGGRESSION_PATTERNS)
     has_target = _has_aggressive_target(text)
     has_profanity = detect_profanity(normalize_for_profanity(text))
 
     if has_threat or (has_insult and has_target and has_profanity):
+        return "high"
+    if has_insult and has_target:
+        return "high"
+    if has_profanity and has_soft_aggression:
         return "high"
     return "low"
 


### PR DESCRIPTION
## Summary
Enhanced the AI-powered content moderation system with more granular severity classifications, improved context awareness, and better detection of targeted harassment. The changes introduce a structured severity framework (0-3) with clear guidelines for each level and improve how moderation decisions are made based on conversation context.

## Key Changes

### Moderation Prompt & Guidelines
- Restructured the AI moderation prompt with explicit severity level definitions:
  - **Severity 0**: No violation (casual profanity, complaints about situations, friendly banter)
  - **Severity 1**: Soft warning (dismissive tone, passive aggression toward specific person)
  - **Severity 2**: Hard warning + counter (direct insults to person, repeated rudeness)
  - **Severity 3**: Deletion + mute (threats, targeted harassment, doxxing)
- Added emphasis on distinguishing between complaints about situations vs. attacks on specific people
- Improved context analysis guidelines with examples (e.g., "УК — дебилы" vs. "Ты дебил")
- Changed fallback logic: when in doubt between levels, default to lower severity

### Expanded Insult Detection
- Added 20+ new insult patterns to `_AGGRESSIVE_INSULT_PATTERNS` (дурак, тупой, кретин, придурок, неадекват, чмо, лох, быдло, etc.)
- Added 8+ threat patterns to `_RUDE_PATTERNS` (зарежу, задушу, прибью, закопаю, etc.)
- Created new `_SOFT_AGGRESSION_PATTERNS` list for passive-aggressive commands (рот закрой, заткнись, завали, лечись, etc.)

### Improved Target Detection
- Rewrote `_has_aggressive_target()` to be more precise:
  - Now checks for combinations of pronouns (ты/вы) + aggression markers, not just pronoun presence
  - Includes direct mention via @ as always targeted
  - Checks against specific insult/aggression word lists to avoid false positives
  - Better handles edge cases where pronouns appear without actual targeting

### Enhanced Local Moderation Logic
- Refined decision tree in `local_moderation()`:
  - Profanity + insult + target = severity 3 (aggression)
  - Insult + target (no profanity) = severity 2 (rude)
  - Profanity + target + high aggression = severity 2
  - Profanity + target + low aggression = severity 1
  - Soft aggression patterns = severity 1
  - Insults without target = severity 0 (situation complaint)
- Updated `detect_aggression_level()` to recognize insults with targets and soft aggression patterns

### Context Handling Improvements
- Increased context window from 5 to 8 messages for better conversation understanding
- Modified `_get_topic_context()` to include user IDs in format `[user_NNNN]: text`
- Updated moderation handler to include current message with user ID in context
- This allows AI to better track who is responding to whom and detect escalation patterns

## Implementation Details
- The severity framework now explicitly prioritizes **who** the message targets over **what words** are used
- Casual profanity without a target remains severity 0 (not punished)
- Targeted rudeness is now caught at severity 1-2 even without profanity
- Context window expansion enables better detection of harassment patterns and conflict escalation

https://claude.ai/code/session_019EDPSUbbLrzmGUy7zCUL2f