### PR TITLE
Восстановление критических регрессионных тестов и добавление quality-gate в CI

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,32 @@
+name: Quality Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  critical-tests:
+    name: critical-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run subsystem critical tests
+        run: |
+          pytest -q \
+            tests/moderation_dedup/test_moderation_dedup.py \
+            tests/quiz_fix/test_quiz_fix.py \
+            tests/quiz_lock/test_quiz_lock.py \
+            tests/datetime_aware/test_datetime_aware.py \
+            tests/circuit_breaker/test_circuit_breaker.py

--- a/app/services/quiz.py
+++ b/app/services/quiz.py
@@ -9,7 +9,7 @@ import random
 import re
 from datetime import datetime, timezone, timedelta
 
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import QuizQuestion, QuizSession, QuizUsedQuestion, QuizUserStat, UserStat
@@ -55,8 +55,8 @@ async def get_available_questions_count(session: AsyncSession) -> int:
 def _is_session_stale(quiz_session: QuizSession) -> bool:
     """Проверяет, зависла ли сессия (например, после перезапуска бота)."""
     if quiz_session.question_started_at is None:
-        # Сессия без активного вопроса — зависла между вопросами
-        return True
+        # Новая сессия ещё не стартовала с первым вопросом: это не зависание.
+        return quiz_session.question_number > 0
     now = datetime.now(timezone.utc)
     started = quiz_session.question_started_at
     if started.tzinfo is None:
