### PR TITLE
Resident services: normalize metadata, add unique constraint, dedupe and race-safe add

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -12,6 +12,7 @@ from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.types import ChatPermissions, Message
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 
 from app.config import settings
 from app.db import get_session
@@ -33,7 +34,11 @@ from app.services.ai_module import (
 from app.handlers.moderation import is_training_mode, set_training_mode
 from app.services.ai_usage import next_reset_delta
 from app.services.rag import add_rag_message, build_canonical_text, get_rag_count, systematize_rag
-from app.services.resident_services import add_service, get_services_count
+from app.services.resident_services import (
+    add_service,
+    get_service_by_source_message_id,
+    get_services_count,
+)
 from app.services.admin_stats_reset import reset_runtime_statistics
 from app.utils.profanity import load_profanity, load_profanity_exceptions
 
@@ -443,6 +448,20 @@ async def usluga_command(message: Message, bot: Bot) -> None:
         await message.reply("Сообщение слишком короткое для добавления в каталог услуг.")
         return
 
+    async for session in get_session():
+        existing = await get_service_by_source_message_id(
+            session,
+            chat_id=settings.forum_chat_id,
+            source_message_id=target_msg.message_id,
+        )
+        if existing is not None:
+            await message.reply(
+                "Эта услуга уже есть в каталоге.\n"
+                f"Категория: {existing.category}\n"
+                f"Описание: {existing.description[:200]}"
+            )
+            return
+
     admin_id = int(_admin_id(message))
     provider_user_id = target_msg.from_user.id if target_msg.from_user else 0
     provider_name = target_msg.from_user.full_name if target_msg.from_user else None
@@ -483,19 +502,35 @@ async def usluga_command(message: Message, bot: Bot) -> None:
         logger.warning("AI-категоризация услуги не удалась, используем локальный fallback.")
 
     async for session in get_session():
-        record = await add_service(
-            session,
-            chat_id=settings.forum_chat_id,
-            message_text=text.strip(),
-            provider_user_id=provider_user_id,
-            provider_name=provider_name,
-            source_message_id=target_msg.message_id,
-            added_by_user_id=admin_id,
-            ai_description=ai_description,
-            ai_keywords=ai_keywords,
-            ai_category=ai_category,
-        )
-        await session.commit()
+        try:
+            record = await add_service(
+                session,
+                chat_id=settings.forum_chat_id,
+                message_text=text.strip(),
+                provider_user_id=provider_user_id,
+                provider_name=provider_name,
+                source_message_id=target_msg.message_id,
+                added_by_user_id=admin_id,
+                ai_description=ai_description,
+                ai_keywords=ai_keywords,
+                ai_category=ai_category,
+            )
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            existing = await get_service_by_source_message_id(
+                session,
+                chat_id=settings.forum_chat_id,
+                source_message_id=target_msg.message_id,
+            )
+            if existing is not None:
+                await message.reply(
+                    "Эта услуга уже была добавлена параллельно другим админом.\n"
+                    f"Категория: {existing.category}\n"
+                    f"Описание: {existing.description[:200]}"
+                )
+                return
+            raise
         count = await get_services_count(session, settings.forum_chat_id)
 
     cat_label = record.category

--- a/app/main.py
+++ b/app/main.py
@@ -263,6 +263,39 @@ async def init_db(async_engine: AsyncEngine) -> None:
                     )
                 )
 
+            if inspector.has_table("resident_services"):
+                duplicate_rows = sync_conn.execute(
+                    text(
+                        "SELECT chat_id, source_message_id, MAX(id) AS keep_id "
+                        "FROM resident_services "
+                        "WHERE source_message_id IS NOT NULL "
+                        "GROUP BY chat_id, source_message_id "
+                        "HAVING COUNT(*) > 1"
+                    )
+                ).fetchall()
+                for duplicate in duplicate_rows:
+                    sync_conn.execute(
+                        text(
+                            "UPDATE resident_services "
+                            "SET source_message_id = NULL "
+                            "WHERE chat_id = :chat_id "
+                            "AND source_message_id = :source_message_id "
+                            "AND id <> :keep_id"
+                        ),
+                        {
+                            "chat_id": duplicate.chat_id,
+                            "source_message_id": duplicate.source_message_id,
+                            "keep_id": duplicate.keep_id,
+                        },
+                    )
+                sync_conn.execute(
+                    text(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS "
+                        "uq_resident_services_chat_source_message_idx "
+                        "ON resident_services(chat_id, source_message_id)"
+                    )
+                )
+
             # Миграция resident_profiles (создаётся через create_all,
             # но проверяем на всякий случай)
 

