### PR TITLE
Remove local mode fallback message from assistant replies

### DIFF
--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -223,7 +223,7 @@ _CONVERSATION_SUMMARY_PROMPT = (
     "Результат — краткое резюме разговора, до 500 символов."
 )
 
-_USER_FALLBACK = "Жабот работает в локальном режиме."
+_USER_FALLBACK = ""
 
 _ALLOWED_ASSISTANT_TOPICS = (
     "жк",
@@ -467,7 +467,7 @@ class StubAiProvider:
         places_context = await _get_places_context(safe_prompt)
         rag_text = await _get_rag_context(chat_id, safe_prompt)
         faq_answer = await _get_faq_answer(chat_id, safe_prompt)
-        return f"{_USER_FALLBACK} {build_local_assistant_reply(safe_prompt, context=context, places_hint=places_context, rag_hint=rag_text, faq_hint=faq_answer)}"
+        return build_local_assistant_reply(safe_prompt, context=context, places_hint=places_context, rag_hint=rag_text, faq_hint=faq_answer)
 
     async def evaluate_quiz_answer(
         self,
@@ -868,7 +868,7 @@ class AiModuleClient:
             places_context = await _get_places_context(prompt)
             rag_text = await _get_rag_context(chat_id, prompt)
             faq_answer = await _get_faq_answer(chat_id, prompt)
-            return f"{_USER_FALLBACK} {build_local_assistant_reply(prompt, context=context, places_hint=places_context, rag_hint=rag_text, faq_hint=faq_answer)}"
+            return build_local_assistant_reply(prompt, context=context, places_hint=places_context, rag_hint=rag_text, faq_hint=faq_answer)
 
     async def assistant_reply_with_history(
         self,

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -94,7 +94,8 @@ def test_probe_returns_stub_status() -> None:
 
 def test_assistant_reply_uses_local_fallback() -> None:
     reply = asyncio.run(AiModuleClient().assistant_reply("вопрос про шлагбаум", [], chat_id=1))
-    assert "локальном режиме" in reply.lower()
+    assert "локальном режиме" not in reply.lower()
+    assert len(reply.strip()) > 0
 
 
 def test_local_assistant_reply_handles_rules_and_mentions() -> None:
@@ -293,7 +294,8 @@ def test_ai_module_client_assistant_timeout_fallback(monkeypatch) -> None:
 
     reply = asyncio.run(client.assistant_reply("шлагбаум не работает", [], chat_id=1))
 
-    assert "локальном режиме" in reply.lower()
+    assert "локальном режиме" not in reply.lower()
+    assert len(reply.strip()) > 0
 
 
 def test_extract_search_words_adds_stem_variant_for_school_words() -> None:


### PR DESCRIPTION
## Summary
Removes the "local mode" fallback message that was being prepended to assistant replies, allowing the local assistant to return responses without the disclaimer prefix.

## Key Changes
- Cleared the `_USER_FALLBACK` constant from a Russian language message to an empty string
- Removed the fallback message prefix from two `assistant_reply` method implementations, returning only the built local assistant reply
- Updated corresponding tests to verify that the fallback message is no longer present in replies while ensuring responses are still non-empty

## Implementation Details
The changes affect the fallback behavior when the AI module operates in local mode:
- Previously, all local assistant replies were prefixed with "Жабот работает в локальном режиме." (Bot works in local mode)
- Now, local assistant replies are returned directly without any mode indicator prefix
- The underlying local assistant reply building logic remains unchanged; only the wrapper message is removed
- Tests were updated to assert the absence of the fallback message while confirming replies still contain meaningful content

https://claude.ai/code/session_01NxmD6jUeTLXjPSNtXFTTBz