### PR TITLE
Add web search capability to AI assistant

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -194,6 +194,7 @@ class Settings(BaseSettings):
     ai_feature_moderation: bool = True
     ai_feature_assistant: bool = True
     ai_feature_quiz: bool = True
+    ai_feature_web_search: bool = True
     ai_feature_daily_summary: bool = True
     ai_summary_hour: int = 21
     ai_summary_minute: int = 0

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -21,6 +21,7 @@ from app.models import Place
 from app.services.ai_usage import add_usage, can_consume_ai, get_usage_stats
 from app.services.faq import get_faq_answer
 from app.services.resident_kb import build_resident_answer, build_resident_context
+from app.services.web_search import format_search_context, search_duckduckgo, should_search_web
 from app.utils.time import now_tz
 
 logger = logging.getLogger(__name__)
@@ -485,7 +486,14 @@ class StubAiProvider:
         places_context = await _get_places_context(safe_prompt)
         rag_text = await _get_rag_context(chat_id, safe_prompt)
         faq_answer = await _get_faq_answer(chat_id, safe_prompt)
-        return build_local_assistant_reply(safe_prompt, context=context, places_hint=places_context, rag_hint=rag_text, faq_hint=faq_answer)
+        web_hint = ""
+        if should_search_web(safe_prompt) and not rag_text and not faq_answer:
+            try:
+                web_results = await search_duckduckgo(safe_prompt)
+                web_hint = format_search_context(web_results)
+            except Exception:
+                pass
+        return build_local_assistant_reply(safe_prompt, context=context, places_hint=places_context, rag_hint=rag_text, faq_hint=faq_answer, web_hint=web_hint)
 
     async def evaluate_quiz_answer(
         self,
@@ -701,11 +709,20 @@ class OpenRouterProvider:
 
         resident_context = build_resident_context(safe_prompt, context=context)
 
+        # Веб-поиск: если вопрос выходит за рамки локальной базы знаний
+        web_context = ""
+        if should_search_web(safe_prompt) and not resident_context and not rag_text and not faq_answer:
+            try:
+                web_results = await search_duckduckgo(safe_prompt)
+                web_context = format_search_context(web_results)
+            except Exception:
+                logger.warning("Веб-поиск при ответе ассистента не удался.")
+
         # Логируем какие контексты были найдены
         logger.info(
-            "AI assistant context: resident_kb=%s rag=%s faq=%s places=%s prompt=%r",
+            "AI assistant context: resident_kb=%s rag=%s faq=%s places=%s web=%s prompt=%r",
             bool(resident_context), bool(rag_text), bool(faq_answer), bool(places_context),
-            safe_prompt[:100],
+            bool(web_context), safe_prompt[:100],
         )
 
         if resident_context:
@@ -719,6 +736,8 @@ class OpenRouterProvider:
                 "\n\nСправочник инфраструктуры ЖК (актуальные данные из БД, используй при ответе):\n"
                 f"{places_context}"
             )
+        if web_context:
+            system_prompt += f"\n\n{web_context}"
 
         # Формируем историю как отдельные user/assistant сообщения
         messages: list[dict[str, str]] = [{"role": "system", "content": system_prompt}]
@@ -1285,6 +1304,7 @@ def build_local_assistant_reply(
     places_hint: str | None = None,
     rag_hint: str | None = None,
     faq_hint: str | None = None,
+    web_hint: str | None = None,
 ) -> str:
     normalized_prompt = _normalize_assistant_prompt(prompt)
     if not normalized_prompt:
@@ -1328,6 +1348,15 @@ def build_local_assistant_reply(
             "Есть данные по этой теме:",
         )
         return f"{random.choice(intros)}\n{rag_hint.strip()[:700]}"
+
+    # Результаты веб-поиска
+    if web_hint and web_hint.strip():
+        intros = (
+            "Вот что нашёл в интернете:",
+            "По результатам поиска:",
+            "Нашёл в сети по вашему запросу:",
+        )
+        return f"{random.choice(intros)}\n{web_hint.strip()[:700]}"
 
     rule_reply = _assistant_rule_reply(normalized_prompt)
     if rule_reply:

