### PR TITLE
Normalize OpenRouter model IDs and retry with fallback on invalid model errors

### DIFF
--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -45,6 +45,20 @@ _CACHE_STOP_WORDS = {
 }
 
 
+def _normalize_model_id(model_id: str) -> str:
+    """Исправляет частые опечатки в ID модели OpenRouter."""
+    normalized = model_id.strip().strip("'\"")
+    return normalized.replace(",", ".").replace("，", ".")
+
+
+_MODEL_FALLBACK_ID = "openrouter/auto"
+
+
+def _is_invalid_model_id_error(error_hint: str) -> bool:
+    normalized = error_hint.lower()
+    return "valid model id" in normalized or "invalid model" in normalized
+
+
 def _normalize_cache_key(text: str) -> str:
     """Нормализует запрос для кэша: lowercase, без стоп-слов, сортировка."""
     tokens = sorted(
@@ -481,7 +495,9 @@ class OpenRouterProvider:
             base_url=base_url.rstrip("/"),
             timeout=httpx.Timeout(settings.ai_timeout_seconds),
         )
-        self._model = settings.ai_model
+        self._model = _normalize_model_id(settings.ai_model)
+        if self._model != settings.ai_model:
+            logger.warning("AI model id normalized: %r -> %r", settings.ai_model, self._model)
         self._retries = max(0, settings.ai_retries)
 
     async def aclose(self) -> None:
@@ -495,7 +511,6 @@ class OpenRouterProvider:
             raise RuntimeError(f"AI лимит: {reason or 'превышен'}")
 
         payload = {
-            "model": self._model,
             "temperature": 0.7,
             "max_tokens": settings.ai_max_tokens,
             "messages": messages,
@@ -504,9 +519,12 @@ class OpenRouterProvider:
             "Authorization": f"Bearer {settings.ai_key}",
             "Content-Type": "application/json",
         }
-        logger.info("AI request -> model=%s chat_id=%s", self._model, chat_id)
+        model_id = self._model
+        used_fallback_model = False
 
         for attempt in range(self._retries + 1):
+            payload["model"] = model_id
+            logger.info("AI request -> model=%s chat_id=%s", model_id, chat_id)
             try:
                 response = await self._client.post("/chat/completions", json=payload, headers=headers)
                 if response.status_code >= 500 and attempt < self._retries:
@@ -516,6 +534,9 @@ class OpenRouterProvider:
                 content = str(data["choices"][0]["message"]["content"])
                 tokens = int(data.get("usage", {}).get("total_tokens") or 0)
                 await _add_remote_usage(chat_id, tokens)
+                if used_fallback_model and self._model != model_id:
+                    logger.warning("AI model switched to fallback for runtime stability: %r", model_id)
+                    self._model = model_id
                 logger.info("AI response <- tokens=%s chat_id=%s", tokens, chat_id)
                 return content, tokens
             except httpx.HTTPStatusError as exc:
@@ -535,6 +556,20 @@ class OpenRouterProvider:
                     error_hint = str(error_payload.get("error", {}).get("message") or "")[:160]
                 except ValueError:
                     error_hint = response_text[:160]
+                if (
+                    status_code == 400
+                    and _is_invalid_model_id_error(error_hint)
+                    and not used_fallback_model
+                    and model_id != _MODEL_FALLBACK_ID
+                ):
+                    logger.warning(
+                        "AI invalid model id, retrying with fallback model: %r -> %r",
+                        model_id,
+                        _MODEL_FALLBACK_ID,
+                    )
+                    model_id = _MODEL_FALLBACK_ID
+                    used_fallback_model = True
+                    continue
                 if error_hint:
                     raise RuntimeError(f"AI API вернул ошибку {status_code}: {error_hint}") from exc
                 raise RuntimeError(f"AI API вернул ошибку {status_code}") from exc

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -17,6 +17,7 @@ from app.services.ai_module import (
     normalize_for_profanity,
     parse_quiz_answer_response,
     _extract_search_words,
+    _normalize_model_id,
 )
 
 
