### PR TITLE
Add coin shop with polls and gift transfer system

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -17,7 +17,7 @@ from sqlalchemy.exc import IntegrityError
 from app.config import settings
 from app.db import get_session
 from app.models import GameState
-from app.services.games import can_grant_coins, get_or_create_stats, register_coin_grant
+from app.services.games import get_or_create_stats
 from app.services.strikes import add_strike, clear_strikes
 from app.utils.admin import extract_target_user, is_admin
 from app.utils.admin_help import (
@@ -277,6 +277,9 @@ async def grant_coins(message: Message, bot: Bot) -> None:
     except ValueError:
         await message.reply("Монеты должны быть числом.")
         return
+    if amount <= 0:
+        await message.reply("Количество должно быть положительным.")
+        return
     target_id, display_name = extract_target_user(message)
     if target_id is None:
         await message.reply("Нужен реплай на сообщение пользователя.")
@@ -288,11 +291,7 @@ async def grant_coins(message: Message, bot: Bot) -> None:
             settings.forum_chat_id,
             display_name=display_name,
         )
-        now = datetime.now(timezone.utc)
-        if not can_grant_coins(stats, now, amount):
-            await message.reply("Нельзя выдать больше 10 монет за раз/сутки.")
-            return
-        register_coin_grant(stats, now, amount)
+        stats.coins += amount
         await session.commit()
     await message.reply(f"Начислено {amount} монет.")
 

--- a/app/handlers/games.py
+++ b/app/handlers/games.py
@@ -21,7 +21,9 @@ from app.services.games import (
     save_game,
     start_game,
     evaluate_game,
+    transfer_coins,
 )
+from app.utils.admin import extract_target_user
 
 router = Router()
 
@@ -176,6 +178,59 @@ async def show_score(message: Message) -> None:
         await session.commit()
     await message.reply(
         f"Монеты: {stats.coins}\nИгры: {stats.games_played}\nПобеды: {stats.wins}"
+    )
+
+
+@router.message(Command("подарить", "gift"))
+async def gift_coins_cmd(message: Message) -> None:
+    if settings.topic_games is None:
+        return
+    if (
+        message.chat.id != settings.forum_chat_id
+        or message.message_thread_id != settings.topic_games
+    ):
+        return
+    if message.from_user is None:
+        return
+    parts = (message.text or "").split()
+    if len(parts) < 2:
+        await message.reply("Укажи количество монет: /подарить 50")
+        return
+    try:
+        amount = int(parts[1])
+    except ValueError:
+        await message.reply("Количество монет должно быть числом.")
+        return
+    target_id, target_name = extract_target_user(message)
+    if target_id is None:
+        await message.reply("Нужен реплай на сообщение получателя.")
+        return
+    if target_id == message.from_user.id:
+        await message.reply("Нельзя подарить монеты самому себе.")
+        return
+    async for session in get_session():
+        sender_stats = await get_or_create_stats(
+            session,
+            message.from_user.id,
+            settings.forum_chat_id,
+            display_name=_display_name(message),
+        )
+        receiver_stats = await get_or_create_stats(
+            session,
+            target_id,
+            settings.forum_chat_id,
+            display_name=target_name,
+        )
+        error = transfer_coins(sender_stats, receiver_stats, amount)
+        if error:
+            await message.reply(error)
+            return
+        await session.commit()
+    sender_name = _display_name(message) or str(message.from_user.id)
+    recv_name = target_name or str(target_id)
+    await message.reply(
+        f"🎁 {sender_name} подарил(а) {amount} монет пользователю {recv_name}!\n"
+        f"Баланс: {sender_stats.coins} | {recv_name}: {receiver_stats.coins}"
     )
 
 

