### PR TITLE
Нормализация `AI_MODEL` (замена запятой на точку) — фикс некорректного model ID

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -264,6 +264,17 @@ class Settings(BaseSettings):
             return cleaned if cleaned else None
         return value
 
+    @field_validator("ai_model", mode="before")
+    @classmethod
+    def _normalize_ai_model(cls, value: object) -> object:
+        """Исправляет частую опечатку `qwen3,5` -> `qwen3.5` в AI_MODEL."""
+        if not isinstance(value, str):
+            return value
+        normalized = value.strip().strip("'\"")
+        if "," in normalized:
+            normalized = normalized.replace(",", ".")
+        return normalized
+
 
     @property
     def data_dir(self) -> Path:

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -60,6 +60,16 @@ def test_settings_reads_openrouter_api_key_alias() -> None:
     assert settings.ai_key == "or-test-key"
 
 
+def test_settings_normalizes_ai_model_decimal_separator() -> None:
+    settings = Settings(
+        **BASE_ENV,
+        _env_file=None,
+        AI_MODEL="qwen/qwen3,5-flash",
+    )
+
+    assert settings.ai_model == "qwen/qwen3.5-flash"
+
+
 def test_extract_compose_bot_env_from_environment_block(tmp_path) -> None:
     compose = tmp_path / "docker-compose.yaml"
     compose.write_text(


### PR DESCRIPTION
### Motivation
- Исправить частую опечатку в `AI_MODEL` типа `qwen/qwen3,5-flash`, из‑за которой OpenRouter возвращал 400 `not a valid model ID`.

### Description
- Добавлен `@field_validator("ai_model", mode="before")` в `Settings`, который очищает значение от пробелов/кавычек и заменяет десятичную запятую на точку (`,` → `.`).
- Добавлен unit-тест `test_settings_normalizes_ai_model_decimal_separator` в `tests/test_config_settings.py`, который проверяет нормализацию `AI_MODEL="qwen/qwen3,5-flash"` → `qwen/qwen3.5-flash`.
- Изменён файл `app/config.py` и обновлён тест `tests/test_config_settings.py`.

### Testing
- Запущена команда `pytest -q tests/test_config_settings.py tests/test_ai_module.py`, все тесты завершились успешно: `31 passed`.
- Новый тест `test_settings_normalizes_ai_model_decimal_separator` проходит успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b02cff363c8326afc80c7f451ce166)