@@ -271,10 +271,6 @@ async def award_correct_answer_coins(
 async def end_quiz_session(session: AsyncSession, quiz_session: QuizSession) -> None:
     quiz_session.is_active = False
     quiz_session.current_question_id = None
-
-    used_ids = get_used_question_ids(quiz_session)
-    if used_ids:
-        await session.execute(delete(QuizQuestion).where(QuizQuestion.id.in_(used_ids)))
 
 
 async def get_quiz_leaderboard(session: AsyncSession, chat_id: int, limit: int = 5) -> list[QuizUserStat]:

--- a/tests/circuit_breaker/test_circuit_breaker.py
+++ b/tests/circuit_breaker/test_circuit_breaker.py
@@ -1,0 +1,37 @@
+"""Почему: проверяем отказоустойчивость AI-провайдера при ошибках сети/таймаутах."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from app.services.ai_module import OpenRouterProvider
+
+
+def test_assistant_reply_falls_back_on_timeout(monkeypatch) -> None:
+    provider = OpenRouterProvider()
+
+    async def _timeout(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise httpx.ReadTimeout("timeout")
+
+    monkeypatch.setattr(provider._client, "post", _timeout)
+    reply = asyncio.run(provider.assistant_reply("как проехать через шлагбаум?", [], chat_id=1))
+    assert isinstance(reply, str)
+    assert len(reply.strip()) > 0
+    asyncio.run(provider.aclose())
+
+
+def test_assistant_reply_falls_back_on_http_error(monkeypatch) -> None:
+    provider = OpenRouterProvider()
+
+    async def _bad_request(*args, **kwargs):  # type: ignore[no-untyped-def]
+        request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+        response = httpx.Response(503, request=request, json={"error": {"message": "unavailable"}})
+        raise httpx.HTTPStatusError("503", request=request, response=response)
+
+    monkeypatch.setattr(provider._client, "post", _bad_request)
+    reply = asyncio.run(provider.assistant_reply("что с парковкой?", [], chat_id=1))
+    assert isinstance(reply, str)
+    assert len(reply.strip()) > 0
+    asyncio.run(provider.aclose())

--- a/tests/datetime_aware/test_datetime_aware.py
+++ b/tests/datetime_aware/test_datetime_aware.py
@@ -1,0 +1,44 @@
+"""Почему: предотвращаем регрессии с naive/aware datetime в викторине."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models import QuizSession
+from app.services.quiz import QUIZ_STALE_SESSION_SEC, _is_session_stale
+from app.utils.time import ensure_aware
+
+
+def test_ensure_aware_adds_utc_to_naive() -> None:
+    naive = datetime(2024, 1, 1, 12, 0, 0)
+    aware = ensure_aware(naive)
+    assert aware.tzinfo == timezone.utc
+
+
+def test_ensure_aware_keeps_aware() -> None:
+    aware_dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert ensure_aware(aware_dt) == aware_dt
+
+
+def test_is_session_stale_with_naive_datetime() -> None:
+    session = QuizSession(chat_id=1, topic_id=1, is_active=True, question_number=1)
+    session.question_started_at = datetime(2024, 1, 1, 12, 0, 0)
+    assert _is_session_stale(session) is True
+
+
+def test_is_session_stale_none_started_at_after_questions() -> None:
+    session = QuizSession(chat_id=1, topic_id=1, is_active=True, question_number=3)
+    session.question_started_at = None
+    assert _is_session_stale(session) is True
+
+
+def test_is_session_stale_none_started_at_initial_session() -> None:
+    session = QuizSession(chat_id=1, topic_id=1, is_active=True, question_number=0)
+    session.question_started_at = None
+    assert _is_session_stale(session) is False
+
+
+def test_is_session_stale_old_aware_datetime() -> None:
+    session = QuizSession(chat_id=1, topic_id=1, is_active=True, question_number=1)
+    session.question_started_at = datetime.now(timezone.utc) - timedelta(seconds=QUIZ_STALE_SESSION_SEC + 60)
+    assert _is_session_stale(session) is True

--- a/tests/moderation_dedup/test_moderation_dedup.py
+++ b/tests/moderation_dedup/test_moderation_dedup.py
@@ -1,0 +1,76 @@
+"""Почему: защищаемся от повторной модерации одного и того же message_id."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import asyncio
+
+from app.handlers import moderation
+
+
+@pytest.fixture(autouse=True)
+def clear_moderated_cache() -> None:
+    """Очищаем in-memory кеш dedup перед/после теста."""
+    moderation._MODERATED_MSG_IDS.clear()
+    yield
+    moderation._MODERATED_MSG_IDS.clear()
+
+
+def _build_message(message_id: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        chat=SimpleNamespace(id=12345),
+        from_user=SimpleNamespace(id=777, mention_html=lambda: "@u"),
+        text="обычное сообщение",
+        message_id=message_id,
+        message_thread_id=99,
+        delete=AsyncMock(),
+    )
+
+
+def test_second_call_with_same_message_id_is_skipped(monkeypatch) -> None:
+    """Повторная модерация того же message_id не должна доходить до AI."""
+    monkeypatch.setattr(moderation.settings, "forum_chat_id", 12345)
+    monkeypatch.setattr(moderation, "is_admin", AsyncMock(return_value=False))
+    monkeypatch.setattr(moderation, "contains_forbidden_link", lambda _: False)
+    monkeypatch.setattr(moderation, "_get_topic_context", AsyncMock(return_value=[]))
+    monkeypatch.setattr(moderation, "_store_message_log", AsyncMock())
+    monkeypatch.setattr(moderation, "_check_flood", AsyncMock(return_value=False))
+
+    ai_moderate = AsyncMock(return_value=SimpleNamespace(severity=0, sentiment="neutral"))
+    monkeypatch.setattr(moderation, "get_ai_client", lambda: SimpleNamespace(moderate=ai_moderate))
+    monkeypatch.setattr(moderation.settings, "ai_feature_moderation", True)
+
+    bot = AsyncMock()
+    message = _build_message(message_id=1001)
+
+    first = asyncio.run(moderation.run_moderation(message, bot))
+    second = asyncio.run(moderation.run_moderation(message, bot))
+
+    assert first is False
+    assert second is False
+    assert ai_moderate.await_count == 1
+
+
+def test_dedup_cache_is_trimmed_when_overflow(monkeypatch) -> None:
+    """При переполнении кеш сокращается, чтобы не расти бесконечно."""
+    monkeypatch.setattr(moderation.settings, "forum_chat_id", 12345)
+    monkeypatch.setattr(moderation, "is_admin", AsyncMock(return_value=False))
+    monkeypatch.setattr(moderation, "contains_forbidden_link", lambda _: False)
+    monkeypatch.setattr(moderation, "_get_topic_context", AsyncMock(return_value=[]))
+    monkeypatch.setattr(moderation, "_store_message_log", AsyncMock())
+    monkeypatch.setattr(moderation, "_check_flood", AsyncMock(return_value=False))
+
+    ai_moderate = AsyncMock(return_value=SimpleNamespace(severity=0, sentiment="neutral"))
+    monkeypatch.setattr(moderation, "get_ai_client", lambda: SimpleNamespace(moderate=ai_moderate))
+    monkeypatch.setattr(moderation.settings, "ai_feature_moderation", True)
+
+    moderation._MODERATED_MSG_IDS.update(range(1, moderation._MODERATED_MSG_IDS_MAX + 2))
+    before = len(moderation._MODERATED_MSG_IDS)
+
+    asyncio.run(moderation.run_moderation(_build_message(message_id=999999), AsyncMock()))
+
+    assert before > moderation._MODERATED_MSG_IDS_MAX
+    assert len(moderation._MODERATED_MSG_IDS) <= moderation._MODERATED_MSG_IDS_MAX // 2 + 2

--- a/tests/quiz_fix/test_quiz_fix.py
+++ b/tests/quiz_fix/test_quiz_fix.py
@@ -1,0 +1,47 @@
+"""Почему: защищаем вопросы викторины от удаления при завершении сессии."""
+
+from __future__ import annotations
+
+import asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.models import QuizQuestion, QuizUsedQuestion
+from app.services.quiz import end_quiz_session, get_random_question, set_current_question, start_quiz_session
+
+
+def test_end_quiz_session_does_not_delete_questions() -> None:
+
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with session_factory() as session:
+            session.add_all([QuizQuestion(question=f"Вопрос {i}", answer=f"Ответ {i}") for i in range(1, 4)])
+            await session.commit()
+
+            quiz_session = await start_quiz_session(session, chat_id=1, topic_id=1)
+            await session.commit()
+
+            for _ in range(3):
+                q = await get_random_question(session, quiz_session)
+                assert q is not None
+                await set_current_question(session, quiz_session, q)
+                await session.commit()
+
+            await end_quiz_session(session, quiz_session)
+            await session.commit()
+
+            remaining_questions = (await session.execute(select(QuizQuestion))).scalars().all()
+            assert len(remaining_questions) == 3
+
+            used_rows = (await session.execute(select(QuizUsedQuestion))).scalars().all()
+            assert len(used_rows) >= 1
+
+        await engine.dispose()
+
+    asyncio.run(_run())

--- a/tests/quiz_lock/test_quiz_lock.py
+++ b/tests/quiz_lock/test_quiz_lock.py
@@ -1,0 +1,65 @@
+"""Почему: фиксируем lock-поведение викторины через запрет второй активной сессии."""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.models import QuizQuestion
+from app.services.quiz import QUIZ_QUESTIONS_COUNT, can_start_quiz, start_quiz_session
+
+
+def test_cannot_start_second_active_session_same_chat_topic() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with session_factory() as session:
+            session.add_all([
+                QuizQuestion(question=f"Q{i}", answer=f"A{i}")
+                for i in range(1, QUIZ_QUESTIONS_COUNT + 2)
+            ])
+            await session.commit()
+
+            await start_quiz_session(session, chat_id=1, topic_id=10)
+            await session.commit()
+
+            allowed, reason = await can_start_quiz(session, chat_id=1, topic_id=10)
+            assert allowed is False
+            assert "уже запущена" in reason
+
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_sessions_independent_for_different_topics() -> None:
+    async def _run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with session_factory() as session:
+            session.add_all([
+                QuizQuestion(question=f"Q{i}", answer=f"A{i}")
+                for i in range(1, QUIZ_QUESTIONS_COUNT + 2)
+            ])
+            await session.commit()
+
+            await start_quiz_session(session, chat_id=1, topic_id=10)
+            await session.commit()
+
+            allowed, reason = await can_start_quiz(session, chat_id=1, topic_id=11)
+            assert allowed is True
+            assert reason == ""
+
+        await engine.dispose()
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Восстановить удалённые тесты, которые защищают ключевые подсистемы от регрессий (модерация, викторина, таймзоны, отказоустойчивость AI). 
- Сделать эти тесты обязательным шагом проверки перед слиянием в `main` для раннего обнаружения критических регрессий.

### Description
- Вернул набор тестов и сгруппировал их по подсистемам в отдельные каталоги: `tests/moderation_dedup/`, `tests/quiz_fix/`, `tests/quiz_lock/`, `tests/datetime_aware/`, `tests/circuit_breaker/` и добавил соответствующие файлы тестов. 
- Минимально адаптировал тесты к текущему API, сохранив исходную семантику проверок (замены async-маркеров на запуск через `asyncio.run` в окружении тестов, мокирование AI/DB-зависимостей там, где нужно). 
- Исправил поведение сервиса викторины в `app/services/quiz.py`: `end_quiz_session` больше не удаляет строки из `QuizQuestion`, и `_is_session_stale` не считает новую сессию (когда `question_started_at is None` и `question_number == 0`) зависшей; также убран неиспользуемый `delete` импорт. 
- Добавлен workflow CI `.github/workflows/quality-gate.yml`, который запускается на `pull_request` в `main` и выполняет критический набор тестов как обязательный quality gate.

### Testing
- Локально прогонял целевой набор тестов командой: `pytest -q tests/moderation_dedup/test_moderation_dedup.py tests/quiz_fix/test_quiz_fix.py tests/quiz_lock/test_quiz_lock.py tests/datetime_aware/test_datetime_aware.py tests/circuit_breaker/test_circuit_breaker.py`, результат: `13 passed`.
- CI-проверка добавлена в виде workflow, который будет запускать те же тесты при `pull_request` в `main`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da13c445c4832683b720bea5e4df07)