### PR TITLE
Handle AI responses with think tags and empty content

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -892,6 +892,12 @@ async def ai_command(message: Message) -> None:
             prompt, context, chat_id=message.chat.id,
         )
 
+        # Защита от пустого ответа (think-теги, whitespace и т.д.)
+        if not reply or not reply.strip():
+            from app.services.ai_module import build_local_assistant_reply
+            reply = build_local_assistant_reply(prompt, context=context)
+            logger.warning("AI вернул пустой ответ, использован локальный fallback.")
+
         await _remember_ai_exchange_persistent(
             message.chat.id, message.from_user.id, prompt, reply,
         )
@@ -971,6 +977,12 @@ async def mention_help(message: Message, bot: Bot) -> None:
 
             context = await _get_ai_context_persistent(message.chat.id, message.from_user.id)
             reply = await get_ai_client().assistant_reply(prompt, context, chat_id=message.chat.id)
+
+            # Защита от пустого ответа (think-теги, whitespace и т.д.)
+            if not reply or not reply.strip():
+                from app.services.ai_module import build_local_assistant_reply
+                reply = build_local_assistant_reply(prompt, context=context)
+                logger.warning("AI вернул пустой ответ на упоминание, использован локальный fallback.")
 
             await _remember_ai_exchange_persistent(
                 message.chat.id, message.from_user.id, prompt, reply,

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -45,6 +45,12 @@ _CACHE_STOP_WORDS = {
 }
 
 
+def _strip_think_tags(text: str) -> str:
+    """Удаляет теги <think>...</think> из ответов моделей (Qwen, DeepSeek и др.)."""
+    cleaned = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+    return cleaned
+
+
 def _normalize_model_id(model_id: str) -> str:
     """Исправляет частые опечатки в ID модели OpenRouter."""
     normalized = model_id.strip().strip("'\"")
@@ -539,9 +545,9 @@ class OpenRouterProvider:
                 content_raw = data["choices"][0]["message"]["content"]
                 if content_raw is None:
                     raise RuntimeError("AI вернул пустой ответ")
-                content = str(content_raw).strip()
+                content = _strip_think_tags(str(content_raw))
                 if not content:
-                    raise RuntimeError("AI вернул пустой текст")
+                    raise RuntimeError("AI вернул пустой текст (только think-теги)")
                 tokens = int(data.get("usage", {}).get("total_tokens") or 0)
                 await _add_remote_usage(chat_id, tokens)
                 if used_fallback_model and self._model != model_id:
@@ -1273,11 +1279,11 @@ def build_local_assistant_reply(
         return random.choice(_THANKS_REPLIES)
 
     # FAQ-ответ — наивысший приоритет (закреплённый ответ из базы)
-    if faq_hint:
-        return faq_hint[:800]
+    if faq_hint and faq_hint.strip():
+        return faq_hint.strip()[:800]
 
     # Данные из БД инфраструктуры приоритетнее статичной базы знаний
-    if places_hint:
+    if places_hint and places_hint.strip():
         # Варьируем вступление к ответу из БД инфраструктуры
         intros = (
             "Вот что нашёл в базе инфраструктуры:",
@@ -1285,17 +1291,17 @@ def build_local_assistant_reply(
             "Есть информация по вашему запросу:",
             "Нашёл кое-что полезное:",
         )
-        return f"{random.choice(intros)}\n{places_hint[:700]}"
+        return f"{random.choice(intros)}\n{places_hint.strip()[:700]}"
 
     # RAG-контекст из базы знаний ЖК
-    if rag_hint:
+    if rag_hint and rag_hint.strip():
         intros = (
             "Вот что нашёл в базе знаний:",
             "По базе знаний есть такая информация:",
             "Нашёл в наших записях:",
             "Есть данные по этой теме:",
         )
-        return f"{random.choice(intros)}\n{rag_hint[:700]}"
+        return f"{random.choice(intros)}\n{rag_hint.strip()[:700]}"
 
     resident_answer = build_resident_answer(normalized_prompt, context=context)
     if resident_answer:


### PR DESCRIPTION
## Summary
This PR adds robust handling for AI model responses that contain thinking tags (used by models like Qwen and DeepSeek) and implements fallback mechanisms when AI responses are empty or contain only whitespace.

## Key Changes

- **Added `_strip_think_tags()` function** in `ai_module.py` to remove `<think>...</think>` tags from AI responses using regex pattern matching
- **Updated response processing** in `_chat_completion()` to strip think tags and provide more descriptive error messages when responses are empty after tag removal
- **Enhanced hint validation** in `build_local_assistant_reply()` to check for empty/whitespace-only strings before using FAQ, infrastructure database, and RAG hints
- **Added fallback protection** in both `ai_command()` and `mention_help()` handlers to use local assistant replies when the AI returns empty or whitespace-only responses
- **Improved error logging** with specific messages indicating when think tags caused empty responses or when local fallback was triggered

## Implementation Details

- Think tag stripping uses `re.DOTALL` flag to handle multi-line content within tags
- All hint checks now use `.strip()` to validate content before processing
- Fallback mechanism gracefully degrades to `build_local_assistant_reply()` when AI fails to provide meaningful content
- Error messages are more descriptive to aid in debugging and monitoring

https://claude.ai/code/session_016iL7fkFBYC5jg6jHrZSdMi