### PR TITLE
Implement admin RAG records with permanent storage and deduplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /data/
+app/data/
 .env
 __pycache__/

--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -15,7 +15,6 @@ from aiogram.types import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     Message,
-    MessageReactionUpdated,
 )
 
 from sqlalchemy import and_, select

--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,7 @@ from app.handlers import (
     roulette,
     text_publish,
 )
-from app.models import MigrationFlag, RagMessage, UserStat
+from app.models import MigrationFlag, UserStat
 from app.services.topic_stats import bump_topic_stat
 from app.services.games import (
     clear_game_command_messages,
@@ -281,21 +281,6 @@ async def apply_v11_stats_reset(session: AsyncSession) -> None:
     await session.commit()
     logger.info("v1.1: статистика сброшена")
 
-
-async def apply_rag_cleanup_v2(session: AsyncSession) -> None:
-    """Единоразовая очистка старых RAG-записей после перехода на каноническую KB."""
-    flag = await session.get(MigrationFlag, "rag_cleanup_v2_kb_migration")
-    if flag:
-        return
-
-    from sqlalchemy import delete, func, select
-    count_result = await session.execute(select(func.count()).select_from(RagMessage))
-    total = count_result.scalar() or 0
-    if total > 0:
-        await session.execute(delete(RagMessage))
-        logger.info("RAG cleanup v2: удалено %s старых записей (переход на KB).", total)
-    session.add(MigrationFlag(key="rag_cleanup_v2_kb_migration"))
-    await session.commit()
 
 
 async def send_daily_summary(bot: Bot) -> None:
@@ -625,8 +610,6 @@ async def on_startup(bot: Bot) -> None:
     # Применяем миграции
     async for session in get_session():
         await apply_v11_stats_reset(session)
-    async for session in get_session():
-        await apply_rag_cleanup_v2(session)
     await heartbeat_job(bot)
     if telegram_available:
         # Публичные команды для всех пользователей

--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -258,12 +258,33 @@ async def add_rag_message(
     ttl_days: int | None = None,
     is_admin: bool = False,
 ) -> RagMessage:
-    """Добавляет сообщение в RAG-базу и сразу классифицирует его."""
+    """Добавляет сообщение в RAG-базу и сразу классифицирует его.
+
+    Админские записи (is_admin=True) хранятся бессрочно (expires_at=None).
+    При добавлении новой админской записи старые с тем же semantic_key удаляются
+    как противоречащие (более новая запись имеет приоритет).
+    """
+    from sqlalchemy import delete as sa_delete
+
     cleaned = _normalize_text(message_text)
     category = classify_rag_message(cleaned)
     semantic_key = build_semantic_key(cleaned, category)
     now = datetime.now(timezone.utc)
-    expires_at = now + timedelta(days=ttl_days or _DEFAULT_RAG_TTL_DAYS)
+
+    # Админские записи хранятся бессрочно; обычные — с TTL
+    if is_admin:
+        expires_at = None
+        # Удаляем старые записи с тем же смысловым ключом — новая запись их отменяет
+        await session.execute(
+            sa_delete(RagMessage).where(
+                RagMessage.chat_id == chat_id,
+                RagMessage.rag_semantic_key == semantic_key,
+                RagMessage.created_at < now,
+            )
+        )
+    else:
+        expires_at = now + timedelta(days=ttl_days or _DEFAULT_RAG_TTL_DAYS)
+
     record = RagMessage(
         chat_id=chat_id,
         message_text=cleaned,
@@ -381,8 +402,8 @@ async def systematize_rag(session: AsyncSession, chat_id: int) -> int:
         msg.message_text = normalized
         msg.rag_category = category
         msg.rag_semantic_key = semantic_key
-        # Проставляем TTL для старых записей без expires_at
-        if msg.expires_at is None and msg.created_at:
+        # Проставляем TTL для старых НЕ-админских записей без expires_at
+        if msg.expires_at is None and msg.created_at and not msg.is_admin:
             msg.expires_at = msg.created_at + timedelta(days=_DEFAULT_RAG_TTL_DAYS)
 
     grouped = _group_by_semantics(messages)


### PR DESCRIPTION
## Summary
This PR introduces support for permanent admin RAG records with automatic deduplication. Admin records are now stored indefinitely without TTL, and when a new admin record is added with the same semantic key, older conflicting records are automatically removed.

## Key Changes
- **Admin RAG records**: Added `is_admin` parameter handling in `add_rag_message()` to store admin records without expiration (`expires_at=None`)
- **Deduplication logic**: When adding an admin record, automatically delete older records with the same `semantic_key` to prevent contradictions
- **TTL handling**: Updated `systematize_rag()` to only apply default TTL to non-admin records, preserving permanent storage for admin entries
- **Migration cleanup**: Removed obsolete `apply_rag_cleanup_v2()` migration function that cleared all RAG records during KB migration
- **Import cleanup**: Removed unused `RagMessage` import from `app/main.py` and unused `MessageReactionUpdated` from moderation handlers
- **Gitignore update**: Added `app/data/` directory to ignore list

## Implementation Details
- Admin records are identified by `is_admin=True` flag and stored with `expires_at=None`
- Deduplication uses `semantic_key` and `chat_id` to identify conflicting records, keeping only the newest one
- The `systematize_rag()` function now checks `is_admin` flag before applying TTL to legacy records
- Uses SQLAlchemy's `delete()` with conditional filtering for efficient deduplication

https://claude.ai/code/session_01MBbgBRXMneLzBj4FgvWvzt