### PR TITLE
Добавить `max_tokens` в запрос OpenRouter и улучшить диагностику 400 ошибок

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -178,6 +178,7 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("AI_KEY", "OPENROUTER_API_KEY"),
     )
     ai_model: str = "qwen/qwen3.5-flash"
+    ai_max_tokens: int = 800
     ai_timeout_seconds: int = 20
     ai_retries: int = 2
     ai_daily_request_limit: int = 2000

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -497,6 +497,7 @@ class OpenRouterProvider:
         payload = {
             "model": self._model,
             "temperature": 0.7,
+            "max_tokens": settings.ai_max_tokens,
             "messages": messages,
         }
         headers = {
@@ -528,6 +529,14 @@ class OpenRouterProvider:
                 )
                 if status_code == 429 and attempt < self._retries:
                     continue
+                error_hint = ""
+                try:
+                    error_payload = exc.response.json()
+                    error_hint = str(error_payload.get("error", {}).get("message") or "")[:160]
+                except ValueError:
+                    error_hint = response_text[:160]
+                if error_hint:
+                    raise RuntimeError(f"AI API вернул ошибку {status_code}: {error_hint}") from exc
                 raise RuntimeError(f"AI API вернул ошибку {status_code}") from exc
             except (httpx.TimeoutException, httpx.TransportError) as exc:
                 if attempt >= self._retries:


### PR DESCRIPTION
### Motivation
- Исправить частые `400 Bad Request` при вызовах OpenRouter и дать понятную причину ошибки в диагностике `/ai_probe` для ускорения расследования инцидентов.

### Description
- Добавлен новый параметр конфигурации `ai_max_tokens` с значением по умолчанию `800` в `app/config.py` и использован в настройках AI.`
- В `OpenRouterProvider._chat_completion` (в `app/services/ai_module.py`) в payload запроса к `/chat/completions` добавлено поле `max_tokens` для явного ограничения выдачи.
- Обновлена обработка HTTP-ошибок: при 4xx/5xx из тела ответа пытаемся извлечь `error.message` и подставить краткую подсказку в текст `RuntimeError`, если она доступна.

### Testing
- Запущена команда `pytest -q tests/test_ai_module.py tests/test_config_settings.py` и все тесты прошли успешно (`30 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b024abf4f48326abc1463c5af5442f)