### PR TITLE
Fail-safe обёртка для критичных Telegram-вызовов в модерации

### DIFF
--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -6,6 +6,7 @@ import json
 import logging
 import random
 from datetime import datetime, timedelta, timezone
+from typing import Awaitable, Callable, TypeVar
 
 from aiogram import Bot, F, Router
 from aiogram.filters import Command, StateFilter
@@ -73,16 +74,47 @@ _HARD_WARNINGS = (
     "это {count}-е предупреждение из 3. Правила действуют для всех.",
 )
 
+_T = TypeVar("_T")
+
+
+async def _safe_tg_call(
+    action: str,
+    operation: Callable[[], Awaitable[_T]],
+    *,
+    chat_id: int | None,
+    user_id: int | None,
+    message_id: int | None,
+    fallback: _T | None = None,
+) -> _T | None:
+    """Почему: Telegram API может быть нестабилен, модерация не должна падать целиком."""
+    try:
+        return await operation()
+    except Exception:
+        logger.exception(
+            "Telegram call failed: action=%s chat_id=%s user_id=%s message_id=%s",
+            action,
+            chat_id,
+            user_id,
+            message_id,
+        )
+        return fallback
+
 
 async def _warn_user(message: Message, text: str, bot: Bot) -> None:
     if message.from_user is None:
         return
     mention = message.from_user.mention_html()