@@ -48,6 +49,10 @@ class _SlowProvider:
     async def categorize_rag_entry(self, text: str, *, chat_id: int):  # type: ignore[no-untyped-def]
         await asyncio.sleep(0.1)
 
+
+def test_normalize_model_id_replaces_decimal_commas() -> None:
+    assert _normalize_model_id("qwen/qwen3,5-flash") == "qwen/qwen3.5-flash"
+    assert _normalize_model_id("qwen/qwen3，5-flash") == "qwen/qwen3.5-flash"
 
 def test_detects_masked_profanity() -> None:
     normalized = normalize_for_profanity("Да ты б*л_я!")
@@ -167,6 +172,50 @@ def test_openrouter_assistant_fallback_on_http_400(monkeypatch) -> None:
     reply = asyncio.run(provider.assistant_reply("вопрос про шлагбаум", [], chat_id=1))
     assert "шлагбаум" in reply.lower()
     asyncio.run(provider.aclose())
+
+
+def test_openrouter_retries_with_fallback_model_on_invalid_id(monkeypatch) -> None:
+    provider = OpenRouterProvider()
+    sent_models: list[str] = []
+
+    async def _fake_add_usage(chat_id: int, tokens: int) -> None:
+        return None
+
+    async def _post(*args, **kwargs):  # type: ignore[no-untyped-def]
+        model = kwargs["json"]["model"]
+        sent_models.append(model)
+        request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+        if len(sent_models) == 1:
+            return httpx.Response(
+                400,
+                request=request,
+                json={"error": {"message": f"{model} is not a valid model ID"}},
+            )
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {"total_tokens": 12},
+            },
+        )
+
+    async def _allow(chat_id: int) -> tuple[bool, str | None]:
+        return (True, None)
+
+    monkeypatch.setattr("app.services.ai_module.settings.ai_key", "test-key", raising=False)
+    monkeypatch.setattr("app.services.ai_module._can_use_remote_ai", _allow)
+    monkeypatch.setattr("app.services.ai_module._add_remote_usage", _fake_add_usage)
+    monkeypatch.setattr(provider._client, "post", _post)
+
+    content, tokens = asyncio.run(provider._chat_completion([{"role": "user", "content": "ping"}], chat_id=1))
+
+    assert content == "ok"
+    assert tokens == 12
+    assert len(sent_models) == 2
+    assert sent_models[-1] == "openrouter/auto"
+    asyncio.run(provider.aclose())
+
 def test_openrouter_summary_fallback_on_runtime_error(monkeypatch) -> None:
     provider = OpenRouterProvider()
 


### PR DESCRIPTION
### Motivation
- Fix common typos in configured OpenRouter model IDs and make runtime requests more resilient when the remote API rejects a model ID. 

### Description
- Add `_normalize_model_id` to trim and normalize model identifiers (replace decimal commas with dots) and apply it to `OpenRouterProvider` on init with a warning when changed. 
- Introduce `_is_invalid_model_id_error` and `_MODEL_FALLBACK_ID` and update `_chat_completion` to set `payload["model"]` per attempt, detect 400 errors that indicate an invalid model id, and retry once with the fallback model `openrouter/auto`, logging the switch and persisting the fallback on success. 
- Adjust error handling and logging around HTTP errors and token accounting; keep original behaviour for other errors and retries. 
- Add unit tests `test_normalize_model_id_replaces_decimal_commas` and `test_openrouter_retries_with_fallback_model_on_invalid_id` and import the new normalizer into the test module. 

### Testing
- Ran the updated unit tests in `tests/test_ai_module.py`, including `test_normalize_model_id_replaces_decimal_commas` and `test_openrouter_retries_with_fallback_model_on_invalid_id`, and they passed. 
- Existing AI-related tests in the same module were executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0339aa84483268fd829af37b4d1fc)