### PR TITLE
Prevent canceling current task in quiz answer grace period

### DIFF
--- a/app/handlers/quiz.py
+++ b/app/handlers/quiz.py
@@ -214,7 +214,7 @@ def _get_session_lock(chat_id: int, topic_id: int) -> asyncio.Lock:
 def _cancel_answer_grace(chat_id: int, topic_id: int) -> None:
     key = (chat_id, topic_id)
     task = _answer_grace_tasks.pop(key, None)
-    if task:
+    if task and task is not asyncio.current_task():
         task.cancel()
     _pending_answers.pop(key, None)
     _question_attempts.pop(key, None)


### PR DESCRIPTION
## Summary
Fixed a potential issue in the quiz handler where the current asyncio task could be canceled when cleaning up answer grace period timers.

## Key Changes
- Added a check in `_cancel_answer_grace()` to prevent canceling the current task
- The condition now verifies that the task exists AND is not the currently running task before calling `cancel()`

## Implementation Details
This prevents a `RuntimeError` that would occur if a task attempted to cancel itself. By checking `task is not asyncio.current_task()`, we ensure that only grace period tasks from other contexts are canceled, while the current execution context is protected from self-cancellation.

https://claude.ai/code/session_012BvBUP1cPGaEcN7h9myCzo