--- a/app/services/web_search.py
+++ b/app/services/web_search.py
@@ -1,0 +1,196 @@
+"""Почему: даём боту доступ к интернету для ответов на вопросы вне базы знаний ЖК."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import httpx
+from bs4 import BeautifulSoup
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_TIMEOUT = 8
+_MAX_RESULTS = 3
+_MAX_SNIPPET_LEN = 300
+
+# Паттерны вопросов, которые могут потребовать веб-поиска
+_WEB_SEARCH_TRIGGERS = (
+    "что такое",
+    "кто такой",
+    "кто такая",
+    "как работает",
+    "когда будет",
+    "когда откроется",
+    "когда закроется",
+    "новости",
+    "курс",
+    "погода",
+    "расписание",
+    "маршрут",
+    "адрес",
+    "телефон",
+    "сайт",
+    "ссылка",
+    "найди",
+    "найти",
+    "загугли",
+    "погугли",
+    "поищи",
+    "в интернете",
+    "в сети",
+    "онлайн",
+)
+
+# Темы, которые НЕ стоит искать в интернете (обрабатываются локально)
+_SKIP_WEB_PATTERNS = (
+    "шлагбаум",
+    "пропуск",
+    "правила чата",
+    "правила форума",
+    "монеты",
+    "игр",
+    "блэкджек",
+    "страйк",
+    "мут",
+    "бан",
+)
+
+
+def should_search_web(prompt: str) -> bool:
+    """Определяет, стоит ли искать ответ в интернете."""
+    if not settings.ai_feature_web_search:
+        return False
+
+    lowered = prompt.lower()
+
+    # Пропускаем вопросы о внутренних делах бота/ЖК
+    if any(p in lowered for p in _SKIP_WEB_PATTERNS):
+        return False
+
+    # Ищем триггеры веб-поиска
+    if any(trigger in lowered for trigger in _WEB_SEARCH_TRIGGERS):
+        return True
+
+    # URL в вопросе — пользователь хочет что-то из интернета
+    if re.search(r"https?://", lowered):
+        return True
+
+    return False
+
+
+async def search_duckduckgo(query: str) -> list[dict[str, str]]:
+    """Ищет в DuckDuckGo HTML и возвращает список результатов.
+
+    Каждый результат: {"title": ..., "snippet": ..., "url": ...}
+    """
+    results: list[dict[str, str]] = []
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(_SEARCH_TIMEOUT),
+            follow_redirects=True,
+        ) as client:
+            response = await client.get(
+                "https://html.duckduckgo.com/html/",
+                params={"q": query[:200]},
+                headers={
+                    "User-Agent": (
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/120.0.0.0 Safari/537.36"
+                    ),
+                },
+            )
+            response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        for result_div in soup.select(".result"):
+            if len(results) >= _MAX_RESULTS:
+                break
+
+            title_tag = result_div.select_one(".result__a")
+            snippet_tag = result_div.select_one(".result__snippet")
+            url_tag = result_div.select_one(".result__url")
+
+            if not title_tag:
+                continue
+
+            title = title_tag.get_text(strip=True)
+            snippet = snippet_tag.get_text(strip=True)[:_MAX_SNIPPET_LEN] if snippet_tag else ""
+            url = ""
+            if url_tag:
+                url = url_tag.get_text(strip=True)
+            if not url and title_tag.get("href"):
+                url = str(title_tag["href"])
+
+            if title:
+                results.append({"title": title, "snippet": snippet, "url": url})
+
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.warning("Веб-поиск DuckDuckGo не удался: %s", exc)
+    except Exception:
+        logger.exception("Неожиданная ошибка при веб-поиске.")
+
+    return results
+
+
+async def fetch_page_text(url: str, max_chars: int = 2000) -> str:
+    """Загружает веб-страницу и извлекает основной текст."""
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(_SEARCH_TIMEOUT),
+            follow_redirects=True,
+        ) as client:
+            response = await client.get(
+                url,
+                headers={
+                    "User-Agent": (
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/120.0.0.0 Safari/537.36"
+                    ),
+                },
+            )
+            response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # Удаляем скрипты, стили, навигацию
+        for tag in soup(["script", "style", "nav", "footer", "header", "aside"]):
+            tag.decompose()
+
+        text = soup.get_text(separator=" ", strip=True)
+        # Убираем лишние пробелы
+        text = re.sub(r"\s+", " ", text).strip()
+
+        return text[:max_chars]
+
+    except (httpx.HTTPError, httpx.TimeoutException) as exc:
+        logger.warning("Не удалось загрузить страницу %s: %s", url, exc)
+    except Exception:
+        logger.exception("Ошибка при загрузке страницы %s", url)
+
+    return ""
+
+
+def format_search_context(results: list[dict[str, str]]) -> str:
+    """Форматирует результаты поиска для контекста AI."""
+    if not results:
+        return ""
+
+    lines = ["Результаты поиска в интернете:"]
+    for i, r in enumerate(results, 1):
+        lines.append(f"{i}. {r['title']}")
+        if r.get("snippet"):
+            lines.append(f"   {r['snippet']}")
+        if r.get("url"):
+            lines.append(f"   Источник: {r['url']}")
+    lines.append(
+        "\nИспользуй эти данные для ответа. Укажи источник, если цитируешь. "
+        "Не выдумывай информацию, которой нет в результатах."
+    )
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
Adds web search functionality to the AI assistant, allowing it to fetch and incorporate information from the internet when questions fall outside the local knowledge base.

## Key Changes
- **New `web_search.py` module**: Implements web search functionality with:
  - `should_search_web()`: Determines if a query warrants web search based on trigger patterns and skip rules
  - `search_duckduckgo()`: Performs HTML-based searches on DuckDuckGo and extracts results
  - `fetch_page_text()`: Loads and extracts text content from web pages
  - `format_search_context()`: Formats search results for inclusion in AI prompts

- **Updated `ai_module.py`**: Integrates web search into both local and resident assistant reply flows:
  - Performs web search only when local knowledge base (RAG, FAQ) doesn't have answers
  - Adds web search results to system prompt context for the AI model
  - Includes logging to track when web context is used

- **Updated `config.py`**: Adds `ai_feature_web_search` feature flag to enable/disable web search

## Implementation Details
- Web search is triggered by specific keywords (e.g., "что такое", "новости", "курс", "погода") or URLs in the prompt
- Certain topics (internal bot/building management) are explicitly excluded from web search
- Results are limited to 3 items with 300-character snippets to keep context concise
- 8-second timeout on HTTP requests to prevent hanging
- Graceful error handling with logging; failures don't break the assistant response
- Web search is only performed as a fallback when local knowledge sources are unavailable

https://claude.ai/code/session_01SCDxKxk7bSkaXrb6fdYnwj