### PR TITLE
Fix timezone-aware datetime comparisons across codebase

### DIFF
--- a/app/handlers/economy.py
+++ b/app/handlers/economy.py
@@ -258,7 +258,8 @@ async def improvements_list_command(message: Message) -> None:
         bar_filled = min(10, int(imp.coins_total / imp.threshold * 10))
         bar = "█" * bar_filled + "░" * (10 - bar_filled)
         pct = min(100, int(imp.coins_total / imp.threshold * 100))
-        days_left = max(0, (imp.expires_at - __import__("datetime").datetime.now(__import__("datetime").timezone.utc)).days)
+        _exp = imp.expires_at if imp.expires_at.tzinfo else imp.expires_at.replace(tzinfo=__import__("datetime").timezone.utc)
+        days_left = max(0, (_exp - __import__("datetime").datetime.now(__import__("datetime").timezone.utc)).days)
         lines.append(
             f"#{imp.id} [{bar}] {pct}%\n"
             f"«{imp.text[:120]}»\n"

--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -27,6 +27,7 @@ from app.services.flood import FloodTracker
 from app.services.strikes import add_strike, clear_strikes
 from app.utils.admin import is_admin
 from app.utils.text import contains_forbidden_link
+from app.utils.time import ensure_aware
 
 logger = logging.getLogger(__name__)
 router = Router()
@@ -334,7 +335,7 @@ async def _check_flood(message: Message, bot: Bot) -> bool:
         if record is None:
             record = FloodRecord(user_id=message.from_user.id, chat_id=settings.forum_chat_id)
             session.add(record)
-        repeat_within_hour = record.last_flood_at and now - record.last_flood_at < timedelta(hours=1)
+        repeat_within_hour = record.last_flood_at and now - ensure_aware(record.last_flood_at) < timedelta(hours=1)
         record.last_flood_at = now
         await session.commit()
 

--- a/app/services/games.py
+++ b/app/services/games.py
@@ -264,4 +264,8 @@ def is_game_timed_out(state: BlackjackState, now: datetime) -> bool:
     if state.started_at is None:
         return False
     started = datetime.fromisoformat(state.started_at)
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     return now - started > timedelta(minutes=GAME_TIMEOUT_MINUTES)

--- a/app/services/improvements.py
+++ b/app/services/improvements.py
@@ -101,7 +101,10 @@ async def vote_for_improvement(
         return None, "not_found", False
     if improvement.is_completed:
         return None, "already_completed", False
-    if improvement.expires_at < datetime.now(timezone.utc):
+    expires_at = improvement.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if expires_at < datetime.now(timezone.utc):
         return None, "expired", False
 
     existing_vote = (

--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -241,6 +241,8 @@ def _time_decay_factor(created_at: datetime | None) -> float:
     """Экспоненциальное затухание: 1.0 для свежих, ~0.5 через half_life дней."""
     if created_at is None:
         return 0.5
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
     age_days = (datetime.now(timezone.utc) - created_at).total_seconds() / 86400
     if age_days <= 0:
         return 1.0

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
 from app.config import settings
@@ -10,6 +10,13 @@ from app.config import settings
 
 def now_tz() -> datetime:
     return datetime.now(tz=ZoneInfo(settings.timezone))
+
+
+def ensure_aware(dt: datetime) -> datetime:
+    """Если datetime naive — считаем его UTC и добавляем tzinfo."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def is_game_time_allowed(start_hour: int, end_hour: int) -> bool:


### PR DESCRIPTION
## Summary
This PR addresses inconsistent handling of timezone-aware and naive datetime objects throughout the codebase. Several functions were comparing or operating on datetime objects without ensuring they all had timezone information, which could lead to runtime errors or incorrect comparisons.

## Key Changes

- **New utility function**: Added `ensure_aware()` in `app/utils/time.py` to convert naive datetime objects to UTC-aware datetimes. This provides a reusable pattern for handling mixed datetime types.

- **Improvements service**: Fixed timezone comparison in `vote_for_improvement()` by ensuring `expires_at` is timezone-aware before comparing with `datetime.now(timezone.utc)`.

- **Games service**: Added timezone awareness checks in `is_game_timed_out()` for both `started` and `now` datetime objects before calculating the timeout delta.

- **Economy handler**: Fixed `improvements_list_command()` to ensure `expires_at` is timezone-aware before calculating days remaining.

- **Moderation handler**: Updated `_check_flood()` to use the new `ensure_aware()` utility when comparing `record.last_flood_at` with the current time.

- **RAG service**: Added timezone awareness check in `_time_decay_factor()` to ensure `created_at` is timezone-aware before age calculation.

## Implementation Details

The fix follows a consistent pattern: when a datetime object's timezone status is uncertain (typically from database records or deserialization), it's checked with `tzinfo is None` and converted to UTC if naive. This ensures all datetime comparisons are between timezone-aware objects, preventing `TypeError` exceptions and ensuring correct temporal logic.

https://claude.ai/code/session_017GWdJ3uZ1e5EGANVVHRw5U