### PR TITLE
Replace scalar_one_or_none() with scalars().first() for query results

### DIFF
--- a/app/services/feedback.py
+++ b/app/services/feedback.py
@@ -32,7 +32,7 @@ async def save_feedback(
             AiFeedback.bot_message_id == bot_message_id,
         )
     )
-    if existing.scalar_one_or_none() is not None:
+    if existing.scalars().first() is not None:
         return None
 
     fb = AiFeedback(

--- a/app/services/quiz.py
+++ b/app/services/quiz.py
@@ -108,7 +108,7 @@ async def get_active_session(session: AsyncSession, chat_id: int, topic_id: int)
             QuizSession.is_active.is_(True),
         )
     )
-    return result.scalar_one_or_none()
+    return result.scalars().first()
 
 
 async def get_random_question(session: AsyncSession, quiz_session: QuizSession | None = None) -> QuizQuestion | None:

--- a/app/services/resident_services.py
+++ b/app/services/resident_services.py
@@ -309,8 +309,9 @@ async def get_service_by_source_message_id(
         select(ResidentService)
         .where(and_(*conditions))
         .order_by(ResidentService.is_active.desc(), ResidentService.created_at.desc())
+        .limit(1)
     )
-    return result.scalar_one_or_none()
+    return result.scalars().first()
 
 
 async def get_services_count(session: AsyncSession, chat_id: int) -> int:

--- a/app/services/roulette.py
+++ b/app/services/roulette.py
@@ -144,7 +144,7 @@ async def get_active_round(session: AsyncSession, chat_id: int, topic_id: int) -
             RouletteRound.is_active.is_(True),
         )
     )
-    return result.scalar_one_or_none()
+    return result.scalars().first()
 
 
 async def close_round(session: AsyncSession, rnd: RouletteRound, result_number: int) -> None:


### PR DESCRIPTION
## Summary
This PR updates SQLAlchemy query result handling across multiple service modules to use `scalars().first()` instead of `scalar_one_or_none()`. This change improves consistency and handles edge cases more gracefully.

## Key Changes
- **resident_services.py**: Added `.limit(1)` to the query and replaced `scalar_one_or_none()` with `scalars().first()` in `get_service_by_source_message_id()`
- **feedback.py**: Replaced `scalar_one_or_none()` with `scalars().first()` in `save_feedback()`
- **quiz.py**: Replaced `scalar_one_or_none()` with `scalars().first()` in `get_active_session()`
- **roulette.py**: Replaced `scalar_one_or_none()` with `scalars().first()` in `get_active_round()`

## Implementation Details
- `scalars().first()` is more forgiving than `scalar_one_or_none()` as it doesn't raise an exception when multiple rows are returned; instead it returns the first result
- The `.limit(1)` addition in `resident_services.py` ensures the query is optimized at the database level to fetch only one row
- All changes maintain the same functional behavior (returning a single object or None) while using the more appropriate SQLAlchemy API

https://claude.ai/code/session_016FXfXsDnPcEhYj79t6WMsJ