### PR TITLE
Reject empty OpenRouter responses and add AI runtime toggle affecting provider selection

### DIFF
--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -531,7 +531,12 @@ class OpenRouterProvider:
                     continue
                 response.raise_for_status()
                 data = response.json()
-                content = str(data["choices"][0]["message"]["content"])
+                content_raw = data["choices"][0]["message"]["content"]
+                if content_raw is None:
+                    raise RuntimeError("AI вернул пустой ответ")
+                content = str(content_raw).strip()
+                if not content:
+                    raise RuntimeError("AI вернул пустой текст")
                 tokens = int(data.get("usage", {}).get("total_tokens") or 0)
                 await _add_remote_usage(chat_id, tokens)
                 if used_fallback_model and self._model != model_id:
@@ -1525,7 +1530,7 @@ async def build_dialog_summary_for_prompt(chat_id: int, user_id: int, *, limit: 
 
 
 _AI_CLIENT: AiModuleClient | None = None
-_AI_RUNTIME_ENABLED: bool = False
+_AI_RUNTIME_ENABLED: bool = True
 _ADMIN_ALERT_NOTIFIER: Callable[[str], Awaitable[None]] | None = None
 _LAST_ERROR: str | None = "stub_mode"
 _LAST_ERROR_AT: datetime | None = datetime.utcnow()
@@ -1565,7 +1570,7 @@ async def get_ai_usage_for_today(chat_id: int) -> tuple[int, int]:
 
 
 async def get_ai_diagnostics(chat_id: int) -> AiDiagnosticsReport:
-    provider_mode: Literal["remote", "stub"] = "remote" if settings.ai_enabled and bool(settings.ai_key) else "stub"
+    provider_mode: Literal["remote", "stub"] = "remote" if settings.ai_enabled and bool(settings.ai_key) and is_ai_runtime_enabled() else "stub"
     req_used, tok_used = await get_ai_usage_for_today(chat_id)
     probe_result = await get_ai_client().probe()
     return AiDiagnosticsReport(
@@ -1591,22 +1596,31 @@ def is_ai_runtime_enabled() -> bool:
 
 
 def set_ai_runtime_enabled(value: bool) -> None:
-    global _AI_RUNTIME_ENABLED
+    global _AI_RUNTIME_ENABLED, _AI_CLIENT, _LAST_ERROR, _LAST_ERROR_AT
     _AI_RUNTIME_ENABLED = value
-    logger.info("AI runtime toggle requested (%s), но активен stub-режим.", value)
+    _AI_CLIENT = None
+    if value:
+        logger.info("AI runtime flag enabled.")
+    else:
+        _LAST_ERROR = "runtime_disabled"
+        _LAST_ERROR_AT = datetime.utcnow()
+        logger.info("AI runtime flag disabled; forcing stub mode.")
 
 
 def get_ai_client() -> AiModuleClient:
     global _LAST_ERROR, _LAST_ERROR_AT
     global _AI_CLIENT
     if _AI_CLIENT is None:
-        if settings.ai_enabled and settings.ai_key:
+        if settings.ai_enabled and settings.ai_key and is_ai_runtime_enabled():
             _AI_CLIENT = AiModuleClient(OpenRouterProvider())
             _LAST_ERROR = None
             _LAST_ERROR_AT = None
         else:
             _AI_CLIENT = AiModuleClient()
-            _LAST_ERROR = "stub_mode"
+            if not is_ai_runtime_enabled():
+                _LAST_ERROR = "runtime_disabled"
+            else:
+                _LAST_ERROR = "stub_mode"
             _LAST_ERROR_AT = datetime.utcnow()
     return _AI_CLIENT
 

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -18,6 +18,9 @@ from app.services.ai_module import (
     parse_quiz_answer_response,
     _extract_search_words,
     _normalize_model_id,
+    get_ai_client,
+    is_ai_runtime_enabled,
+    set_ai_runtime_enabled,
 )
 
 
@@ -228,6 +231,41 @@ def test_openrouter_summary_fallback_on_runtime_error(monkeypatch) -> None:
     asyncio.run(provider.aclose())
 
 
+def test_openrouter_chat_completion_raises_on_empty_content(monkeypatch) -> None:
+    provider = OpenRouterProvider()
+
+    async def _fake_add_usage(chat_id: int, tokens: int) -> None:
+        return None
+
+    async def _post(*args, **kwargs):  # type: ignore[no-untyped-def]
+        request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "choices": [{"message": {"content": None}}],
+                "usage": {"total_tokens": 0},
+            },
+        )
+
+    async def _allow(chat_id: int) -> tuple[bool, str | None]:
+        return (True, None)
+
+    monkeypatch.setattr("app.services.ai_module.settings.ai_key", "test-key", raising=False)
+    monkeypatch.setattr("app.services.ai_module._can_use_remote_ai", _allow)
+    monkeypatch.setattr("app.services.ai_module._add_remote_usage", _fake_add_usage)
+    monkeypatch.setattr(provider._client, "post", _post)
+
+    try:
+        asyncio.run(provider._chat_completion([{"role": "user", "content": "ping"}], chat_id=1))
+    except RuntimeError as exc:
+        assert "пустой ответ" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError for empty AI content")
+    finally:
+        asyncio.run(provider.aclose())
+
+
 def test_get_ai_diagnostics_for_stub(monkeypatch) -> None:
     async def _fake_usage(chat_id: int) -> tuple[int, int]:
         return (0, 0)
