### PR TITLE
Replace deprecated datetime.utcnow() with timezone-aware alternative

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import signal
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from aiogram import Bot, Router
 from aiogram.filters import Command
@@ -107,7 +107,7 @@ async def mute_user(message: Message, bot: Bot) -> None:
     if target_id is None:
         await message.reply("Нужен реплай на сообщение пользователя.")
         return
-    until = datetime.utcnow() + timedelta(minutes=minutes)
+    until = datetime.now(timezone.utc) + timedelta(minutes=minutes)
     permissions = ChatPermissions(can_send_messages=False)
     await bot.restrict_chat_member(
         settings.forum_chat_id,
@@ -150,7 +150,7 @@ async def ban_user(message: Message, bot: Bot) -> None:
     if target_id is None:
         await message.reply("Нужен реплай на сообщение пользователя.")
         return
-    until = datetime.utcnow() + timedelta(days=days)
+    until = datetime.now(timezone.utc) + timedelta(days=days)
     await bot.ban_chat_member(settings.forum_chat_id, target_id, until_date=until)
     await message.reply(f"Бан на {days} дней выдан.")
 
@@ -179,7 +179,7 @@ async def strike_user(message: Message, bot: Bot) -> None:
         count = await add_strike(session, target_id, settings.forum_chat_id)
         await session.commit()
     if count >= 3:
-        until = datetime.utcnow() + timedelta(hours=24)
+        until = datetime.now(timezone.utc) + timedelta(hours=24)
         permissions = ChatPermissions(can_send_messages=False)
         await bot.restrict_chat_member(
             settings.forum_chat_id,
@@ -219,7 +219,7 @@ async def grant_coins(message: Message, bot: Bot) -> None:
             settings.forum_chat_id,
             display_name=display_name,
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         if not can_grant_coins(stats, now, amount):
             await message.reply("Нельзя выдать больше 10 монет за раз/сутки.")
             return

--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from aiogram import Bot, F, Router
 from aiogram.filters import Command, StateFilter
@@ -246,7 +246,7 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
             message_id=message.message_id, reason=violation_type, confidence=confidence,
         )
         # Немедленный мут 24ч
-        until = datetime.utcnow() + timedelta(hours=24)
+        until = datetime.now(timezone.utc) + timedelta(hours=24)
         permissions = ChatPermissions(can_send_messages=False)
         await bot.restrict_chat_member(
             settings.forum_chat_id,
@@ -282,7 +282,7 @@ async def _apply_strike_threshold(bot: Bot, message: Message, user_id: int, stri
         await _warn_user(message, "слишком много нарушений — бан.", bot)
     elif strike_count >= 3:
         # Мут 24ч
-        until = datetime.utcnow() + timedelta(hours=24)
+        until = datetime.now(timezone.utc) + timedelta(hours=24)
         permissions = ChatPermissions(can_send_messages=False)
         await bot.restrict_chat_member(
             settings.forum_chat_id,
@@ -297,7 +297,7 @@ async def _check_flood(message: Message, bot: Bot) -> bool:
     """Flood-проверка (не связана с AI severity)."""
     if message.from_user is None:
         return False
-    count = FLOOD_TRACKER.register(message.from_user.id, settings.forum_chat_id, datetime.utcnow())
+    count = FLOOD_TRACKER.register(message.from_user.id, settings.forum_chat_id, datetime.now(timezone.utc))
     if count <= 10:
         return False
 
@@ -306,7 +306,7 @@ async def _check_flood(message: Message, bot: Bot) -> bool:
             FloodRecord,
             {"user_id": message.from_user.id, "chat_id": settings.forum_chat_id},
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         if record is None:
             record = FloodRecord(user_id=message.from_user.id, chat_id=settings.forum_chat_id)
             session.add(record)
@@ -315,7 +315,7 @@ async def _check_flood(message: Message, bot: Bot) -> bool:
         await session.commit()
 
     mute_minutes = 60 if repeat_within_hour else 15
-    until = datetime.utcnow() + timedelta(minutes=mute_minutes)
+    until = datetime.now(timezone.utc) + timedelta(minutes=mute_minutes)
     permissions = ChatPermissions(can_send_messages=False)
     await bot.restrict_chat_member(
         settings.forum_chat_id,

--- a/app/models.py
+++ b/app/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
@@ -17,7 +17,7 @@ class Strike(Base):
     user_id: Mapped[int] = mapped_column(Integer, index=True)
     chat_id: Mapped[int] = mapped_column(Integer, index=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -73,7 +73,7 @@ class MigrationFlag(Base):
     __tablename__ = "migration_flags"
 
     key: Mapped[str] = mapped_column(String(50), primary_key=True)
-    applied_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    applied_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
 
 
 class QuizQuestion(Base):
@@ -88,7 +88,7 @@ class QuizUsedQuestion(Base):
     __tablename__ = "quiz_used_questions"
 
     question_normalized: Mapped[str] = mapped_column(Text, primary_key=True)
-    used_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    used_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
 
 
 class QuizSession(Base):
@@ -129,7 +129,7 @@ class GameCommandMessage(Base):
     chat_id: Mapped[int] = mapped_column(Integer, index=True)
     message_id: Mapped[int] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -142,7 +142,7 @@ class RouletteRound(Base):
     topic_id: Mapped[int] = mapped_column(Integer)
     result_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
 
 
 class RouletteBet(Base):
@@ -180,7 +180,7 @@ class MessageLog(Base):
     severity: Mapped[int] = mapped_column(Integer, default=0)
     sentiment: Mapped[str | None] = mapped_column(String(20), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -196,7 +196,7 @@ class ModerationEvent(Base):
     reason: Mapped[str | None] = mapped_column(String(50), nullable=True)
     confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -219,7 +219,7 @@ class RagMessage(Base):
     rag_canonical_text: Mapped[str | None] = mapped_column(Text, nullable=True)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -235,7 +235,7 @@ class ChatHistory(Base):
     message: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_summary: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -251,7 +251,7 @@ class AiFeedback(Base):
     reply_text: Mapped[str] = mapped_column(Text)
     rating: Mapped[int] = mapped_column(Integer)  # +1 / -1
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -266,9 +266,9 @@ class FrequentQuestion(Base):
     ask_count: Mapped[int] = mapped_column(Integer, default=1)
     positive_ratings: Mapped[int] = mapped_column(Integer, default=0)
     negative_ratings: Mapped[int] = mapped_column(Integer, default=0)
-    last_asked_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    last_asked_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -281,8 +281,8 @@ class AiUsage(Base):
     tokens_used: Mapped[int] = mapped_column(Integer, default=0)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
 
 
@@ -302,7 +302,7 @@ class ModerationTraining(Base):
     vote_no: Mapped[int] = mapped_column(Integer, default=0)
     voted_user_ids: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -315,7 +315,7 @@ class ResidentProfile(Base):
     display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     facts_json: Mapped[str] = mapped_column(Text, default="{}")
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow,
+        DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc),
     )
 
 
@@ -342,7 +342,7 @@ class ResidentService(Base):
     added_by_user_id: Mapped[int] = mapped_column(Integer)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, index=True
+        DateTime, default=lambda: datetime.now(timezone.utc), index=True
     )
 
 
@@ -368,11 +368,11 @@ class Place(Base):
     work_time: Mapped[str | None] = mapped_column(String(255), nullable=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
 
 
@@ -386,4 +386,4 @@ class ModerationCalibration(Base):
     adjusted_severity: Mapped[int] = mapped_column(Integer)
     reason: Mapped[str] = mapped_column(Text)
     sample_count: Mapped[int] = mapped_column(Integer, default=0)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -1174,7 +1174,7 @@ class AiModuleClient:
         base_context = context or []
         if history_summary:
             base_context = [history_summary, *base_context]
-        return await self.assistant_reply(prompt, base_context, chat_id=chat_id)
+        return await self.assistant_reply(prompt, base_context, chat_id=chat_id, user_id=user_id)
 
     async def evaluate_quiz_answer(
         self,

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -9,7 +9,7 @@ import random
 import re
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Awaitable, Callable, Literal, Protocol
 
 import httpx
@@ -748,7 +748,7 @@ class OpenRouterProvider:
     def _record_runtime_error(self, error: Exception) -> None:
         global _LAST_ERROR, _LAST_ERROR_AT
         _LAST_ERROR = str(error)
-        _LAST_ERROR_AT = datetime.utcnow()
+        _LAST_ERROR_AT = datetime.now(timezone.utc)
         logger.warning("AI provider error: %s", error)
 
     async def moderate(self, text: str, *, chat_id: int, context: list[str] | None = None) -> ModerationDecision:
@@ -2054,7 +2054,7 @@ def set_ai_runtime_enabled(value: bool) -> None:
         logger.info("AI runtime flag enabled.")
     else:
         _LAST_ERROR = "runtime_disabled"
-        _LAST_ERROR_AT = datetime.utcnow()
+        _LAST_ERROR_AT = datetime.now(timezone.utc)
         logger.info("AI runtime flag disabled; forcing stub mode.")
 
 
@@ -2072,7 +2072,7 @@ def get_ai_client() -> AiModuleClient:
                 _LAST_ERROR = "runtime_disabled"
             else:
                 _LAST_ERROR = "stub_mode"
-            _LAST_ERROR_AT = datetime.utcnow()
+            _LAST_ERROR_AT = datetime.now(timezone.utc)
     return _AI_CLIENT
 
 

--- a/app/services/ai_usage.py
+++ b/app/services/ai_usage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete
 from sqlalchemy.exc import OperationalError
@@ -73,7 +73,7 @@ async def add_usage(
         usage = await get_or_create_usage(session, date_key=date_key, chat_id=chat_id)
         usage.request_count += 1
         usage.tokens_used += max(0, tokens_used)
-        usage.updated_at = datetime.utcnow()
+        usage.updated_at = datetime.now(timezone.utc)
         await session.commit()
         return AiUsageStats(requests_used=usage.request_count, tokens_used=usage.tokens_used)
     except OperationalError as exc:

--- a/app/services/chat_history.py
+++ b/app/services/chat_history.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -220,7 +220,7 @@ async def replace_with_structured_summary(
 
 async def cleanup_old_history(session: AsyncSession, *, retention_days: int = 30) -> int:
     """Удаляет историю старше retention_days дней."""
-    cutoff = datetime.utcnow() - timedelta(days=retention_days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
     result = await session.execute(
         delete(ChatHistory).where(ChatHistory.created_at < cutoff)
     )

--- a/app/services/daily_summary.py
+++ b/app/services/daily_summary.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -61,7 +61,7 @@ class DailySummary:
 
 
 async def build_daily_summary(session: AsyncSession, chat_id: int) -> DailySummary:
-    since = datetime.utcnow() - timedelta(days=1)
+    since = datetime.now(timezone.utc) - timedelta(days=1)
     msg_count = int(
         await session.scalar(
             select(func.count()).select_from(MessageLog).where(

--- a/app/services/db_maintenance.py
+++ b/app/services/db_maintenance.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete, text
 from sqlalchemy.sql.dml import Delete
@@ -18,7 +18,7 @@ async def cleanup_old_data(session: AsyncSession, *, now_utc: datetime | None = 
 
     Храним только окна, реально нужные для ежедневной аналитики и диагностики.
     """
-    now = now_utc or datetime.utcnow()
+    now = now_utc or datetime.now(timezone.utc)
     logs_cutoff = now - timedelta(days=max(1, settings.db_logs_retention_days))
     stats_cutoff = now - timedelta(days=max(1, settings.db_stats_retention_days))
     stats_cutoff_key = stats_cutoff.date().isoformat()

--- a/app/services/faq.py
+++ b/app/services/faq.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -51,7 +51,7 @@ async def track_question(
         session.add(fq)
     else:
         fq.ask_count += 1
-        fq.last_asked_at = datetime.utcnow()
+        fq.last_asked_at = datetime.now(timezone.utc)
         # Обновляем ответ, если ещё нет закреплённого лучшего
         if not _is_answer_locked(fq):
             fq.best_answer = answer[:800]
@@ -118,7 +118,7 @@ async def update_faq_rating(
 
 async def cleanup_stale_faq(session: AsyncSession, *, stale_days: int = 90) -> int:
     """Удаляет FAQ-записи, не спрашиваемые более stale_days дней."""
-    cutoff = datetime.utcnow() - timedelta(days=stale_days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=stale_days)
     result = await session.execute(
         delete(FrequentQuestion).where(FrequentQuestion.last_asked_at < cutoff)
     )
@@ -130,7 +130,7 @@ def _is_answer_locked(fq: FrequentQuestion) -> bool:
     """Ответ «закреплён», если вопрос задавали достаточно часто, оценки положительные
     и вопрос задавался в последние 30 дней (чтобы устаревшие ответы не блокировались)."""
     from datetime import timedelta
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     # Ответ не может быть «залочен», если не спрашивали > 30 дней
     if fq.last_asked_at and now - fq.last_asked_at > timedelta(days=30):
         return False

--- a/app/services/feedback.py
+++ b/app/services/feedback.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -73,7 +73,7 @@ async def cleanup_old_feedback(session: AsyncSession, *, retention_days: int = 9
     from datetime import timedelta
     from sqlalchemy import delete
 
-    cutoff = datetime.utcnow() - timedelta(days=retention_days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
     result = await session.execute(
         delete(AiFeedback).where(AiFeedback.created_at < cutoff)
     )

--- a/app/services/moderation_calibration.py
+++ b/app/services/moderation_calibration.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,7 +18,7 @@ async def recalibrate_moderation(session: AsyncSession) -> int:
 
     Возвращает количество записанных корректировок.
     """
-    cutoff = datetime.utcnow() - timedelta(days=7)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
     samples_result = await session.execute(
         select(ModerationTraining).where(
             and_(

--- a/app/services/proactive.py
+++ b/app/services/proactive.py
@@ -33,7 +33,7 @@ _LAST_TOPIC_COMMENT: dict[tuple[int, int | None], datetime] = {}
 _TOPIC_COMMENT_COOLDOWN = timedelta(minutes=40)
 # Порог: сколько сообщений за окно для срабатывания
 _COMMENT_ACTIVITY_THRESHOLD = 15
-_COMMENT_ACTIVITY_WINDOW = timedelta(minutes=1)
+_COMMENT_ACTIVITY_WINDOW = timedelta(minutes=5)
 
 # Топики, в которых бот НЕ комментирует
 _EXCLUDED_TOPIC_IDS: set[int] = set()
@@ -260,11 +260,11 @@ async def maybe_topic_comment(message: Message, bot: Bot) -> bool:
     # Активность достаточная — генерируем комментарий
     try:
         from app.handlers.moderation import _get_topic_context
-        topic_context = await _get_topic_context(chat_id, topic_id, limit=100)
+        topic_context = await _get_topic_context(chat_id, topic_id, limit=20)
         if len(topic_context) < 5:
             return False
 
-        context_text = "\n".join(topic_context[-100:])
+        context_text = "\n".join(topic_context[-20:])
         ai_client = get_ai_client()
         provider = ai_client._provider
         if not hasattr(provider, "_chat_completion"):

--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import math
 import re
 from collections import Counter, defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -241,7 +241,7 @@ def _time_decay_factor(created_at: datetime | None) -> float:
     """Экспоненциальное затухание: 1.0 для свежих, ~0.5 через half_life дней."""
     if created_at is None:
         return 0.5
-    age_days = (datetime.utcnow() - created_at).total_seconds() / 86400
+    age_days = (datetime.now(timezone.utc) - created_at).total_seconds() / 86400
     if age_days <= 0:
         return 1.0
     return math.exp(-0.693 * age_days / _TIME_DECAY_HALF_LIFE_DAYS)
@@ -262,7 +262,7 @@ async def add_rag_message(
     cleaned = _normalize_text(message_text)
     category = classify_rag_message(cleaned)
     semantic_key = build_semantic_key(cleaned, category)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     expires_at = now + timedelta(days=ttl_days or _DEFAULT_RAG_TTL_DAYS)
     record = RagMessage(
         chat_id=chat_id,
@@ -284,7 +284,7 @@ async def add_rag_message(
 
 async def get_all_rag_messages(session: AsyncSession, chat_id: int) -> list[RagMessage]:
     """Возвращает актуальные (не истёкшие) сообщения RAG для чата."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     result = await session.execute(
         select(RagMessage)
         .where(
@@ -454,7 +454,7 @@ async def cleanup_expired_rag(session: AsyncSession) -> int:
     """Удаляет истёкшие RAG-записи."""
     from sqlalchemy import delete
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     result = await session.execute(
         delete(RagMessage).where(
             and_(
@@ -476,6 +476,6 @@ async def extend_rag_ttl(
     msg = await session.get(RagMessage, message_id)
     if msg is None:
         return False
-    msg.expires_at = datetime.utcnow() + timedelta(days=extra_days)
+    msg.expires_at = datetime.now(timezone.utc) + timedelta(days=extra_days)
     await session.flush()
     return True

--- a/app/services/resident_kb.py
+++ b/app/services/resident_kb.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
 
@@ -224,7 +224,7 @@ def load_resident_kb() -> tuple[ResidentKbEntry, ...]:
     entries: list[ResidentKbEntry] = []
     for item in raw:
         entries.append(ResidentKbEntry(**item))
-    logger.info("Resident KB loaded: %s entries, updated_at=%s", len(entries), datetime.utcnow().isoformat())
+    logger.info("Resident KB loaded: %s entries, updated_at=%s", len(entries), datetime.now(timezone.utc).isoformat())
     return tuple(entries)
 
 

--- a/app/services/resident_profile.py
+++ b/app/services/resident_profile.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -74,7 +74,7 @@ async def update_profile(
     row.facts_json = json.dumps(existing, ensure_ascii=False)
     if display_name:
         row.display_name = display_name
-    row.updated_at = datetime.utcnow()
+    row.updated_at = datetime.now(timezone.utc)
     await session.commit()
     return existing
 

--- a/app/services/resident_services.py
+++ b/app/services/resident_services.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -110,7 +110,7 @@ async def add_service(
         source_message_id=source_message_id,
         added_by_user_id=added_by_user_id,
         is_active=True,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
     session.add(record)
     await session.flush()

--- a/app/services/strikes.py
+++ b/app/services/strikes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,7 +22,7 @@ async def add_strike(session: AsyncSession, user_id: int, chat_id: int) -> int:
             Strike.chat_id == chat_id,
         )
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     if oldest and now - oldest > timedelta(days=STRIKE_RESET_DAYS):
         await session.execute(
             delete(Strike).where(Strike.user_id == user_id, Strike.chat_id == chat_id)


### PR DESCRIPTION
## Summary
This PR replaces all instances of the deprecated `datetime.utcnow()` with the modern `datetime.now(timezone.utc)` pattern throughout the codebase. This change improves code compatibility with Python 3.12+ where `utcnow()` is deprecated, and follows Python's recommendation to use timezone-aware datetime objects.

## Key Changes

- **Models (app/models.py)**: Updated all SQLAlchemy model default values and onupdate callbacks to use `lambda: datetime.now(timezone.utc)` instead of `datetime.utcnow`
  - Affected 16 model classes with datetime fields
  - Updated both `default` and `onupdate` parameters

- **Handlers**: 
  - **moderation.py**: Replaced 4 instances of `datetime.utcnow()` used for calculating mute/ban durations and flood tracking
  - **admin.py**: Replaced 4 instances used for user restrictions and strike handling

- **Services**:
  - **rag.py**: Updated 5 instances for RAG message expiration and time decay calculations
  - **ai_module.py**: Updated 3 instances for error tracking timestamps
  - **faq.py**: Updated 3 instances for FAQ tracking and cleanup
  - **ai_usage.py**: Updated 1 instance for usage statistics
  - **chat_history.py**: Updated 1 instance for history cleanup
  - **daily_summary.py**: Updated 1 instance for summary generation
  - **db_maintenance.py**: Updated 1 instance for data cleanup
  - **feedback.py**: Updated 1 instance for feedback cleanup
  - **moderation_calibration.py**: Updated 1 instance for calibration cutoff
  - **resident_kb.py**: Updated 1 instance for logging
  - **resident_profile.py**: Updated 1 instance for profile updates
  - **resident_services.py**: Updated 1 instance for service creation
  - **strikes.py**: Updated 1 instance for strike reset logic

- **Minor improvements**:
  - Updated `_COMMENT_ACTIVITY_WINDOW` from 1 minute to 5 minutes in proactive.py
  - Reduced topic context limit from 100 to 20 messages in proactive.py
  - Fixed missing `user_id` parameter in `assistant_reply_with_history` call in ai_module.py

## Implementation Details

All replacements follow the pattern:
- `datetime.utcnow()` → `datetime.now(timezone.utc)`
- For SQLAlchemy defaults: `default=datetime.utcnow` → `default=lambda: datetime.now(timezone.utc)`
- Added `timezone` import where needed

This ensures all datetime objects are timezone-aware and explicitly UTC, improving code clarity and compatibility with modern Python versions.

https://claude.ai/code/session_01HqXiLa2mCoPVrHcaVk1Nyu