### PR TITLE
Укрепить fallback ассистента и защитить обработчик упоминаний от ошибки контекста

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -964,6 +964,7 @@ async def mention_help(message: Message, bot: Bot) -> None:
         return
 
     if prompt:
+        context: list[str] = []
         # Дедупликация: проверяем, не отвечали ли недавно на такой же запрос
         if _is_duplicate_prompt(message.chat.id, prompt):
             logger.info("OUT: MENTION_REPLY_SKIPPED_DUPLICATE prompt=%r", prompt[:80])

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -1211,7 +1211,10 @@ def _assistant_rule_reply(prompt: str) -> str | None:
 
 
 def _pick_fallback_variant(seed_text: str) -> str:
-    return random.choice(_FALLBACK_VARIANTS)
+    base_reply = random.choice(_FALLBACK_VARIANTS)
+    if "уточн" in base_reply.lower():
+        return base_reply
+    return f"{base_reply} Если хотите, можете уточнить вопрос — попробую помочь точнее."
 
 
 _EMPTY_PROMPT_REPLIES = (


### PR DESCRIPTION
### Motivation
- Повысить предсказуемость и UX локального fallback-а ассистента: при неизвестных вопросах нужно всегда предлагать пользователю явный следующий шаг. 
- Предотвратить потенциальную ошибку при обработке упоминаний, когда в блоке `except` пытаются использовать `context`, не инициализированный из‑за исключения.

### Description
- Обновлён `app/services/ai_module.py`: функция `_pick_fallback_variant` теперь всегда возвращает вариант с явным приглашением уточнить вопрос (если исходный вариант этого не содержит). Это делает поведение локального fallback-а более дружелюбным и предсказуемым.
- Обновлён `app/handlers/help.py`: в обработчике упоминаний (`mention_help`) переменная `context` инициализируется заранее (`context: list[str] = []`), чтобы гарантировать корректную работу fallback-ветки при исключениях до загрузки истории.
- Изменения минимальны, совместимы с существующими API и не меняют внешнее поведение команд, кроме улучшения текстов ответов и надёжности обработчика упоминаний.

### Testing
- Запущен набор unit/integration тестов: `pytest -q` — успешно, `136 passed`.
- Линтер: `ruff check app tests scripts` ранее выявил ряд небольших рекомендаций по чистоте кода; это не было решено в данном PR и требует отдельного шага (статус: `ruff` остаётся с находками).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2a607a59c83268b8f2c5f421832d1)