--- a/app/handlers/shop.py
+++ b/app/handlers/shop.py
@@ -1,0 +1,212 @@
+"""Почему: магазин монет — отдельный модуль с FSM для многошаговых покупок."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from aiogram import Bot, F, Router
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
+
+from app.config import settings
+from app.db import get_session
+from app.services.games import get_or_create_stats
+from app.services.shop import SHOP_CATALOG, get_item, record_purchase
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────
+# FSM-состояния для товаров, требующих ввода
+# ──────────────────────────────────────────────────────────
+class ShopForm(StatesGroup):
+    waiting_poll_question = State()
+
+
+# ──────────────────────────────────────────────────────────
+# Вспомогательные функции
+# ──────────────────────────────────────────────────────────
+def _is_shop_topic(message: Message) -> bool:
+    """Проверяет, находится ли сообщение в допустимом топике магазина."""
+    if message.chat.id != settings.forum_chat_id:
+        return False
+    thread = message.message_thread_id
+    return thread in (settings.topic_smoke, settings.topic_games)
+
+
+def _shop_keyboard() -> InlineKeyboardMarkup:
+    """Генерирует клавиатуру магазина из каталога."""
+    buttons = []
+    for item in SHOP_CATALOG:
+        buttons.append([
+            InlineKeyboardButton(
+                text=f"{item.name} — {item.price} монет",
+                callback_data=f"shop_buy:{item.key}",
+            )
+        ])
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+# ──────────────────────────────────────────────────────────
+# КОМАНДА МАГАЗИН
+# ──────────────────────────────────────────────────────────
+@router.message(Command("магазин"))
+@router.message(F.text & F.text.casefold() == "магазин")
+async def shop_command(message: Message, state: FSMContext) -> None:
+    if message.from_user is None:
+        return
+
+    if not _is_shop_topic(message):
+        topics = []
+        if settings.topic_games is not None:
+            topics.append("Блэкджек и боулинг (игры)")
+        if settings.topic_smoke is not None:
+            topics.append("Курилка")
+        where = " или ".join(topics) if topics else "игровом топике"
+        await message.reply(f"Магазин доступен только в топике: {where}")
+        return
+
+    await state.clear()
+    await message.reply(
+        "🏪 Магазин монет\n\nВыберите услугу:",
+        reply_markup=_shop_keyboard(),
+    )
+
+
+# ──────────────────────────────────────────────────────────
+# КОЛЛБЭК ПОКУПКИ
+# ──────────────────────────────────────────────────────────
+@router.callback_query(F.data.startswith("shop_buy:"))
+async def shop_buy_callback(callback: CallbackQuery, state: FSMContext, bot: Bot) -> None:
+    if callback.from_user is None or callback.message is None:
+        await callback.answer("Ошибка.", show_alert=True)
+        return
+
+    item_key = callback.data.split(":", 1)[1]
+    item = get_item(item_key)
+    if item is None:
+        await callback.answer("Товар не найден.", show_alert=True)
+        return
+
+    async for session in get_session():
+        stats = await get_or_create_stats(
+            session,
+            callback.from_user.id,
+            settings.forum_chat_id,
+            display_name=callback.from_user.full_name,
+        )
+        if stats.coins < item.price:
+            await callback.answer(
+                f"Недостаточно монет. Нужно {item.price}, у вас {stats.coins}.",
+                show_alert=True,
+            )
+            return
+
+    if item.needs_input and item.key == "poll":
+        await state.set_state(ShopForm.waiting_poll_question)
+        await state.update_data(item_key=item.key)
+        await callback.message.reply(
+            "По какому вопросу будет голосование? Напишите ваш вопрос:"
+        )
+        await callback.answer()
+        return
+
+    # Для товаров без ввода — мгновенная покупка
+    async for session in get_session():
+        stats = await get_or_create_stats(
+            session,
+            callback.from_user.id,
+            settings.forum_chat_id,
+            display_name=callback.from_user.full_name,
+        )
+        if stats.coins < item.price:
+            await callback.answer("Недостаточно монет.", show_alert=True)
+            return
+        stats.coins -= item.price
+        await record_purchase(
+            session,
+            callback.from_user.id,
+            settings.forum_chat_id,
+            callback.from_user.full_name,
+            item.key,
+            item.price,
+        )
+        await session.commit()
+    await callback.message.reply(f"Покупка совершена: {item.name}!")
+    await callback.answer()
+
+
+# ──────────────────────────────────────────────────────────
+# FSM: ОЖИДАНИЕ ВОПРОСА ГОЛОСОВАНИЯ
+# ──────────────────────────────────────────────────────────
+@router.message(ShopForm.waiting_poll_question, F.text)
+async def shop_poll_question_received(message: Message, state: FSMContext, bot: Bot) -> None:
+    if message.from_user is None:
+        return
+
+    data = await state.get_data()
+    item_key = data.get("item_key", "poll")
+    item = get_item(item_key)
+    if item is None:
+        await state.clear()
+        await message.reply("Ошибка: товар не найден.")
+        return
+
+    question_text = message.text
+    user_name = message.from_user.full_name
+    user_id = message.from_user.id
+
+    async for session in get_session():
+        stats = await get_or_create_stats(
+            session,
+            user_id,
+            settings.forum_chat_id,
+            display_name=user_name,
+        )
+        if stats.coins < item.price:
+            await state.clear()
+            await message.reply(
+                f"Недостаточно монет. Нужно {item.price}, у вас {stats.coins}."
+            )
+            return
+        stats.coins -= item.price
+        await record_purchase(
+            session,
+            user_id,
+            settings.forum_chat_id,
+            user_name,
+            item.key,
+            item.price,
+            details={"question": question_text},
+        )
+        await session.commit()
+
+    await state.clear()
+
+    deadline = datetime.now(timezone.utc) + timedelta(days=3)
+    deadline_str = deadline.strftime("%d.%m.%Y")
+
+    await message.reply(
+        f"✅ Покупка совершена!\n\n"
+        f"Голосование по вашему вопросу будет организовано в течение 3 дней "
+        f"(до {deadline_str}). Следите за обновлениями!"
+    )
+
+    # Уведомление в чат логов
+    if settings.admin_log_chat_id:
+        log_text = (
+            f"🛒 Покупка в магазине\n\n"
+            f"Покупатель: {user_name} (ID: {user_id})\n"
+            f"Товар: {item.name}\n"
+            f"Стоимость: {item.price} монет\n\n"
+            f"Вопрос голосования:\n{question_text}\n\n"
+            f"Срок проведения: до {deadline_str}"
+        )
+        try:
+            await bot.send_message(settings.admin_log_chat_id, log_text)
+        except Exception:
+            logger.exception("Не удалось отправить уведомление о покупке в лог-чат")

--- a/app/main.py
+++ b/app/main.py
@@ -40,7 +40,7 @@ from app.handlers import (
     moderation,
     quiz,
     roulette,
-
+    shop,
     text_publish,
 )
 from app.models import MigrationFlag, UserStat
@@ -1064,6 +1064,7 @@ async def main() -> None:
     dp.include_router(admin.router)  # админ-команды
     dp.include_router(games.router)  # игры (команды /21, /score)
     dp.include_router(forms.router)  # формы с FSM (перед модерацией!)
+    dp.include_router(shop.router)  # магазин монет (FSM, перед economy)
     dp.include_router(economy_handler.router)  # лотерея и инициативы жителей (до quiz — catch-all в topic_games)
     dp.include_router(quiz.router)  # викторина (команды /umnij_start, /bal, /topumnij)
     dp.include_router(roulette.router)  # рулетка (команда /bet)

--- a/app/models.py
+++ b/app/models.py
@@ -442,3 +442,17 @@ class ImprovementVote(Base):
     user_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     amount: Mapped[int] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+
+class ShopPurchase(Base):
+    """Почему: история покупок в магазине монет."""
+    __tablename__ = "shop_purchases"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(Integer, index=True)
+    chat_id: Mapped[int] = mapped_column(Integer)
+    user_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    item_key: Mapped[str] = mapped_column(Text)
+    coins_spent: Mapped[int] = mapped_column(Integer)
+    details_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/app/services/games.py
+++ b/app/services/games.py
@@ -224,6 +224,17 @@ async def clear_game_command_messages(session: AsyncSession, chat_id: int) -> No
     )
 
 
+def transfer_coins(sender: UserStat, receiver: UserStat, amount: int) -> str | None:
+    """Перевод монет между пользователями. Возвращает None при успехе или текст ошибки."""
+    if amount <= 0:
+        return "Количество должно быть положительным числом."
+    if sender.coins < amount:
+        return "Недостаточно монет для подарка."
+    sender.coins -= amount
+    receiver.coins += amount
+    return None
+
+
 def can_grant_coins(stats: UserStat, now: datetime, amount: int) -> bool:
     if amount > 10:
         return False

--- a/app/services/shop.py
+++ b/app/services/shop.py
@@ -1,0 +1,62 @@
+"""Почему: каталог магазина и логика покупок вынесены отдельно от хендлеров."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ShopPurchase, UserStat
+
+
+@dataclass(frozen=True)
+class ShopItem:
+    key: str           # уникальный идентификатор, напр. "poll"
+    name: str          # отображаемое название
+    price: int         # стоимость в монетах
+    description: str   # описание для меню
+    needs_input: bool  # требуется ли ввод от пользователя после покупки
+
+
+# ──────────────────────────────────────────────────────────
+# КАТАЛОГ ТОВАРОВ — для добавления нового товара достаточно
+# дописать элемент в список ниже
+# ──────────────────────────────────────────────────────────
+SHOP_CATALOG: list[ShopItem] = [
+    ShopItem(
+        key="poll",
+        name="Организовать голосование",
+        price=1000,
+        description="Бот проведёт голосование по любому вашему вопросу",
+        needs_input=True,
+    ),
+]
+
+
+def get_item(key: str) -> ShopItem | None:
+    """Найти товар по ключу."""
+    return next((item for item in SHOP_CATALOG if item.key == key), None)
+
+
+async def record_purchase(
+    session: AsyncSession,
+    user_id: int,
+    chat_id: int,
+    user_name: str | None,
+    item_key: str,
+    coins_spent: int,
+    details: dict | None = None,
+) -> ShopPurchase:
+    """Сохранить покупку в базу."""
+    purchase = ShopPurchase(
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name=user_name,
+        item_key=item_key,
+        coins_spent=coins_spent,
+        details_json=json.dumps(details, ensure_ascii=False) if details else None,
+    )
+    session.add(purchase)
+    return purchase


