### PR TITLE
Reorder router registration to fix economy handler precedence

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1064,10 +1064,9 @@ async def main() -> None:
     dp.include_router(admin.router)  # админ-команды
     dp.include_router(games.router)  # игры (команды /21, /score)
     dp.include_router(forms.router)  # формы с FSM (перед модерацией!)
+    dp.include_router(economy_handler.router)  # лотерея и инициативы жителей (до quiz — catch-all в topic_games)
     dp.include_router(quiz.router)  # викторина (команды /umnij_start, /bal, /topumnij)
     dp.include_router(roulette.router)  # рулетка (команда /bet)
-
-    dp.include_router(economy_handler.router)  # лотерея и инициативы жителей
     dp.include_router(text_publish.router)  # отправка текста от лица бота в выбранный топик
     dp.include_router(moderation.router)  # модерация (catch-all, пропускает FSM)
     # stats.router убран — статистика через middleware


### PR DESCRIPTION
## Summary
Adjusted the order of router registration in the dispatcher to ensure the economy handler router is processed before the quiz router, preventing the quiz router's catch-all handler from intercepting economy-related messages.

## Key Changes
- Moved `economy_handler.router` registration to execute before `quiz.router`
- Removed unnecessary blank line that separated the routers
- Added clarifying comment noting that economy handler must run before quiz due to topic_games catch-all behavior

## Implementation Details
The economy handler (lottery and citizen initiatives) contains handlers that need to be evaluated before the quiz router's catch-all handler in the topic_games topic. By reordering the router registration, messages are now correctly routed to economy features instead of being caught by the quiz router's broader matching logic.

https://claude.ai/code/session_013fxMajq3n92bgGQrVLd86L