--- a/app/models.py
+++ b/app/models.py
@@ -323,6 +323,13 @@ class ResidentProfile(Base):
 class ResidentService(Base):
     """Почему: каталог услуг от жителей ЖК — бот подсказывает соседей-специалистов."""
     __tablename__ = "resident_services"
+    __table_args__ = (
+        UniqueConstraint(
+            "chat_id",
+            "source_message_id",
+            name="uq_resident_services_chat_source_message",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     chat_id: Mapped[int] = mapped_column(Integer, index=True)

--- a/app/services/resident_services.py
+++ b/app/services/resident_services.py
@@ -55,21 +55,44 @@ _SERVICE_CATEGORIES: list[tuple[str, tuple[str, ...]]] = [
                     "украшен", "букет", "цветы", "цветов", "флорист")),
 ]
 
+_KNOWN_CATEGORIES = {category.lower() for category, _markers in _SERVICE_CATEGORIES}
+
+
+def _normalize_service_text(text: str) -> str:
+    """Нормализует текст услуги для локального поиска и классификации."""
+    return text.lower().replace("ё", "е")
+
+
+def _extract_service_tokens(text: str) -> list[str]:
+    """Достаёт токены из описания услуги."""
+    return re.findall(r"[а-яёa-z0-9]+", _normalize_service_text(text))
+
 
 def classify_service(text: str) -> str:
-    """Определяет категорию услуги по тексту."""
-    lowered = text.lower().replace("ё", "е")
-    tokens = set(re.findall(r"[а-яёa-z0-9]+", lowered))
+    """Определяет категорию услуги по тексту через ранжирование маркеров."""
+    lowered = _normalize_service_text(text)
+    tokens = set(_extract_service_tokens(text))
+    best_category = "общее"
+    best_score = 0
+
     for category, markers in _SERVICE_CATEGORIES:
-        if any(any(token.startswith(m) for token in tokens) for m in markers):
-            return category
-    return "общее"
+        score = 0
+        for marker in markers:
+            if any(token.startswith(marker) for token in tokens):
+                score += 3
+                continue
+            if marker in lowered:
+                score += 1
+        if score > best_score:
+            best_category = category
+            best_score = score
+
+    return best_category
 
 
 def extract_keywords(text: str) -> str:
     """Извлекает ключевые слова из текста услуги для поиска."""
-    lowered = text.lower().replace("ё", "е")
-    tokens = re.findall(r"[а-яёa-z0-9]+", lowered)
+    tokens = _extract_service_tokens(text)
     meaningful = [t for t in tokens if len(t) >= 3 and t not in _STOP_WORDS]
     # Убираем дубли, сохраняя порядок
     seen: set[str] = set()
@@ -79,6 +102,41 @@ def extract_keywords(text: str) -> str:
             seen.add(t)
             unique.append(t)
     return ",".join(unique[:30])
