### PR TITLE
Исправление парсинга ответов OpenRouter в AI-модуле

### DIFF
--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -51,6 +51,45 @@ def _strip_think_tags(text: str) -> str:
     return cleaned
 
 
+def _extract_response_content(data: dict[str, object]) -> str:
+    """Извлекает текст ответа OpenRouter из разных совместимых форматов."""
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise RuntimeError("AI вернул ответ без choices")
+
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        raise RuntimeError("AI вернул некорректный формат choices")
+
+    message = first_choice.get("message")
+    if not isinstance(message, dict):
+        raise RuntimeError("AI вернул ответ без message")
+
+    content_raw = message.get("content")
+    if isinstance(content_raw, str):
+        return content_raw
+    if content_raw is None:
+        return ""
+    if isinstance(content_raw, list):
+        parts: list[str] = []
+        for item in content_raw:
+            if isinstance(item, str):
+                parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                continue
+            text_part = item.get("text")
+            if isinstance(text_part, str) and text_part.strip():
+                parts.append(text_part)
+                continue
+            if item.get("type") == "reasoning":
+                reasoning_part = item.get("reasoning")
+                if isinstance(reasoning_part, str) and reasoning_part.strip():
+                    parts.append(reasoning_part)
+        return "\n".join(parts)
+    return str(content_raw)
+
+
 def _normalize_model_id(model_id: str) -> str:
     """Исправляет частые опечатки в ID модели OpenRouter."""
     normalized = model_id.strip().strip("'\"")
@@ -545,10 +584,7 @@ class OpenRouterProvider:
                     continue
                 response.raise_for_status()
                 data = response.json()
-                content_raw = data["choices"][0]["message"]["content"]
-                if content_raw is None:
-                    raise RuntimeError("AI вернул пустой ответ")
-                content = _strip_think_tags(str(content_raw))
+                content = _strip_think_tags(_extract_response_content(data))
                 if not content:
                     raise RuntimeError("AI вернул пустой текст (только think-теги)")
                 tokens = int(data.get("usage", {}).get("total_tokens") or 0)

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -17,6 +17,7 @@ from app.services.ai_module import (
     normalize_for_profanity,
     parse_quiz_answer_response,
     _extract_search_words,
+    _extract_response_content,
     _normalize_model_id,
     get_ai_client,
     is_ai_runtime_enabled,
@@ -57,6 +58,27 @@ class _SlowProvider:
 def test_normalize_model_id_replaces_decimal_commas() -> None:
     assert _normalize_model_id("qwen/qwen3,5-flash") == "qwen/qwen3.5-flash"
     assert _normalize_model_id("qwen/qwen3，5-flash") == "qwen/qwen3.5-flash"
+
+
+def test_extract_response_content_supports_string() -> None:
+    payload = {"choices": [{"message": {"content": "Привет"}}]}
+    assert _extract_response_content(payload) == "Привет"
+
+
+def test_extract_response_content_supports_content_parts() -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "Первая часть"},
+                        {"type": "text", "text": "Вторая часть"},
+                    ]
+                }
+            }
+        ]
+    }
+    assert _extract_response_content(payload) == "Первая часть\nВторая часть"
 
 def test_detects_masked_profanity() -> None:
     normalized = normalize_for_profanity("Да ты б*л_я!")
@@ -304,7 +326,7 @@ def test_openrouter_chat_completion_raises_on_empty_content(monkeypatch) -> None
     try:
         asyncio.run(provider._chat_completion([{"role": "user", "content": "ping"}], chat_id=1))
     except RuntimeError as exc:
-        assert "пустой ответ" in str(exc)
+        assert "пустой текст" in str(exc)
     else:
         raise AssertionError("Expected RuntimeError for empty AI content")
     finally:


### PR DESCRIPTION
### Motivation
- Были случаи, когда `OpenRouter` возвращал `message.content` в нестандартном формате (не строка), и бот не отправлял ответ пользователю.
- Нужно надёжно извлекать текст из разных форматов ответа провайдера, чтобы избежать «молчания» ассистента при изменениях у поставщика.

### Description
- Добавлена функция ` _extract_response_content(data: dict)` в `app/services/ai_module.py`, которая валидирует структуру `choices/message` и извлекает текст из `content` в формах строки, списка частей или reasoning-блоков.
- Интегрирован новый парсер в `OpenRouterProvider._chat_completion`, заменив жёсткую индексацию `data["choices"][0]["message"]["content"]` на вызов ` _extract_response_content` и последующее очищение через ` _strip_think_tags`.
- Добавлены unit-тесты в `tests/test_ai_module.py` для проверки строкового `content` и `content` в виде списка частей, а также обновлена проверка ожидаемой текстовой ошибки для случая пустого контента.
- Изменены только `app/services/ai_module.py` и `tests/test_ai_module.py` для обратной совместимости с остальным кодом.

### Testing
- Запущена команда `pytest -q tests/test_ai_module.py tests/test_check_openrouter.py`, результат: `37 passed` (все тесты прошли успешно).
- Локальные тесты модуля AI подтверждают корректную обработку новых форматов `message.content` и сохранение прежней логики отката на локальный fallback при ошибках API.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2a7c97bc083269e867c0b5c9db01c)