### PR TITLE
Стабилизация: вернуть безопасные функциональные фиксы (Telegram API, запуск, викторина)

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -20,6 +20,7 @@ from app.models import GameState
 from app.services.games import get_or_create_stats
 from app.services.strikes import add_strike, clear_strikes
 from app.utils.admin import extract_target_user, is_admin
+from app.utils.safe_telegram import safe_call
 from app.utils.admin_help import (
     ADMIN_CATEGORIES,
     admin_back_keyboard,
@@ -178,12 +179,18 @@ async def mute_user(message: Message, bot: Bot) -> None:
         return
     until = datetime.now(timezone.utc) + timedelta(minutes=minutes)
     permissions = ChatPermissions(can_send_messages=False)
-    await bot.restrict_chat_member(
-        settings.forum_chat_id,
-        target_id,
-        permissions=permissions,
-        until_date=until,
+    result = await safe_call(
+        bot.restrict_chat_member(
+            settings.forum_chat_id,
+            target_id,
+            permissions=permissions,
+            until_date=until,
+        ),
+        log_ctx=f"/mute user_id={target_id} minutes={minutes}",
     )
+    if result is None:
+        await message.reply("Не удалось замьютить: Telegram API вернул ошибку (см. логи).")
+        return
     await message.reply(f"Пользователь замьючен на {minutes} минут.")
 
 
@@ -196,9 +203,15 @@ async def unmute_user(message: Message, bot: Bot) -> None:
         await message.reply("Нужен реплай на сообщение пользователя.")
         return
     permissions = ChatPermissions(can_send_messages=True, can_send_other_messages=True)
-    await bot.restrict_chat_member(
-        settings.forum_chat_id, target_id, permissions=permissions
+    result = await safe_call(
+        bot.restrict_chat_member(
+            settings.forum_chat_id, target_id, permissions=permissions
+        ),
+        log_ctx=f"/unmute user_id={target_id}",
     )
+    if result is None:
+        await message.reply("Не удалось снять мут: Telegram API вернул ошибку (см. логи).")
+        return
     await message.reply("Мут снят.")
 
 
@@ -220,7 +233,13 @@ async def ban_user(message: Message, bot: Bot) -> None:
         await message.reply("Нужен реплай на сообщение пользователя.")
         return
     until = datetime.now(timezone.utc) + timedelta(days=days)
-    await bot.ban_chat_member(settings.forum_chat_id, target_id, until_date=until)
+    result = await safe_call(
+        bot.ban_chat_member(settings.forum_chat_id, target_id, until_date=until),
+        log_ctx=f"/ban user_id={target_id} days={days}",
+    )
+    if result is None:
+        await message.reply("Не удалось забанить: Telegram API вернул ошибку (см. логи).")
+        return
     await message.reply(f"Бан на {days} дней выдан.")
 
 
@@ -232,7 +251,13 @@ async def unban_user(message: Message, bot: Bot) -> None:
     if target_id is None:
         await message.reply("Нужен реплай на сообщение пользователя.")
         return
-    await bot.unban_chat_member(settings.forum_chat_id, target_id)
+    result = await safe_call(
+        bot.unban_chat_member(settings.forum_chat_id, target_id),
+        log_ctx=f"/unban user_id={target_id}",
+    )
+    if result is None:
+        await message.reply("Не удалось снять бан: Telegram API вернул ошибку (см. логи).")
+        return
     await message.reply("Бан снят.")
 
 
@@ -250,11 +275,14 @@ async def strike_user(message: Message, bot: Bot) -> None:
     if count >= 3:
         until = datetime.now(timezone.utc) + timedelta(hours=24)
         permissions = ChatPermissions(can_send_messages=False)
-        await bot.restrict_chat_member(
-            settings.forum_chat_id,
-            target_id,
-            permissions=permissions,
-            until_date=until,
+        await safe_call(
+            bot.restrict_chat_member(
+                settings.forum_chat_id,
+                target_id,
+                permissions=permissions,
+                until_date=until,
+            ),
+            log_ctx=f"/strike L3 mute user_id={target_id}",
         )
         async for session in get_session():
             await clear_strikes(session, target_id, settings.forum_chat_id)

--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import random
+import time
 from datetime import datetime, timedelta, timezone
 
 from aiogram import Bot, F, Router
@@ -26,6 +27,7 @@ from app.services.ai_module import get_ai_client
 from app.services.flood import FloodTracker
 from app.services.strikes import add_strike, clear_strikes
 from app.utils.admin import is_admin
+from app.utils.safe_telegram import safe_call
 from app.utils.text import contains_forbidden_link
 from app.utils.time import ensure_aware
 
@@ -51,9 +53,26 @@ def is_training_mode() -> bool:
     return settings.moderation_training_mode
 
 
-# Множество message_id, уже прошедших модерацию (предотвращает двойной вызов)
-_MODERATED_MSG_IDS: set[int] = set()
-_MODERATED_MSG_IDS_MAX = 500
+# Dict message_id → timestamp для идемпотентности модерации
+_MODERATED_MSG_IDS: dict[int, float] = {}
+_MODERATED_MSG_IDS_TTL = 120.0
+_MODERATED_MSG_IDS_MAX = 1000
+
+
+def _is_already_moderated(msg_id: int) -> bool:
+    now = time.monotonic()
+    if msg_id in _MODERATED_MSG_IDS:
+        return True
+    if len(_MODERATED_MSG_IDS) >= _MODERATED_MSG_IDS_MAX:
+        expired = [k for k, v in _MODERATED_MSG_IDS.items() if now - v > _MODERATED_MSG_IDS_TTL]
+        for key in expired:
+            del _MODERATED_MSG_IDS[key]
+        if len(_MODERATED_MSG_IDS) >= _MODERATED_MSG_IDS_MAX:
+            oldest = sorted(_MODERATED_MSG_IDS, key=_MODERATED_MSG_IDS.__getitem__)
+            for key in oldest[: _MODERATED_MSG_IDS_MAX // 2]:
+                del _MODERATED_MSG_IDS[key]
+    _MODERATED_MSG_IDS[msg_id] = now
+    return False
 
 # Вариативные мягкие предупреждения (L1)
 _SOFT_WARNINGS = (
@@ -78,11 +97,14 @@ async def _warn_user(message: Message, text: str, bot: Bot) -> None:
     if message.from_user is None:
         return
     mention = message.from_user.mention_html()
-    await bot.send_message(
-        message.chat.id,
-        f"{mention}, {text}",
-        parse_mode="HTML",
-        message_thread_id=message.message_thread_id,
+    await safe_call(
+        bot.send_message(
+            message.chat.id,
+            f"{mention}, {text}",
+            parse_mode="HTML",
+            message_thread_id=message.message_thread_id,
+        ),
+        log_ctx=f"warn user_id={message.from_user.id}",
     )
 
 
@@ -178,14 +200,8 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
         return False
 
     # Предотвращаем двойную модерацию одного сообщения (mention_help + moderate_message)
-    msg_id = message.message_id
-    if msg_id in _MODERATED_MSG_IDS:
+    if _is_already_moderated(message.message_id):
         return False
-    if len(_MODERATED_MSG_IDS) > _MODERATED_MSG_IDS_MAX:
-        to_remove = sorted(_MODERATED_MSG_IDS)[:_MODERATED_MSG_IDS_MAX // 2]
-        for mid in to_remove:
-            _MODERATED_MSG_IDS.discard(mid)
-    _MODERATED_MSG_IDS.add(msg_id)
 
     if await is_admin(bot, settings.forum_chat_id, message.from_user.id):
         return False
@@ -196,7 +212,10 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
 
     # Проверка запрещённых ссылок (до AI)
     if contains_forbidden_link(text):
-        await message.delete()
+        await safe_call(
+            message.delete(),
+            log_ctx=f"delete forbidden link msg={message.message_id}",
+        )
         await _warn_user(message, "ссылки разрешены только в формате Telegram.", bot)
         await _store_mod_event(chat_id, user_id, "delete", 1, message_id=message.message_id)
         return True
@@ -262,7 +281,10 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
 
     # L3: удаление + счётчик +1 + немедленный мут + уведомление админа
     if severity >= 3:
-        await message.delete()
+        await safe_call(
+            message.delete(),
+            log_ctx=f"delete L3 msg={message.message_id}",
+        )
         async for session in get_session():
             strike_count = await add_strike(session, user_id, settings.forum_chat_id)
             await session.commit()
@@ -273,11 +295,14 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
         # Немедленный мут 24ч
         until = datetime.now(timezone.utc) + timedelta(hours=24)
         permissions = ChatPermissions(can_send_messages=False)
-        await bot.restrict_chat_member(
-            settings.forum_chat_id,
-            user_id,
-            permissions=permissions,
-            until_date=until,
+        await safe_call(
+            bot.restrict_chat_member(
+                settings.forum_chat_id,
+                user_id,
+                permissions=permissions,
+                until_date=until,
+            ),
+            log_ctx=f"L3 mute user_id={user_id}",
         )
         await _warn_user(message, "сообщение удалено, мут на 24 часа за грубое нарушение.", bot)
         # Уведомление админа
@@ -289,7 +314,10 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
             f"Уверенность: {confidence or 'н/д'}\n"
             f"Текст: {text[:200]}"
         )
-        await bot.send_message(settings.admin_log_chat_id, admin_text, parse_mode="HTML")
+        await safe_call(
+            bot.send_message(settings.admin_log_chat_id, admin_text, parse_mode="HTML"),
+            log_ctx="L3 admin notify",
+        )
         await _apply_strike_threshold(bot, message, user_id, strike_count)
         return True
 
@@ -300,7 +328,10 @@ async def _apply_strike_threshold(bot: Bot, message: Message, user_id: int, stri
     """Применяет мут/бан по порогам счётчика предупреждений."""
     if strike_count >= 5:
         # Бан
-        await bot.ban_chat_member(settings.forum_chat_id, user_id)
+        await safe_call(
+            bot.ban_chat_member(settings.forum_chat_id, user_id),
+            log_ctx=f"strike ban user_id={user_id}",
+        )
         async for session in get_session():
             await clear_strikes(session, user_id, settings.forum_chat_id)
             await session.commit()
@@ -309,11 +340,14 @@ async def _apply_strike_threshold(bot: Bot, message: Message, user_id: int, stri
         # Мут 24ч
         until = datetime.now(timezone.utc) + timedelta(hours=24)
         permissions = ChatPermissions(can_send_messages=False)
-        await bot.restrict_chat_member(
-            settings.forum_chat_id,
-            user_id,
-            permissions=permissions,
-            until_date=until,
+        await safe_call(
+            bot.restrict_chat_member(
+                settings.forum_chat_id,
+                user_id,
+                permissions=permissions,
+                until_date=until,
+            ),
+            log_ctx=f"strike mute user_id={user_id}",
         )
         await _warn_user(message, "3 предупреждения — пауза в чате на 24 часа.", bot)
 
@@ -342,11 +376,14 @@ async def _check_flood(message: Message, bot: Bot) -> bool:
     mute_minutes = 60 if repeat_within_hour else 15
     until = datetime.now(timezone.utc) + timedelta(minutes=mute_minutes)
     permissions = ChatPermissions(can_send_messages=False)
-    await bot.restrict_chat_member(
-        settings.forum_chat_id,
-        message.from_user.id,
-        permissions=permissions,
-        until_date=until,
+    await safe_call(
+        bot.restrict_chat_member(
+            settings.forum_chat_id,
+            message.from_user.id,
+            permissions=permissions,
+            until_date=until,
+        ),
+        log_ctx=f"flood mute user_id={message.from_user.id}",
     )
     await _warn_user(message, f"слишком частые сообщения. Мут на {mute_minutes} минут.", bot)
     await _store_mod_event(message.chat.id, message.from_user.id, "mute", 2)

--- a/app/handlers/quiz.py
+++ b/app/handlers/quiz.py
@@ -27,7 +27,6 @@ from app.services.quiz import (
     award_winner_bonus_coins,
     build_answer_hint,
     build_session_stats,
-    can_start_quiz,
     check_answer,
     end_quiz_session,
     get_active_session,
@@ -37,7 +36,7 @@ from app.services.quiz import (
     get_random_question,
     is_quiz_finished,
     set_current_question,
-    start_quiz_session,
+    safe_start_quiz,
     winners_from_results,
 )
 from app.utils.admin import is_admin_message
@@ -144,13 +143,11 @@ async def _start_quiz(bot: Bot, chat_id: int, topic_id: int, actor: str) -> tupl
     _cancel_answer_grace(chat_id, topic_id)
 
     async for session in get_session():
-        can_start, reason = await can_start_quiz(session, chat_id, topic_id)
-        if not can_start:
+        quiz_session, reason = await safe_start_quiz(session, chat_id, topic_id)
+        if quiz_session is None:
             if actor == "авто":
                 await bot.send_message(settings.admin_log_chat_id, f"Автозапуск викторины отменён: {reason}")
             return False, reason
-
-        quiz_session = await start_quiz_session(session, chat_id, topic_id)
         question = await get_random_question(session, quiz_session)
         if not question:
             await bot.send_message(chat_id, "Вопросы закончились. Загрузите новую базу.", message_thread_id=topic_id)

--- a/app/main.py
+++ b/app/main.py
@@ -911,15 +911,28 @@ async def on_startup(bot: Bot) -> None:
                 len(settings.bot_token),
             )
             break
-    await init_db(engine)
+    try:
+        await init_db(engine)
+    except Exception:
+        logger.exception(
+            "Критическая ошибка: не удалось инициализировать БД. "
+            "Проверьте DATABASE_URL и права на директорию данных."
+        )
+        raise
     try:
         await cleanup_database()
     except Exception:  # noqa: BLE001 - не блокируем старт из-за не-критичной очистки
         logger.exception("Очистка БД при старте завершилась с ошибкой.")
     # Применяем миграции
-    async for session in get_session():
-        await apply_v11_stats_reset(session)
-    await heartbeat_job(bot)
+    try:
+        async for session in get_session():
+            await apply_v11_stats_reset(session)
+    except Exception:  # noqa: BLE001
+        logger.exception("Не удалось выполнить миграцию v1.1 (некритично, продолжаем).")
+    try:
+        await heartbeat_job(bot)
+    except Exception:  # noqa: BLE001
+        logger.exception("Ошибка heartbeat при старте (некритично, продолжаем).")
     if telegram_available:
         # Публичные команды для всех пользователей
         await bot.set_my_commands(
@@ -1000,7 +1013,10 @@ async def on_startup(bot: Bot) -> None:
     await _sync_places_from_sheets()
 
     # Возобновляем рулетку, если бот перезагрузился в игровое время
-    await roulette.resume_roulette_if_needed(bot)
+    try:
+        await roulette.resume_roulette_if_needed(bot)
+    except Exception:  # noqa: BLE001
+        logger.exception("Не удалось возобновить рулетку при старте (некритично, продолжаем).")
 
     # Инициализируем AI-клиент и логируем режим работы
     get_ai_client()

--- a/app/services/quiz.py
+++ b/app/services/quiz.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import math
 import logging
@@ -9,10 +10,11 @@ import random
 import re
 from datetime import datetime, timezone, timedelta
 
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import QuizQuestion, QuizSession, QuizUsedQuestion, QuizUserStat, UserStat
+from app.utils.time import ensure_aware
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +57,9 @@ async def get_available_questions_count(session: AsyncSession) -> int:
 def _is_session_stale(quiz_session: QuizSession) -> bool:
     """Проверяет, зависла ли сессия (например, после перезапуска бота)."""
     if quiz_session.question_started_at is None:
-        # Сессия без активного вопроса — зависла между вопросами
-        return True
+        return bool(quiz_session.question_number)
     now = datetime.now(timezone.utc)
-    started = quiz_session.question_started_at
-    if started.tzinfo is None:
-        started = started.replace(tzinfo=timezone.utc)
+    started = ensure_aware(quiz_session.question_started_at)
     elapsed = (now - started).total_seconds()
     return elapsed > QUIZ_STALE_SESSION_SEC
 
@@ -272,9 +271,30 @@ async def end_quiz_session(session: AsyncSession, quiz_session: QuizSession) -> 
     quiz_session.is_active = False
     quiz_session.current_question_id = None
 
-    used_ids = get_used_question_ids(quiz_session)
-    if used_ids:
-        await session.execute(delete(QuizQuestion).where(QuizQuestion.id.in_(used_ids)))
+
+_QUIZ_LOCKS: dict[tuple[int, int], asyncio.Lock] = {}
+
+
+def _get_quiz_lock(chat_id: int, topic_id: int) -> asyncio.Lock:
+    key = (chat_id, topic_id)
+    if key not in _QUIZ_LOCKS:
+        _QUIZ_LOCKS[key] = asyncio.Lock()
+    return _QUIZ_LOCKS[key]
+
+
+async def safe_start_quiz(
+    session: AsyncSession,
+    chat_id: int,
+    topic_id: int,
+) -> tuple[QuizSession | None, str]:
+    """Атомарно проверяет и запускает викторину в пределах одного event-loop."""
+    async with _get_quiz_lock(chat_id, topic_id):
+        ok, reason = await can_start_quiz(session, chat_id, topic_id)
+        if not ok:
+            return None, reason
+        quiz_session = await start_quiz_session(session, chat_id, topic_id)
+        await session.commit()
+        return quiz_session, ""
 
 
 async def get_quiz_leaderboard(session: AsyncSession, chat_id: int, limit: int = 5) -> list[QuizUserStat]:

--- a/app/utils/safe_telegram.py
+++ b/app/utils/safe_telegram.py
@@ -1,0 +1,26 @@
+"""Почему: ошибки Telegram API не должны прерывать обработчики и джобы."""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, TypeVar
+
+from aiogram.exceptions import TelegramAPIError
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+async def safe_call(coro: Awaitable[T], *, log_ctx: str) -> T | None:
+    """Выполняет Telegram-вызов с мягкой обработкой ошибок.
+
+    Возвращает результат корутины или ``None`` при ошибке.
+    """
+    try:
+        return await coro
+    except TelegramAPIError as exc:
+        logger.warning("Telegram API error [%s]: %s", log_ctx, exc)
+    except Exception:  # noqa: BLE001
+        logger.exception("Unexpected Telegram call error [%s].", log_ctx)
+    return None


### PR DESCRIPTION
### Motivation
- Восстановить только безопасные функциональные правки, откатившиеся в цепочке между e784d0a..31e8dfc, чтобы устранить падения при ошибках Telegram API, защитить процедуру старта и убрать гонки/утечки в викторине.
- Сфокусироваться на минимальных изменениях, не внося косметики и не смешивая функциональные откаты с рефакторингом.

### Description
- Добавлен `app/utils/safe_telegram.py` с `safe_call()` и обёрнуты критичные вызовы Telegram API в `app/handlers/moderation.py` и `app/handlers/admin.py`, с логированием и дружелюбными ответами при ошибке API.
- Укреплён запуск приложения в `app/main.py`: `init_db()` теперь логирует и пробрасывает критические ошибки, а некритичные шаги (`apply_v11_stats_reset`, `heartbeat_job`, `roulette.resume_roulette_if_needed`) обёрнуты в `try/except` с логированием, чтобы не ронять стартап целиком.
- Повышена устойчивость викторины: в `app/services/quiz.py` исправлена проверка зависшей сессии, добавлен `ensure_aware()` для времени, удалён разрушительный удаляющий код при завершении сессии, добавлена атомарная функция `safe_start_quiz()` с per-topic `asyncio.Lock`, и `app/handlers/quiz.py` переведён на её использование для предотвращения race condition при стартах.

### Testing
- Выполнена компиляция изменённых модулей: `python -m compileall app/handlers/admin.py app/handlers/moderation.py app/main.py app/handlers/quiz.py app/services/quiz.py app/utils/safe_telegram.py`, компиляция прошла успешно.
- Запуск полного набора тестов `pytest -q` завершился ошибкой на этапе коллекции из-за существующей проблемы в тестах репозитория (ImportError в `tests/test_resident_services.py` — ожидается `usluga_command` в `app.handlers.admin`), поэтому полный прогон тестов не завершился.
- Попытка запустить конкретный набор тестов (`tests/test_quiz_fix.py tests/test_quiz_lock.py tests/test_moderation_dedup.py`) не выполнилась из‑за отсутствия указанных файлов в окружении, соответственно дополнительные целевые тесты не были выполнены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da13bf9dc88326b903723c61e9bb83)