+
+
+def normalize_service_category(category: str | None, fallback_text: str) -> str:
+    """Нормализует категорию от AI или локального классификатора."""
+    if category:
+        normalized = category.strip().lower().replace("ё", "е")
+        if normalized in _KNOWN_CATEGORIES:
+            return normalized
+    return classify_service(fallback_text)
+
+
+def normalize_service_keywords(keywords: str | None, fallback_text: str) -> str:
+    """Очищает AI-ключевые слова или строит их локально."""
+    if not keywords:
+        return extract_keywords(fallback_text)
+
+    tokens = re.findall(r"[а-яёa-z0-9]+", keywords.lower().replace("ё", "е"))
+    meaningful = [token for token in tokens if len(token) >= 3 and token not in _STOP_WORDS]
+    if not meaningful:
+        return extract_keywords(fallback_text)
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for token in meaningful:
+        if token in seen:
+            continue
+        seen.add(token)
+        unique.append(token)
+    return ",".join(unique[:30])
+
+
+def normalize_service_description(description: str | None, fallback_text: str) -> str:
+    """Очищает описание услуги и ограничивает его размер."""
+    candidate = (description or "").strip() or fallback_text.strip()
+    return candidate[:500]
 
 
 async def add_service(
@@ -95,13 +153,33 @@ async def add_service(
     ai_category: str | None = None,
 ) -> ResidentService:
     """Добавляет услугу в каталог."""
-    description = ai_description or message_text[:500]
-    keywords = ai_keywords or extract_keywords(message_text)
-    category = ai_category or classify_service(message_text)
+    description = normalize_service_description(ai_description, message_text)
+    keywords = normalize_service_keywords(ai_keywords, message_text)
+    category = normalize_service_category(ai_category, message_text)
+    normalized_message_text = message_text.strip()[:2000]
+
+    if source_message_id is not None:
+        existing = await get_service_by_source_message_id(
+            session,
+            chat_id=chat_id,
+            source_message_id=source_message_id,
+            is_active=None,
+        )
+        if existing is not None:
+            existing.message_text = normalized_message_text
+            existing.description = description.strip()[:500]
+            existing.keywords = keywords[:1000]
+            existing.category = category
+            existing.provider_user_id = provider_user_id
+            existing.provider_name = provider_name
+            existing.added_by_user_id = added_by_user_id
+            existing.is_active = True
+            await session.flush()
+            return existing
 
     record = ResidentService(
         chat_id=chat_id,
-        message_text=message_text.strip()[:2000],
+        message_text=normalized_message_text,
         description=description.strip()[:500],
         keywords=keywords[:1000],
         category=category,
@@ -210,6 +288,29 @@ def format_services_for_user(services: list[ResidentService]) -> str:
             line += f" — {svc.provider_name}"
         parts.append(line)
     return "\n".join(parts)
+
+
+async def get_service_by_source_message_id(
+    session: AsyncSession,
+    *,
+    chat_id: int,
+    source_message_id: int,
+    is_active: bool | None = True,
+) -> ResidentService | None:
+    """Возвращает услугу по исходному сообщению, при необходимости фильтруя по активности."""
+    conditions = [
+        ResidentService.chat_id == chat_id,
+        ResidentService.source_message_id == source_message_id,
+    ]
+    if is_active is not None:
+        conditions.append(ResidentService.is_active.is_(is_active))
+
+    result = await session.execute(
+        select(ResidentService)
+        .where(and_(*conditions))
+        .order_by(ResidentService.is_active.desc(), ResidentService.created_at.desc())
+    )
+    return result.scalar_one_or_none()
 
 
 async def get_services_count(session: AsyncSession, chat_id: int) -> int:

--- a/tests/test_resident_services.py
+++ b/tests/test_resident_services.py
@@ -1,0 +1,161 @@
+import asyncio
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.handlers.admin import usluga_command
+from app.models import ResidentService
+from app.services.resident_services import add_service, deactivate_service
+
+
+class _DummyUser:
+    def __init__(self, user_id: int, full_name: str = "Житель") -> None:
+        self.id = user_id
+        self.full_name = full_name
+
+
+class _DummyReplyMessage:
+    def __init__(self, text: str, message_id: int = 77) -> None:
+        self.text = text
+        self.caption = None
+        self.message_id = message_id
+        self.from_user = _DummyUser(200, "Иван Житель")
+
+
+class _DummyMessage:
+    def __init__(self) -> None:
+        self.from_user = _DummyUser(100, "Админ")
+        self.reply_to_message = _DummyReplyMessage("Делаю маникюр и педикюр на дому")
+        self.message_thread_id = 3240
+        self.replies: list[str] = []
+
+    async def reply(self, text: str) -> None:
+        self.replies.append(text)
+
+
+class _DummyBot:
+    pass
+
+
+async def _run_add_service_with_ai_fallback() -> tuple[str, str, str]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        service = await add_service(
+            session,
+            chat_id=1,
+            message_text="Делаю маникюр и педикюр на дому",
+            provider_user_id=200,
+            provider_name="Иван Житель",
+            source_message_id=77,
+            added_by_user_id=100,
+            ai_description="  ",
+            ai_keywords="Маникюр, маникюр, красота, и, ногти ",
+            ai_category="Несуществующая категория",
+        )
+        await session.commit()
+
+    await engine.dispose()
+    return service.description, service.keywords, service.category
+
+
+async def _run_reactivate_existing_service() -> tuple[int, int, bool, str]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        first = await add_service(
+            session,
+            chat_id=1,
+            message_text="Ремонт стиральных машин",
+            provider_user_id=200,
+            provider_name="Иван Житель",
+            source_message_id=88,
+            added_by_user_id=100,
+        )
+        await session.commit()
+
+        await deactivate_service(session, first.id)
+        await session.commit()
+
+        second = await add_service(
+            session,
+            chat_id=1,
+            message_text="Ремонт стиральных машин и посудомоек",
+            provider_user_id=200,
+            provider_name="Иван Житель",
+            source_message_id=88,
+            added_by_user_id=101,
+            ai_category="ремонт",
+        )
+        await session.commit()
+
+        total = len((await session.execute(ResidentService.__table__.select())).all())
+
+    await engine.dispose()
+    return first.id, total, second.is_active, second.message_text
+
+
+async def _fake_existing_session_gen():
+    class _DummySession:
+        pass
+
+    yield _DummySession()
+
+
+def test_add_service_normalizes_ai_metadata() -> None:
+    description, keywords, category = asyncio.run(_run_add_service_with_ai_fallback())
+
+    assert description == "Делаю маникюр и педикюр на дому"
+    assert keywords == "маникюр,красота,ногти"
+    assert category == "красота"
+
+
+def test_usluga_command_reports_duplicate_service(monkeypatch) -> None:
+    async def _allow_admin(_message, _bot) -> bool:
+        return True
+
+    async def _fake_get_existing(_session, *, chat_id: int, source_message_id: int):
+        assert chat_id == 1
+        assert source_message_id == 77
+        return ResidentService(
+            chat_id=1,
+            message_text="Делаю маникюр и педикюр на дому",
+            description="Маникюр и педикюр на дому",
+            keywords="маникюр,педикюр",
+            category="красота",
+            provider_user_id=200,
+            provider_name="Иван Житель",
+            source_message_id=77,
+            added_by_user_id=100,
+            is_active=True,
+        )
+
+    async def _should_not_add(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("add_service не должен вызываться для дубля")
+
+    monkeypatch.setattr("app.handlers.admin._ensure_admin", _allow_admin)
+    monkeypatch.setattr("app.handlers.admin.get_session", lambda: _fake_existing_session_gen())
+    monkeypatch.setattr("app.handlers.admin.get_service_by_source_message_id", _fake_get_existing)
+    monkeypatch.setattr("app.handlers.admin.add_service", _should_not_add)
+
+    message = _DummyMessage()
+    asyncio.run(usluga_command(message, _DummyBot()))
+
+    assert message.replies == [
+        "Эта услуга уже есть в каталоге.\nКатегория: красота\nОписание: Маникюр и педикюр на дому"
+    ]
+
+
+def test_add_service_reactivates_existing_source_message() -> None:
+    service_id, total, is_active, message_text = asyncio.run(_run_reactivate_existing_service())
+
+    assert service_id == 1
+    assert total == 1
+    assert is_active is True
+    assert message_text == "Ремонт стиральных машин и посудомоек"


### PR DESCRIPTION
### Motivation

- Prevent duplicate catalog entries for the same source message and make AI-supplied metadata more robust and consistent.
- Avoid race conditions when multiple admins add the same service concurrently and ensure DB integrity via a unique constraint.

### Description

- Add a `UNIQUE` constraint on `resident_services(chat_id, source_message_id)` in `models.py` and dedupe existing rows during `init_db` migration by nulling duplicate `source_message_id` values and creating the unique index in `main.py`.
- Normalize and validate AI-provided metadata by introducing `normalize_service_description`, `normalize_service_keywords`, `normalize_service_category`, tokenization helpers, and improving `classify_service`, `extract_keywords`, and `add_service` logic in `services/resident_services.py`.
- Make `add_service` idempotent for entries with `source_message_id` by updating and reactivating an existing record instead of inserting a duplicate, and add `get_service_by_source_message_id` helper query.
- Make admin `/usluga` handler race-safe by pre-checking for existing services, importing and handling `IntegrityError`, rolling back on conflict, and reporting duplicates to the admin in `handlers/admin.py`.

### Testing

- Added `tests/test_resident_services.py` with `test_add_service_normalizes_ai_metadata`, `test_usluga_command_reports_duplicate_service`, and `test_add_service_reactivates_existing_source_message` which exercise normalization, duplicate reporting, and reactivation behavior using an in-memory SQLite engine.
- Ran the new test suite with `pytest` and all new tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16bf679188326b186faa67b7ee6f2)