-    await bot.send_message(
-        message.chat.id,
-        f"{mention}, {text}",
-        parse_mode="HTML",
-        message_thread_id=message.message_thread_id,
+    await _safe_tg_call(
+        "warn_user",
+        lambda: bot.send_message(
+            message.chat.id,
+            f"{mention}, {text}",
+            parse_mode="HTML",
+            message_thread_id=message.message_thread_id,
+        ),
+        chat_id=message.chat.id,
+        user_id=message.from_user.id,
+        message_id=message.message_id,
     )
 
 
@@ -196,7 +228,13 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
 
     # Проверка запрещённых ссылок (до AI)
     if contains_forbidden_link(text):
-        await message.delete()
+        await _safe_tg_call(
+            "delete_forbidden_link",
+            message.delete,
+            chat_id=chat_id,
+            user_id=user_id,
+            message_id=message.message_id,
+        )
         await _warn_user(message, "ссылки разрешены только в формате Telegram.", bot)
         await _store_mod_event(chat_id, user_id, "delete", 1, message_id=message.message_id)
         return True
@@ -262,7 +300,16 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
 
     # L3: удаление + счётчик +1 + немедленный мут + уведомление админа
     if severity >= 3:
-        await message.delete()
+        deleted = bool(
+            await _safe_tg_call(
+                "delete_l3_message",
+                message.delete,
+                chat_id=chat_id,
+                user_id=user_id,
+                message_id=message.message_id,
+                fallback=False,
+            )
+        )
         async for session in get_session():
             strike_count = await add_strike(session, user_id, settings.forum_chat_id)
             await session.commit()
@@ -273,13 +320,24 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
         # Немедленный мут 24ч
         until = datetime.now(timezone.utc) + timedelta(hours=24)
         permissions = ChatPermissions(can_send_messages=False)
-        await bot.restrict_chat_member(
-            settings.forum_chat_id,
-            user_id,
-            permissions=permissions,
-            until_date=until,
+        await _safe_tg_call(
+            "restrict_l3_user",
+            lambda: bot.restrict_chat_member(
+                settings.forum_chat_id,
+                user_id,
+                permissions=permissions,
+                until_date=until,
+            ),
+            chat_id=chat_id,
+            user_id=user_id,
+            message_id=message.message_id,
         )
-        await _warn_user(message, "сообщение удалено, мут на 24 часа за грубое нарушение.", bot)
+        warn_text = (
+            "сообщение удалено, мут на 24 часа за грубое нарушение."
+            if deleted
+            else "не удалось удалить сообщение, но применён мут на 24 часа за грубое нарушение."
+        )
+        await _warn_user(message, warn_text, bot)
         # Уведомление админа
         mention = message.from_user.mention_html()
         admin_text = (
@@ -289,7 +347,13 @@ async def run_moderation(message: Message, bot: Bot) -> bool:
             f"Уверенность: {confidence or 'н/д'}\n"
             f"Текст: {text[:200]}"
         )
-        await bot.send_message(settings.admin_log_chat_id, admin_text, parse_mode="HTML")
+        await _safe_tg_call(
+            "notify_admin_l3",
+            lambda: bot.send_message(settings.admin_log_chat_id, admin_text, parse_mode="HTML"),
+            chat_id=chat_id,
+            user_id=user_id,
+            message_id=message.message_id,
+        )
         await _apply_strike_threshold(bot, message, user_id, strike_count)
         return True
 
@@ -300,20 +364,34 @@ async def _apply_strike_threshold(bot: Bot, message: Message, user_id: int, stri
     """Применяет мут/бан по порогам счётчика предупреждений."""
     if strike_count >= 5:
         # Бан
-        await bot.ban_chat_member(settings.forum_chat_id, user_id)
-        async for session in get_session():
-            await clear_strikes(session, user_id, settings.forum_chat_id)
-            await session.commit()
+        banned = await _safe_tg_call(
+            "ban_by_strike_threshold",
+            lambda: bot.ban_chat_member(settings.forum_chat_id, user_id),
+            chat_id=message.chat.id,
+            user_id=user_id,
+            message_id=message.message_id,
+            fallback=False,
+        )
+        if banned:
+            async for session in get_session():
+                await clear_strikes(session, user_id, settings.forum_chat_id)
+                await session.commit()
         await _warn_user(message, "слишком много нарушений — бан.", bot)
     elif strike_count >= 3:
         # Мут 24ч
         until = datetime.now(timezone.utc) + timedelta(hours=24)
         permissions = ChatPermissions(can_send_messages=False)
-        await bot.restrict_chat_member(
-            settings.forum_chat_id,
-            user_id,
-            permissions=permissions,
-            until_date=until,
+        await _safe_tg_call(
+            "restrict_by_strike_threshold",
+            lambda: bot.restrict_chat_member(
+                settings.forum_chat_id,
+                user_id,
+                permissions=permissions,
+                until_date=until,
+            ),
+            chat_id=message.chat.id,
+            user_id=user_id,
+            message_id=message.message_id,
         )
         await _warn_user(message, "3 предупреждения — пауза в чате на 24 часа.", bot)
 
@@ -342,11 +420,17 @@ async def _check_flood(message: Message, bot: Bot) -> bool:
     mute_minutes = 60 if repeat_within_hour else 15
     until = datetime.now(timezone.utc) + timedelta(minutes=mute_minutes)
     permissions = ChatPermissions(can_send_messages=False)
-    await bot.restrict_chat_member(
-        settings.forum_chat_id,
-        message.from_user.id,
-        permissions=permissions,
-        until_date=until,
+    await _safe_tg_call(
+        "restrict_flood_user",
+        lambda: bot.restrict_chat_member(
+            settings.forum_chat_id,
+            message.from_user.id,
+            permissions=permissions,
+            until_date=until,
+        ),
+        chat_id=message.chat.id,
+        user_id=message.from_user.id,
+        message_id=message.message_id,
     )
     await _warn_user(message, f"слишком частые сообщения. Мут на {mute_minutes} минут.", bot)
     await _store_mod_event(message.chat.id, message.from_user.id, "mute", 2)

--- a/tests/test_moderation_fail_safe.py
+++ b/tests/test_moderation_fail_safe.py
@@ -1,0 +1,156 @@
+"""Почему: критичные Telegram-вызовы в модерации должны быть fail-safe и не ронять сценарий."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from app.handlers import moderation
+
+
+@dataclass
+class _Decision:
+    severity: int
+    violation_type: str | None = "aggression"
+    confidence: float | None = 0.9
+    sentiment: str | None = "negative"
+
+
+class _User:
+    def __init__(self, user_id: int) -> None:
+        self.id = user_id
+
+    def mention_html(self) -> str:
+        return f"<a href='tg://user?id={self.id}'>user</a>"
+
+
+class _Chat:
+    def __init__(self, chat_id: int) -> None:
+        self.id = chat_id
+
+
+class _Message:
+    def __init__(self, *, chat_id: int, user_id: int, message_id: int, text: str) -> None:
+        self.chat = _Chat(chat_id)
+        self.from_user = _User(user_id)
+        self.message_id = message_id
+        self.text = text
+        self.message_thread_id = None
+        self.deleted = False
+
+    async def delete(self) -> bool:
+        self.deleted = True
+        return True
+
+
+class _Session:
+    async def commit(self) -> None:
+        return None
+
+    async def get(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return None
+
+    def add(self, *_args, **_kwargs) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+
+async def _session_gen():
+    yield _Session()
+
+
+class _BotWithFailures:
+    def __init__(self) -> None:
+        self.sent_messages: list[tuple[int, str]] = []
+        self.restrict_calls = 0
+        self.raise_restrict = False
+        self.raise_admin_send = False
+
+    async def send_message(self, chat_id: int, text: str, **_kwargs) -> bool:  # type: ignore[no-untyped-def]
+        if self.raise_admin_send and chat_id == 999_999:
+            raise RuntimeError("admin log unavailable")
+        self.sent_messages.append((chat_id, text))
+        return True
+
+    async def restrict_chat_member(self, *_args, **_kwargs) -> bool:  # type: ignore[no-untyped-def]
+        self.restrict_calls += 1
+        if self.raise_restrict:
+            raise RuntimeError("restrict failed")
+        return True
+
+    async def ban_chat_member(self, *_args, **_kwargs) -> bool:  # type: ignore[no-untyped-def]
+        raise RuntimeError("ban failed")
+
+
+def test_apply_strike_threshold_does_not_crash_on_ban_error(monkeypatch) -> None:
+    message = _Message(chat_id=1, user_id=7, message_id=55, text="x")
+    bot = _BotWithFailures()
+
+    monkeypatch.setattr(moderation, "get_session", _session_gen)
+
+    asyncio.run(moderation._apply_strike_threshold(bot, message, user_id=7, strike_count=5))
+
+    assert any("слишком много нарушений" in text for _, text in bot.sent_messages)
+
+
+def test_check_flood_returns_true_when_restrict_fails(monkeypatch) -> None:
+    message = _Message(chat_id=1, user_id=11, message_id=88, text="flood")
+    bot = _BotWithFailures()
+    bot.raise_restrict = True
+
+    monkeypatch.setattr(moderation, "get_session", _session_gen)
+    monkeypatch.setattr(
+        moderation.FLOOD_TRACKER,
+        "register",
+        lambda *_args, **_kwargs: 11,
+    )
+    stored_events: list[tuple[int, int, str, int]] = []
+
+    async def _store_event(chat_id: int, user_id: int, event_type: str, severity: int, **_kwargs) -> None:
+        stored_events.append((chat_id, user_id, event_type, severity))
+
+    monkeypatch.setattr(moderation, "_store_mod_event", _store_event)
+
+    result = asyncio.run(moderation._check_flood(message, bot))
+
+    assert result is True
+    assert bot.restrict_calls == 1
+    assert stored_events == [(1, 11, "mute", 2)]
+    assert any("слишком частые сообщения" in text for _, text in bot.sent_messages)
+
+
+def test_run_moderation_l3_degrades_when_delete_fails(monkeypatch) -> None:
+    message = _Message(chat_id=1, user_id=42, message_id=101, text="очень грубый текст")
+
+    async def _delete_fail() -> bool:
+        raise RuntimeError("delete failed")
+
+    message.delete = _delete_fail  # type: ignore[method-assign]
+
+    bot = _BotWithFailures()
+    bot.raise_admin_send = True
+
+    monkeypatch.setattr("app.handlers.moderation.settings.forum_chat_id", 1, raising=False)
+    monkeypatch.setattr("app.handlers.moderation.settings.admin_log_chat_id", 999_999, raising=False)
+    monkeypatch.setattr("app.handlers.moderation.settings.ai_feature_moderation", False, raising=False)
+    monkeypatch.setattr(moderation, "is_admin", lambda *_args, **_kwargs: asyncio.sleep(0, result=False))
+    monkeypatch.setattr(moderation, "contains_forbidden_link", lambda _text: False)
+    monkeypatch.setattr(moderation, "_get_topic_context", lambda *_args, **_kwargs: asyncio.sleep(0, result=[]))
+    monkeypatch.setattr(moderation, "_store_message_log", lambda *_args, **_kwargs: asyncio.sleep(0))
+    monkeypatch.setattr(moderation, "_store_mod_event", lambda *_args, **_kwargs: asyncio.sleep(0))
+    monkeypatch.setattr(moderation, "_apply_strike_threshold", lambda *_args, **_kwargs: asyncio.sleep(0))
+    monkeypatch.setattr(moderation, "get_session", _session_gen)
+
+    async def _add_strike(_session, _user_id: int, _chat_id: int) -> int:
+        return 1
+
+    monkeypatch.setattr(moderation, "add_strike", _add_strike)
+    monkeypatch.setattr(
+        "app.services.ai_module.local_moderation",
+        lambda _text: _Decision(severity=3),
+    )
+
+    result = asyncio.run(moderation.run_moderation(message, bot))
+
+    assert result is True
+    assert bot.restrict_calls == 1
+    assert any("не удалось удалить сообщение" in text for _, text in bot.sent_messages)


### PR DESCRIPTION
### Motivation
- Телеграм-API может давать ошибки, и критичные вызовы в модуле модерации не должны приводить к падению всего сценария модерации.
- Нужно логировать контекст ошибок (`chat_id`, `user_id`, `action`, `message_id`) и по возможности продолжать с деградированным действием вместо прерывания процесса.

### Description
- Добавлен единый helper `async def _safe_tg_call(action, operation, *, chat_id, user_id, message_id, fallback=None)` в `app/handlers/moderation.py` для безопасного выполнения Telegram-вызовов с контекстным логированием ошибок.
- Критичные Telegram-вызовы в модерации переведены на использование `@_safe_tg_call`: `send_message` в `_warn_user`, удаление сообщений при `contains_forbidden_link`, операции L3 в `run_moderation` (delete/restrict/admin notify), а также вызовы в `_apply_strike_threshold` и `_check_flood`.
- Для L3 ветки реализована деградация: если удаление сообщения падает, сценарий продолжается (применяется мут/уведомление) и пользователю отправляется предупреждение о деградации действия; очистка страйков после бана выполняется только при успешном бане.
- Добавлен набор unit-тестов `tests/test_moderation_fail_safe.py`, симулирующий падение Telegram-вызовов и проверяющий fail-safe поведение `_apply_strike_threshold`, `_check_flood` и L3 ветки `run_moderation`.

### Testing
- Запущены новые тесты: `pytest -q tests/test_moderation_fail_safe.py` — все тесты прошли (`3 passed`).
- Для проверки совместимости был запущен частичный набор тестов `pytest -q tests/test_moderation_fail_safe.py tests/test_help_ai_context.py`, при котором появились 2 падения в `tests/test_help_ai_context.py`, не связанных с изменениями в модуле модерации (ошибки в других частях тестов).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da13c902148326a2082c2667cb761a)