### PR TITLE
Поддержка AI_API_KEY алиаса для OpenRouter (исправляет нежелательный локальный fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,9 @@ BUILD_VERSION=dev
 AI_ENABLED=true
 AI_API_URL=https://openrouter.ai/api/v1
 AI_KEY=
-# Альтернативное имя (поддерживается как алиас):
+# Альтернативные имена (поддерживаются как алиасы):
 OPENROUTER_API_KEY=
+AI_API_KEY=
 AI_MODEL=qwen/qwen3.5-flash
 AI_TIMEOUT_SECONDS=20
 AI_RETRIES=2

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python scripts/import_places_from_google_sheets.py --dry-run
 ## AI: текущий статус
 
 Бот поддерживает два режима AI:
-- **Remote AI**: если заданы `AI_KEY` (и опционально `AI_API_URL`, `AI_MODEL`), используется внешний провайдер через Chat Completions API.
+- **Remote AI**: если задан `AI_KEY` (или алиас `OPENROUTER_API_KEY`/`AI_API_KEY`) и опционально `AI_API_URL`, `AI_MODEL`, используется внешний провайдер через Chat Completions API.
 - **Stub fallback**: если ключ не задан или API недоступен, бот автоматически работает в локальном режиме без падений.
 
 В remote-режиме включены:
@@ -122,7 +122,7 @@ python scripts/import_places_from_google_sheets.py --dry-run
 
 ### Что контролирует админ
 
-- `/ai_on` — включает runtime-флаг AI (если есть `AI_KEY`, бот работает через внешний провайдер).
+- `/ai_on` — включает runtime-флаг AI (если есть `AI_KEY` (или алиасы), бот работает через внешний провайдер).
 - `/ai_off` — принудительно отключает runtime AI и переводит функции в локальный fallback.
 - `/ai_status` — показывает текущий режим, usage за день и последнюю ошибку.
 - `/ai_ping` — быстрый health-check клиента.
@@ -196,7 +196,7 @@ python -m app.main
 python scripts/check_openrouter.py --api-key sk-or-...
 ```
 
-Если аргументы не переданы, скрипт берёт `AI_KEY` (или `OPENROUTER_API_KEY`), `AI_MODEL`, `AI_API_URL`
+Если аргументы не переданы, скрипт берёт `AI_KEY` (или `OPENROUTER_API_KEY`/`AI_API_KEY`), `AI_MODEL`, `AI_API_URL`
 сначала из переменных окружения процесса, затем из локального файла `.env`.
 
 Или через переменные окружения:

--- a/app/config.py
+++ b/app/config.py
@@ -180,7 +180,7 @@ class Settings(BaseSettings):
     ai_api_url: str | None = None
     ai_key: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("AI_KEY", "OPENROUTER_API_KEY"),
+        validation_alias=AliasChoices("AI_KEY", "OPENROUTER_API_KEY", "AI_API_KEY"),
     )
     ai_model: str = "qwen/qwen3.5-flash"
     ai_max_tokens: int = 800

--- a/scripts/check_openrouter.py
+++ b/scripts/check_openrouter.py
@@ -25,8 +25,10 @@ def build_parser() -> argparse.ArgumentParser:
     default_api_key = (
         os.getenv("AI_KEY")
         or os.getenv("OPENROUTER_API_KEY")
+        or os.getenv("AI_API_KEY")
         or env_values.get("AI_KEY")
         or env_values.get("OPENROUTER_API_KEY")
+        or env_values.get("AI_API_KEY")
     )
     default_model = os.getenv("AI_MODEL") or env_values.get("AI_MODEL") or "qwen/qwen3.5-flash"
     default_api_url = os.getenv("AI_API_URL") or env_values.get("AI_API_URL") or "https://openrouter.ai/api/v1"
@@ -84,7 +86,7 @@ def main() -> int:
     args = parser.parse_args()
 
     if not args.api_key:
-        print("ERROR: не задан API ключ. Передайте --api-key или переменную AI_KEY/OPENROUTER_API_KEY.")
+        print("ERROR: не задан API ключ. Передайте --api-key или переменную AI_KEY/OPENROUTER_API_KEY/AI_API_KEY.")
         return 2
 
     result = asyncio.run(

--- a/tests/test_check_openrouter.py
+++ b/tests/test_check_openrouter.py
@@ -56,3 +56,16 @@ def test_build_parser_prefers_ai_key_over_openrouter_alias(monkeypatch) -> None:
     args = parser.parse_args([])
 
     assert args.api_key == "ai-key"
+
+
+def test_build_parser_reads_ai_api_key_alias_from_dotenv(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("AI_API_KEY=dotenv-ai-api-key\n", encoding="utf-8")
+    monkeypatch.delenv("AI_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("AI_API_KEY", raising=False)
+
+    parser = check_openrouter.build_parser()
+    args = parser.parse_args([])
+
+    assert args.api_key == "dotenv-ai-api-key"

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -60,6 +60,16 @@ def test_settings_reads_openrouter_api_key_alias() -> None:
     assert settings.ai_key == "or-test-key"
 
 
+def test_settings_reads_ai_api_key_alias() -> None:
+    settings = Settings(
+        **BASE_ENV,
+        _env_file=None,
+        AI_API_KEY="legacy-test-key",
+    )
+
+    assert settings.ai_key == "legacy-test-key"
+
+
 def test_settings_normalizes_ai_model_decimal_separator() -> None:
     settings = Settings(
         **BASE_ENV,


### PR DESCRIPTION
### Motivation
- На некоторых серверах API-ключ мог задаваться под именем `AI_API_KEY` в `docker-compose.yaml`, но приложение учитывало только `AI_KEY` и `OPENROUTER_API_KEY`, из‑за чего бот уходил в локальный stub/fallback режим.
- Нужно гарантировать, что ключ из сервера (/opt/alexbot/docker-compose.yaml/.env) будет корректно подхвачен и бот сможет работать в remote AI-режиме.

### Description
- Добавлен дополнительный алиас `AI_API_KEY` в `Settings.ai_key` (`app/config.py`) для чтения ключа через pydantic `validation_alias`.
- Обновлён `scripts/check_openrouter.py`, чтобы health-check также искал `AI_API_KEY` в процессном окружении и в `.env` и обновлён текст ошибки для подсказки о новом алиасе.
- Обновлены документация и пример переменных: `README.md` и `.env.example` с указанием поддержки `AI_KEY`, `OPENROUTER_API_KEY` и `AI_API_KEY`.
- Добавлены/обновлены тесты: `tests/test_config_settings.py` и `tests/test_check_openrouter.py` для покрытия нового алиаса и предотвращения регрессий.

### Testing
- Запущена группа тестов: `pytest -q tests/test_config_settings.py tests/test_check_openrouter.py` — результат: `16 passed`.
- Локальная проверка парсинга `.env` и приоритезации переменных выполнена в автотестах, все добавленные тесты проходят успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b039ec66808326a2fb69f76e8fd3da)