### PR TITLE
Bypass AI rate limits for daily scheduled messages

### DIFF
--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -686,12 +686,13 @@ class OpenRouterProvider:
     async def aclose(self) -> None:
         await self._client.aclose()
 
-    async def _chat_completion(self, messages: list[dict[str, str]], *, chat_id: int, temperature: float = 0.8) -> tuple[str, int]:
+    async def _chat_completion(self, messages: list[dict[str, str]], *, chat_id: int, temperature: float = 0.8, bypass_limit: bool = False) -> tuple[str, int]:
         if not settings.ai_key:
             raise RuntimeError("AI_KEY не задан")
-        allowed, reason = await _can_use_remote_ai(chat_id)
-        if not allowed:
-            raise RuntimeError(f"AI лимит: {reason or 'превышен'}")
+        if not bypass_limit:
+            allowed, reason = await _can_use_remote_ai(chat_id)
+            if not allowed:
+                raise RuntimeError(f"AI лимит: {reason or 'превышен'}")
 
         payload = {
             "temperature": temperature,

--- a/app/services/daily_messages.py
+++ b/app/services/daily_messages.py
@@ -259,6 +259,7 @@ async def send_morning_greeting(bot: Bot) -> None:
                 {"role": "user", "content": user_message},
             ],
             chat_id=settings.forum_chat_id,
+            bypass_limit=True,
         )
 
         if content and content.strip():
@@ -269,7 +270,7 @@ async def send_morning_greeting(bot: Bot) -> None:
             logger.info("DAILY_GREETING: утреннее приветствие отправлено в General")
 
     except Exception:
-        logger.warning("Не удалось отправить утреннее приветствие.")
+        logger.warning("Не удалось отправить утреннее приветствие.", exc_info=True)
 
 
 async def send_traffic_report(bot: Bot, period: str) -> None:
@@ -318,6 +319,7 @@ async def send_traffic_report(bot: Bot, period: str) -> None:
                 {"role": "user", "content": direction_info},
             ],
             chat_id=settings.forum_chat_id,
+            bypass_limit=True,
         )
 
         if content and content.strip():
@@ -329,4 +331,4 @@ async def send_traffic_report(bot: Bot, period: str) -> None:
             logger.info("TRAFFIC_REPORT: %s отчёт отправлен в Попутчики", period)
 
     except Exception:
-        logger.warning("Не удалось отправить трафик-отчёт (%s).", period)
+        logger.warning("Не удалось отправить трафик-отчёт (%s).", period, exc_info=True)


### PR DESCRIPTION
## Summary
This PR adds the ability to bypass AI rate limits for scheduled daily messages (morning greeting and traffic reports) while maintaining rate limiting for regular user interactions.

## Key Changes
- Added `bypass_limit` parameter to `_chat_completion()` method in `ai_module.py` to allow selective bypassing of rate limit checks
- Updated `send_morning_greeting()` to bypass AI rate limits when generating greeting messages
- Updated `send_traffic_report()` to bypass AI rate limits when generating traffic reports
- Improved error logging by adding `exc_info=True` to exception handlers in both daily message functions for better debugging

## Implementation Details
- The `bypass_limit` parameter defaults to `False` to maintain existing behavior for all other callers
- When `bypass_limit=True`, the `_can_use_remote_ai()` check is skipped entirely
- This allows scheduled system messages to be generated without being subject to per-chat rate limits, while user-initiated requests continue to respect rate limiting
- Enhanced logging will now include full exception tracebacks when daily message operations fail

https://claude.ai/code/session_01Hu2VQFZfdsQdehY1njngPD