@@ -261,3 +299,33 @@ def test_extract_search_words_adds_stem_variant_for_school_words() -> None:
     words = _extract_search_words("Какая школа рядом?")
     assert "школа" in words
     assert "школ" in words
+
+
+def test_runtime_flag_is_enabled_by_default() -> None:
+    assert is_ai_runtime_enabled() is True
+
+
+def test_get_ai_client_uses_stub_when_runtime_disabled(monkeypatch) -> None:
+    monkeypatch.setattr("app.services.ai_module._AI_CLIENT", None, raising=False)
+    monkeypatch.setattr("app.services.ai_module.settings.ai_enabled", True, raising=False)
+    monkeypatch.setattr("app.services.ai_module.settings.ai_key", "test-key", raising=False)
+
+    set_ai_runtime_enabled(False)
+    client = get_ai_client()
+
+    assert type(client._provider).__name__ == "StubAiProvider"
+
+
+def test_runtime_toggle_recreates_client(monkeypatch) -> None:
+    monkeypatch.setattr("app.services.ai_module._AI_CLIENT", None, raising=False)
+    monkeypatch.setattr("app.services.ai_module.settings.ai_enabled", True, raising=False)
+    monkeypatch.setattr("app.services.ai_module.settings.ai_key", "test-key", raising=False)
+
+    set_ai_runtime_enabled(False)
+    first = get_ai_client()
+    set_ai_runtime_enabled(True)
+    second = get_ai_client()
+
+    assert first is not second
+
+    asyncio.run(second.aclose())


### PR DESCRIPTION
### Motivation

- Ensure the code fails fast when the remote AI returns an empty or null message payload to avoid downstream misbehavior.
- Allow switching the AI runtime on/off at runtime so diagnostics and client creation respect an operational toggle.

### Description

- In `OpenRouterProvider._chat_completion` check for `None` and empty string in `choices[0].message.content` and raise `RuntimeError` with clear messages if empty, and `strip()` the content before returning.
- Change default `_AI_RUNTIME_ENABLED` to `True` and add `is_ai_runtime_enabled()` checks to `get_ai_diagnostics` and `get_ai_client` so provider selection respects the runtime flag.
- Update `set_ai_runtime_enabled` to reset `_AI_CLIENT`, update `_LAST_ERROR` and `_LAST_ERROR_AT`, and log the runtime toggle; `get_ai_client` sets `_LAST_ERROR` to `runtime_disabled` when appropriate.
- Add tests and imports to validate the new behaviors and runtime toggle interactions with the client implementation.

### Testing

- Added and ran unit tests including `test_openrouter_chat_completion_raises_on_empty_content`, `test_runtime_flag_is_enabled_by_default`, `test_get_ai_client_uses_stub_when_runtime_disabled`, and `test_runtime_toggle_recreates_client`, which passed locally.
- Ran the `tests/test_ai_module.py` suite to validate moderation/assistant fallbacks and the new runtime-related behavior, with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b03cb349ec8326bc36441921388abd)