### PR TITLE
Учёт runtime-флага при определении режима AI (resolve_provider_mode)

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -28,6 +28,7 @@ from app.services.ai_module import (
     get_ai_usage_for_today,
     is_ai_runtime_enabled,
     set_ai_runtime_enabled,
+    resolve_provider_mode,
 )
 from app.services.ai_usage import next_reset_delta, reset_ai_usage
 from app.services.rag import add_rag_message, build_canonical_text, get_rag_count, systematize_rag
@@ -255,7 +256,7 @@ async def ai_status(message: Message, bot: Bot) -> None:
     if runtime.last_error_at:
         last_error = f"{last_error} ({runtime.last_error_at.isoformat(timespec='seconds')} UTC)"
 
-    provider = "Remote API" if settings.ai_enabled and bool(settings.ai_key) else "STUB"
+    provider = "Remote API" if resolve_provider_mode() == "remote" else "STUB"
     await message.reply(
         "Статус AI:\n"
         f"• Провайдер: {provider}\n"

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -1561,6 +1561,13 @@ def get_ai_runtime_status() -> AiRuntimeStatus:
     return AiRuntimeStatus(last_error=_LAST_ERROR, last_error_at=_LAST_ERROR_AT)
 
 
+def resolve_provider_mode() -> Literal["remote", "stub"]:
+    """Возвращает фактический режим провайдера с учетом ключа и runtime-флага."""
+    if settings.ai_enabled and bool(settings.ai_key) and is_ai_runtime_enabled():
+        return "remote"
+    return "stub"
+
+
 async def get_ai_usage_for_today(chat_id: int) -> tuple[int, int]:
     date_key = now_tz().date().isoformat()
     async for session in get_session():
@@ -1570,7 +1577,7 @@ async def get_ai_usage_for_today(chat_id: int) -> tuple[int, int]:
 
 
 async def get_ai_diagnostics(chat_id: int) -> AiDiagnosticsReport:
-    provider_mode: Literal["remote", "stub"] = "remote" if settings.ai_enabled and bool(settings.ai_key) and is_ai_runtime_enabled() else "stub"
+    provider_mode = resolve_provider_mode()
     req_used, tok_used = await get_ai_usage_for_today(chat_id)
     probe_result = await get_ai_client().probe()
     return AiDiagnosticsReport(

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -21,6 +21,7 @@ from app.services.ai_module import (
     get_ai_client,
     is_ai_runtime_enabled,
     set_ai_runtime_enabled,
+    resolve_provider_mode,
 )
 
 
@@ -303,6 +304,17 @@ def test_extract_search_words_adds_stem_variant_for_school_words() -> None:
 
 def test_runtime_flag_is_enabled_by_default() -> None:
     assert is_ai_runtime_enabled() is True
+
+
+def test_resolve_provider_mode_respects_runtime_flag(monkeypatch) -> None:
+    monkeypatch.setattr("app.services.ai_module.settings.ai_enabled", True, raising=False)
+    monkeypatch.setattr("app.services.ai_module.settings.ai_key", "test-key", raising=False)
+
+    set_ai_runtime_enabled(False)
+    assert resolve_provider_mode() == "stub"
+
+    set_ai_runtime_enabled(True)
+    assert resolve_provider_mode() == "remote"
 
 
 def test_get_ai_client_uses_stub_when_runtime_disabled(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Исправить рассинхрон между фактическим режимом работы AI и отображением в диагностике/админском статусе, когда при выключенном runtime-флаге бот выглядел как «Remote» несмотря на локальный fallback. 

### Description
- Добавлен `resolve_provider_mode()` в `app/services/ai_module.py` для единой логики выбора режима (`"remote"` или `"stub"`) с учётом `ai_enabled`, наличия `ai_key` и runtime-флага.
- Переведён `get_ai_diagnostics()` на использование нового резолвера вместо дублированной проверки.
- Обновлён `/ai_status` в `app/handlers/admin.py`, теперь поле «Провайдер» вычисляется через `resolve_provider_mode()` и корректно отражает реальный режим.
- Добавлен юнит-тест `test_resolve_provider_mode_respects_runtime_flag` в `tests/test_ai_module.py` для предотвращения регрессов.

### Testing
- Запуск целевых тестов: `pytest -q tests/test_ai_module.py::test_resolve_provider_mode_respects_runtime_flag tests/test_ai_module.py::test_get_ai_client_uses_stub_when_runtime_disabled tests/test_config_settings.py` — все тесты прошли (`3 passed`).
- Полный прогон модулей: `pytest -q tests/test_config_settings.py tests/test_ai_module.py` — все тесты прошли (`40 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b042cf94408326907b09d6c5a47cb2)