### PR DESCRIPTION
## Summary
Implements a coin shop system allowing users to purchase services (starting with poll creation), adds coin gifting between users, and removes the previous coin grant rate limiting.

## Key Changes

**New Shop System:**
- Added `app/handlers/shop.py` with FSM-based shop interface for multi-step purchases
- Created `app/services/shop.py` with extensible shop catalog and purchase recording
- Added `ShopPurchase` model to track purchase history with optional JSON details
- Shop accessible only in designated forum topics (games and smoke lounge)
- First shop item: "Organize a poll" (1000 coins) with user-provided question

**Coin Transfer Feature:**
- Added `/подарить` (gift) command in games handler for peer-to-peer coin transfers
- Implemented `transfer_coins()` utility function with validation
- Added `extract_target_user()` helper to identify gift recipients via message reply

**Admin Changes:**
- Removed `can_grant_coins()` rate limiting from admin coin grants
- Simplified admin grant flow to direct coin addition without daily/per-grant caps
- Added validation for positive amounts

**Integration:**
- Registered shop router in main dispatcher
- Added admin log notifications for poll purchases with deadline information
- Imported new utilities and services across handlers

## Implementation Details
- Shop items are defined in a simple catalog list for easy extension
- FSM state `ShopForm.waiting_poll_question` handles multi-step poll creation
- Purchase details stored as JSON for flexibility (e.g., poll questions)
- Admin notifications include purchase details and 3-day poll deadline

https://claude.ai/code/session_012hNX16w2eH448S4mDMjRK1