### PR TITLE
Не перезаписывать переменные окружения из docker-compose и пропускать пустые значения

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -136,6 +136,11 @@ def _inject_env_from_server_compose() -> None:
     """Подхватывает env из /opt/alexbot/docker-compose.yaml как источник истины."""
     compose_env = _extract_compose_bot_env(SERVER_COMPOSE_PATH)
     for key, value in compose_env.items():
+        if not value:
+            continue
+        existing = os.getenv(key)
+        if existing:
+            continue
         os.environ[key] = value
 
 

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -163,7 +163,7 @@ def test_extract_compose_bot_env_resolves_compose_placeholders(monkeypatch, tmp_
     assert env["ADMIN_LOG_CHAT_ID"] == "-100777"
 
 
-def test_inject_env_from_server_compose_overrides_existing(monkeypatch, tmp_path) -> None:
+def test_inject_env_from_server_compose_keeps_existing_process_env(monkeypatch, tmp_path) -> None:
     compose = tmp_path / "docker-compose.yaml"
     compose.write_text(
         """services:
@@ -186,7 +186,27 @@ def test_inject_env_from_server_compose_overrides_existing(monkeypatch, tmp_path
 
     _inject_env_from_server_compose()
 
-    assert os.environ["BOT_TOKEN"] == "from-compose"
+    assert os.environ["BOT_TOKEN"] == "from-env"
     assert os.environ["FORUM_CHAT_ID"] == "-100123"
     assert os.environ["ADMIN_LOG_CHAT_ID"] == "-100456"
     assert os.environ["AI_MODEL"] == "qwen/qwen3.5-flash"
+
+
+def test_inject_env_from_server_compose_skips_empty_values(monkeypatch, tmp_path) -> None:
+    compose = tmp_path / "docker-compose.yaml"
+    compose.write_text(
+        """services:
+  bot:
+    image: test
+    environment:
+      AI_KEY: ${AI_KEY}
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("app.config.SERVER_COMPOSE_PATH", compose)
+    monkeypatch.delenv("AI_KEY", raising=False)
+
+    _inject_env_from_server_compose()
+
+    assert "AI_KEY" not in os.environ


### PR DESCRIPTION
### Motivation
- При старте бот мог оставаться в локальном (stub) режиме, потому что `_inject_env_from_server_compose()` записывала значения из `/opt/alexbot/docker-compose.yaml` в `os.environ`, перезаписывая runtime/process env или записывая пустые значения (включая `AI_KEY`).

### Description
- Изменил `_inject_env_from_server_compose()` в `app/config.py`, чтобы пропускать пустые значения из compose и не перезаписывать уже заданные в process env переменные (рантайм имеет приоритет).
- Обновил тест `tests/test_config_settings.py`: переименовал/адаптировал проверку приоритета process env и добавил тест `test_inject_env_from_server_compose_skips_empty_values` для контроля пропуска пустых значений.
- Изменённые файлы: `app/config.py`, `tests/test_config_settings.py`.

### Testing
- Запустил `pytest -q tests/test_config_settings.py`, все тесты прошли (`10 passed`).
- Запустил `pytest -q tests/test_ai_module.py`, все тесты прошли (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b03641585483268cf04b920984a0d7)