### PR TITLE
AI: normalize more OpenRouter error hints, add `AI_MODEL` alias, and test 'no endpoints' fallback

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -182,7 +182,10 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("AI_KEY", "OPENROUTER_API_KEY", "AI_API_KEY"),
     )
-    ai_model: str = "qwen/qwen3.5-flash-02-23"
+    ai_model: str = Field(
+        default="qwen/qwen3.5-flash-02-23",
+        validation_alias=AliasChoices("AI_MODEL", "ai_model"),
+    )
     ai_max_tokens: int = 800
     ai_timeout_seconds: int = 20
     ai_retries: int = 2

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -67,6 +67,9 @@ def _is_invalid_model_id_error(error_hint: str) -> bool:
         or "invalid model" in normalized
         or "model not found" in normalized
         or "not found" in normalized
+        or "no endpoints found" in normalized
+        or "provider returned error" in normalized and "model" in normalized
+        or "is not available" in normalized
     )
 
 

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -221,6 +221,49 @@ def test_openrouter_retries_with_fallback_model_on_invalid_id(monkeypatch) -> No
     assert sent_models[-1] == "openrouter/auto"
     asyncio.run(provider.aclose())
 
+
+def test_openrouter_retries_with_fallback_model_on_no_endpoints(monkeypatch) -> None:
+    provider = OpenRouterProvider()
+    sent_models: list[str] = []
+
+    async def _fake_add_usage(chat_id: int, tokens: int) -> None:
+        return None
+
+    async def _post(*args, **kwargs):  # type: ignore[no-untyped-def]
+        model = kwargs["json"]["model"]
+        sent_models.append(model)
+        request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+        if len(sent_models) == 1:
+            return httpx.Response(
+                404,
+                request=request,
+                json={"error": {"message": f"No endpoints found for {model}"}},
+            )
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {"total_tokens": 7},
+            },
+        )
+
+    async def _allow(chat_id: int) -> tuple[bool, str | None]:
+        return (True, None)
+
+    monkeypatch.setattr("app.services.ai_module.settings.ai_key", "test-key", raising=False)
+    monkeypatch.setattr("app.services.ai_module._can_use_remote_ai", _allow)
+    monkeypatch.setattr("app.services.ai_module._add_remote_usage", _fake_add_usage)
+    monkeypatch.setattr(provider._client, "post", _post)
+
+    content, tokens = asyncio.run(provider._chat_completion([{"role": "user", "content": "ping"}], chat_id=1))
+
+    assert content == "ok"
+    assert tokens == 7
+    assert len(sent_models) == 2
+    assert sent_models[-1] == "openrouter/auto"
+    asyncio.run(provider.aclose())
+
 def test_openrouter_summary_fallback_on_runtime_error(monkeypatch) -> None:
     provider = OpenRouterProvider()
 


### PR DESCRIPTION
### Motivation

- Improve detection of invalid model identifiers returned by OpenRouter and similar providers to trigger fallback behavior more reliably.
- Expose an environment variable alias for the AI model setting so `AI_MODEL` (and lowercase `ai_model`) can be used to override the default model.
- Add a unit test to cover the case where the provider returns a "no endpoints" error and ensure fallback to the auto model occurs.

### Description

- In `app/services/ai_module.py` extended `_is_invalid_model_id_error` to consider additional error hints such as `"no endpoints found"`, `"provider returned error"` with `"model"`, and `"is not available"` so these cases trigger the fallback model logic.
- In `app/config.py` changed `ai_model` from a plain `str` to a `Field` with `validation_alias=AliasChoices("AI_MODEL", "ai_model")` so `AI_MODEL` and `ai_model` environment variables can set the model.
- Added `test_openrouter_retries_with_fallback_model_on_no_endpoints` to `tests/test_ai_module.py` which simulates a 404 "No endpoints found" response and asserts the provider retries with `openrouter/auto`.

### Testing

- Ran the AI module tests in `tests/test_ai_module.py`, including `test_openrouter_retries_with_fallback_model_on_no_endpoints`, and the tests passed.
- Existing OpenRouter retry and fallback tests such as the invalid-id fallback test were executed and remained passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29f195bc88326ba177ea2ef33add7)