### PR TITLE
Приоритет ответов из resident_kb над подсказкой places_hint в локальном ассистенте

### DIFF
--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -1324,7 +1324,14 @@ def build_local_assistant_reply(
     if faq_hint and faq_hint.strip():
         return faq_hint.strip()[:800]
 
-    # Данные из БД инфраструктуры приоритетнее статичной базы знаний
+    # Каноническая база знаний ЖК приоритетнее инфраструктурной БД,
+    # чтобы домовые вопросы (шлагбаум, УК, аварийка) не перебивались
+    # общими объектами вроде школ и магазинов.
+    resident_answer = build_resident_answer(normalized_prompt, context=context)
+    if resident_answer:
+        return resident_answer
+
+    # Данные из БД инфраструктуры — следующий приоритет
     if places_hint and places_hint.strip():
         # Варьируем вступление к ответу из БД инфраструктуры
         intros = (
@@ -1344,10 +1351,6 @@ def build_local_assistant_reply(
             "Есть данные по этой теме:",
         )
         return f"{random.choice(intros)}\n{rag_hint.strip()[:700]}"
-
-    resident_answer = build_resident_answer(normalized_prompt, context=context)
-    if resident_answer:
-        return resident_answer
 
     rule_reply = _assistant_rule_reply(normalized_prompt)
     if rule_reply:

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -140,6 +140,21 @@ def test_local_assistant_reply_uses_places_hint() -> None:
     assert "мфц видное" in reply.lower()
 
 
+def test_local_assistant_reply_prioritizes_resident_kb_over_places(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.ai_module.build_resident_answer",
+        lambda prompt, *, context=None: "Ответ по шлагбауму из базы ЖК",  # type: ignore[return-value]
+    )
+
+    reply = build_local_assistant_reply(
+        "Как оформить пропуск на шлагбаум?",
+        places_hint="- Школа №1, адрес: ул. Центральная, 10",
+    )
+
+    assert "шлагбаум" in reply.lower()
+    assert "школа" not in reply.lower()
+
+
 
 
 def test_detects_masked_profanity_with_latin_and_digits() -> None:


### PR DESCRIPTION
### Motivation
- Обнаружена проблема: при одновременном наличии данных из домовой базы знаний и подсказки из инфраструктурной БД (`places_hint`) бот иногда отдавал нерелевантный ответ (например, про школы вместо шлагбаума).
- Это снижало точность ответов на «домовые» вопросы (шлагбаум, УК, аварийка) и требовало минимального исправления порядка приоритетов источников.

### Description
- В `build_local_assistant_reply` изменён порядок приоритетов: теперь сначала проверяется `faq_hint`, затем `resident_kb` через `build_resident_answer`, затем `places_hint`, затем `rag_hint`, и только потом правила и fallback (`app/services/ai_module.py`).
- Добавлен регрессионный тест `test_local_assistant_reply_prioritizes_resident_kb_over_places` в `tests/test_ai_module.py`, который проверяет, что при наличии ответа из `resident_kb` подсказка из `places_hint` не переопределяет результат.
- Небольшие комментарии в коде для пояснения rationale приоритета источников.

### Testing
- Запущена группа тестов: `BOT_TOKEN=1:AA FORUM_CHAT_ID=1 ADMIN_LOG_CHAT_ID=1 pytest -q tests/test_ai_module.py -k "local_assistant_reply_uses_places_hint or prioritizes_resident_kb_over_places or assistant_reply_uses_local_fallback"`.
- Результат выполнения тестов: `3 passed, 30 deselected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2addaafb083268bedc99272a886cd)