### PR TITLE
Refactor AI timeouts and add feature flags for AI services

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -871,6 +871,9 @@ async def ai_command(message: Message) -> None:
         return
     if message.from_user is None or message.from_user.is_bot:
         return
+    if not settings.ai_feature_assistant:
+        await message.reply("AI-ассистент временно отключён.")
+        return
     prompt = _extract_ai_prompt(message)
     if not prompt:
         await message.reply("Напишите вопрос после команды: /ai <ваш вопрос>")
@@ -944,6 +947,12 @@ async def mention_help(message: Message, bot: Bot) -> None:
     message_id = getattr(message, "message_id", None)
     if message_id is not None:
         _mark_message_processed(message_id)
+
+    # Если AI-ассистент отключён — отвечаем шуткой
+    if not settings.ai_feature_assistant:
+        await message.reply(_next_mention_reply())
+        logger.info("OUT: MENTION_REPLY (ai_feature_assistant=off)")
+        return
 
     # Проверяем модерацию перед ответом ассистента (только severity >= 2 блокирует)
     prompt = _extract_ai_prompt(message)

--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 router = Router()
 FLOOD_TRACKER = FloodTracker(limit=10, window_seconds=120)
 
+# Множество message_id, уже прошедших модерацию (предотвращает двойной вызов)
+_MODERATED_MSG_IDS: set[int] = set()
+_MODERATED_MSG_IDS_MAX = 500
+
 # Вариативные мягкие предупреждения (L1)
 _SOFT_WARNINGS = (
     "давайте мягче 🙂",
@@ -146,6 +150,17 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
         return False
     if message.from_user is None or message.text is None:
         return False
+
+    # Предотвращаем двойную модерацию одного сообщения (mention_help + moderate_message)
+    msg_id = message.message_id
+    if msg_id in _MODERATED_MSG_IDS:
+        return False
+    if len(_MODERATED_MSG_IDS) > _MODERATED_MSG_IDS_MAX:
+        to_remove = sorted(_MODERATED_MSG_IDS)[:_MODERATED_MSG_IDS_MAX // 2]
+        for mid in to_remove:
+            _MODERATED_MSG_IDS.discard(mid)
+    _MODERATED_MSG_IDS.add(msg_id)
+
     if await is_admin(bot, settings.forum_chat_id, message.from_user.id):
         return False
 
@@ -163,12 +178,17 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
     # Загружаем контекст разговора из того же топика
     topic_context = await _get_topic_context(chat_id, message.message_thread_id)
 
-    ai_client = get_ai_client()
     # Добавляем текущее сообщение с user_id для полного контекста
     current_msg = f"[user_{user_id}]: {text}"
-    decision = await ai_client.moderate(
-        current_msg, chat_id=chat_id, context=topic_context,
-    )
+
+    if settings.ai_feature_moderation:
+        ai_client = get_ai_client()
+        decision = await ai_client.moderate(
+            current_msg, chat_id=chat_id, context=topic_context,
+        )
+    else:
+        from app.services.ai_module import local_moderation
+        decision = local_moderation(current_msg)
     severity = decision.severity
     violation_type = getattr(decision, "violation_type", None)
     confidence = getattr(decision, "confidence", None)

--- a/app/main.py
+++ b/app/main.py
@@ -259,6 +259,9 @@ async def apply_v11_stats_reset(session: AsyncSession) -> None:
 
 
 async def send_daily_summary(bot: Bot) -> None:
+    if not settings.ai_feature_daily_summary:
+        logger.info("Ежедневная сводка пропущена: ai_feature_daily_summary=false.")
+        return
     target_chat_id = settings.forum_chat_id
     target_thread_id = settings.ai_summary_topic_id
     if target_thread_id is None:

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -25,11 +25,13 @@ from app.utils.time import now_tz
 
 logger = logging.getLogger(__name__)
 
-_MODERATION_SOFT_TIMEOUT_SECONDS = 8
-_ASSISTANT_SOFT_TIMEOUT_SECONDS = 12
-_QUIZ_SOFT_TIMEOUT_SECONDS = 12
-_SUMMARY_SOFT_TIMEOUT_SECONDS = 12
-_RAG_CATEGORIZE_SOFT_TIMEOUT_SECONDS = 10
+# Soft timeout = настроенный ai_timeout_seconds + запас на сеть (2 сек)
+_SOFT_TIMEOUT_BASE = settings.ai_timeout_seconds + 2
+_MODERATION_SOFT_TIMEOUT_SECONDS = _SOFT_TIMEOUT_BASE
+_ASSISTANT_SOFT_TIMEOUT_SECONDS = _SOFT_TIMEOUT_BASE
+_QUIZ_SOFT_TIMEOUT_SECONDS = _SOFT_TIMEOUT_BASE
+_SUMMARY_SOFT_TIMEOUT_SECONDS = _SOFT_TIMEOUT_BASE
+_RAG_CATEGORIZE_SOFT_TIMEOUT_SECONDS = _SOFT_TIMEOUT_BASE
 
 # ---------------------------------------------------------------------------
 # Кэш ответов ассистента (in-memory, TTL 24ч)
@@ -265,32 +267,6 @@ _CONVERSATION_SUMMARY_PROMPT = (
     "Результат — краткое резюме разговора, до 500 символов."
 )
 
-_USER_FALLBACK = ""
-
-_ALLOWED_ASSISTANT_TOPICS = (
-    "жк",
-    "двор",
-    "подъезд",
-    "парков",
-    "шлагбаум",
-    "инфраструктур",
-    "ремонт",
-    "сосед",
-    "быт",
-    "коммун",
-    "дом",
-    "квартира",
-    "правил",
-    "ук",
-    "управля",
-    "шум",
-    "сосед",
-    "парковк",
-    "лифт",
-    "мусор",
-    "охран",
-    "чат",
-)
 _FORBIDDEN_ASSISTANT_TOPICS = (
     "полит",
     "религи",
@@ -655,6 +631,7 @@ class OpenRouterProvider:
         global _LAST_ERROR, _LAST_ERROR_AT
         _LAST_ERROR = str(error)
         _LAST_ERROR_AT = datetime.utcnow()
+        logger.warning("AI provider error: %s", error)
 
     async def moderate(self, text: str, *, chat_id: int, context: list[str] | None = None) -> ModerationDecision:
         try:
@@ -1588,8 +1565,8 @@ async def build_dialog_summary_for_prompt(chat_id: int, user_id: int, *, limit: 
 _AI_CLIENT: AiModuleClient | None = None
 _AI_RUNTIME_ENABLED: bool = True
 _ADMIN_ALERT_NOTIFIER: Callable[[str], Awaitable[None]] | None = None
-_LAST_ERROR: str | None = "stub_mode"
-_LAST_ERROR_AT: datetime | None = datetime.utcnow()
+_LAST_ERROR: str | None = None
+_LAST_ERROR_AT: datetime | None = None
 
 
 async def _can_use_remote_ai(chat_id: int) -> tuple[bool, str | None]:


### PR DESCRIPTION
## Summary
This PR refactors AI module timeout configuration to be dynamic based on settings, adds feature flags to control AI services independently, implements deduplication for moderation checks, and improves error logging.

## Key Changes

- **Dynamic AI Timeouts**: Replaced hardcoded timeout values with a configurable base timeout (`settings.ai_timeout_seconds + 2 seconds network buffer`) applied uniformly across all AI operations (moderation, assistant, quiz, summary, RAG categorization)

- **Feature Flags for AI Services**: Added three new feature flags to independently control AI functionality:
  - `ai_feature_moderation`: Toggle AI-based content moderation (falls back to local moderation when disabled)
  - `ai_feature_assistant`: Toggle AI assistant responses (returns joke replies when disabled)
  - `ai_feature_daily_summary`: Toggle daily summary generation

- **Moderation Deduplication**: Implemented `_MODERATED_MSG_IDS` set to prevent duplicate moderation checks on the same message (handles both `mention_help` and `moderate_message` handlers), with automatic cleanup when cache exceeds 500 entries

- **Removed Unused Code**: Deleted `_ALLOWED_ASSISTANT_TOPICS` tuple that was not being used

- **Improved Error Handling**: Added warning-level logging for AI provider errors in `_record_runtime_error()`

- **Fixed Initial State**: Changed `_LAST_ERROR` and `_LAST_ERROR_AT` initialization from stub values to `None` for accurate error tracking

## Implementation Details

- Timeout configuration is now centralized in `_SOFT_TIMEOUT_BASE`, making it easier to adjust all AI operation timeouts globally
- Moderation deduplication uses a simple set-based approach with LRU-style cleanup (removes oldest half when limit exceeded)
- Feature flags allow graceful degradation: moderation falls back to local implementation, assistant returns humorous responses, and summary generation is skipped entirely
- All changes maintain backward compatibility with existing code paths

https://claude.ai/code/session_01SNZW5hD8eacveMdMy7GJqr