### PR TITLE
Обработка деградаций при старте: некритичные шаги не валят процесс и логируются

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -872,6 +872,13 @@ async def schedule_jobs(bot: Bot) -> AsyncIOScheduler:
 
 
 async def on_startup(bot: Bot) -> None:
+    startup_degradations: list[str] = []
+
+    def _mark_degradation(step: str, exc: Exception) -> None:
+        reason = f"{type(exc).__name__}: {exc}"
+        startup_degradations.append(f"{step} — {reason}")
+        logger.warning("Нестартовавший некритичный шаг '%s': %s", step, reason)
+
     async def _admin_notifier(text: str) -> None:
         await bot.send_message(settings.admin_log_chat_id, f"⚠️ {text}")
 
@@ -914,12 +921,20 @@ async def on_startup(bot: Bot) -> None:
     await init_db(engine)
     try:
         await cleanup_database()
-    except Exception:  # noqa: BLE001 - не блокируем старт из-за не-критичной очистки
-        logger.exception("Очистка БД при старте завершилась с ошибкой.")
-    # Применяем миграции
-    async for session in get_session():
-        await apply_v11_stats_reset(session)
-    await heartbeat_job(bot)
+    except Exception as exc:  # noqa: BLE001 - не блокируем старт из-за не-критичной очистки
+        _mark_degradation("cleanup_database", exc)
+
+    # Применяем миграции-флаги (некритично)
+    try:
+        async for session in get_session():
+            await apply_v11_stats_reset(session)
+    except Exception as exc:  # noqa: BLE001 - деградация допустима
+        _mark_degradation("apply_v11_stats_reset", exc)
+
+    try:
+        await heartbeat_job(bot)
+    except Exception as exc:  # noqa: BLE001 - деградация допустима
+        _mark_degradation("heartbeat_job", exc)
     if telegram_available:
         # Публичные команды для всех пользователей
         await bot.set_my_commands(
@@ -981,8 +996,8 @@ async def on_startup(bot: Bot) -> None:
     # Проверяем и прогреваем каноническую базу знаний жителей
     try:
         load_resident_kb()
-    except Exception:
-        logger.exception("Не удалось загрузить базу знаний жителей (resident_kb.json).")
+    except Exception as exc:
+        _mark_degradation("load_resident_kb", exc)
 
     # Очистка устаревших и seed инфраструктуры из JSON
     try:
@@ -993,31 +1008,42 @@ async def on_startup(bot: Bot) -> None:
             if purged or seeded:
                 await session.commit()
                 logger.info("Инфраструктура: удалено %s, добавлено %s объектов.", purged, seeded)
-    except Exception:
-        logger.exception("Ошибка seed инфраструктуры.")
+    except Exception as exc:
+        _mark_degradation("seed_places", exc)
 
     # Импорт инфраструктуры из Google Sheets (если настроен сервисный аккаунт)
-    await _sync_places_from_sheets()
+    try:
+        await _sync_places_from_sheets()
+    except Exception as exc:  # noqa: BLE001 - деградация допустима
+        _mark_degradation("_sync_places_from_sheets", exc)
 
     # Возобновляем рулетку, если бот перезагрузился в игровое время
-    await roulette.resume_roulette_if_needed(bot)
+    try:
+        await roulette.resume_roulette_if_needed(bot)
+    except Exception as exc:  # noqa: BLE001 - деградация допустима
+        _mark_degradation("resume_roulette_if_needed", exc)
 
     # Инициализируем AI-клиент и логируем режим работы
-    get_ai_client()
-    if settings.ai_enabled and settings.ai_key:
-        source_note = " (по умолчанию, AI_MODEL не задан)" if settings.ai_model_is_default else ""
-        ai_mode = f"AI: OpenRouter ({settings.ai_model}){source_note}"
-        probe = await get_ai_client().probe()
-        if probe.ok:
-            ai_probe_note = f"API: ✅ доступен ({probe.latency_ms} ms)"
+    try:
+        get_ai_client()
+        if settings.ai_enabled and settings.ai_key:
+            source_note = " (по умолчанию, AI_MODEL не задан)" if settings.ai_model_is_default else ""
+            ai_mode = f"AI: OpenRouter ({settings.ai_model}){source_note}"
+            probe = await get_ai_client().probe()
+            if probe.ok:
+                ai_probe_note = f"API: ✅ доступен ({probe.latency_ms} ms)"
+            else:
+                ai_probe_note = f"API: ❌ недоступен — {probe.details}"
+            logger.info("AI probe: ok=%s details=%s latency_ms=%s", probe.ok, probe.details, probe.latency_ms)
+        elif not settings.ai_enabled:
+            ai_mode = "AI: отключен (AI_ENABLED=false)"
+            ai_probe_note = ""
         else:
-            ai_probe_note = f"API: ❌ недоступен — {probe.details}"
-        logger.info("AI probe: ok=%s details=%s latency_ms=%s", probe.ok, probe.details, probe.latency_ms)
-    elif not settings.ai_enabled:
-        ai_mode = "AI: отключен (AI_ENABLED=false)"
-        ai_probe_note = ""
-    else:
-        ai_mode = "AI: отключен (AI_KEY не задан)"
+            ai_mode = "AI: отключен (AI_KEY не задан)"
+            ai_probe_note = ""
+    except Exception as exc:  # noqa: BLE001 - деградация допустима
+        _mark_degradation("ai_client_probe", exc)
+        ai_mode = "AI: деградация (инициализация не удалась)"
         ai_probe_note = ""
     logger.info("AI модуль: %s", ai_mode)
     if telegram_available:
@@ -1026,6 +1052,9 @@ async def on_startup(bot: Bot) -> None:
             lines.append(tg_probe_note)
         if ai_probe_note:
             lines.append(ai_probe_note)
+        if startup_degradations:
+            lines.append("Деградации запуска:")
+            lines.extend(f"• {degradation}" for degradation in startup_degradations)
         await bot.send_message(settings.admin_log_chat_id, "\n".join(lines))
 
 

--- a/tests/test_startup_stability.py
+++ b/tests/test_startup_stability.py
@@ -91,6 +91,67 @@ def test_on_startup_does_not_crash_when_cleanup_fails(monkeypatch) -> None:
     asyncio.run(_run())
 
 
+def test_on_startup_collects_degradations_for_noncritical_steps(monkeypatch) -> None:
+    async def _run() -> None:
+        bot = AsyncMock()
+
+        class _DummyAiClient:
+            async def probe(self):
+                return type("Probe", (), {"ok": True, "latency_ms": 10, "details": "ok"})()
+
+        class _DummySession:
+            async def commit(self) -> None:
+                return None
+
+        class _DummyResidentKbLoader:
+            def __call__(self) -> None:
+                return None
+
+            def cache_clear(self) -> None:
+                return None
+
+        async def _session_gen():
+            yield _DummySession()
+
+        monkeypatch.setattr("app.main.init_db", AsyncMock())
+        monkeypatch.setattr(
+            "app.main.cleanup_database",
+            AsyncMock(side_effect=RuntimeError("cleanup failed")),
+        )
+        monkeypatch.setattr(
+            "app.main.apply_v11_stats_reset",
+            AsyncMock(side_effect=RuntimeError("flags failed")),
+        )
+        monkeypatch.setattr(
+            "app.main.heartbeat_job",
+            AsyncMock(side_effect=RuntimeError("heartbeat failed")),
+        )
+        monkeypatch.setattr(
+            "app.main._sync_places_from_sheets",
+            AsyncMock(side_effect=RuntimeError("sync failed")),
+        )
+        monkeypatch.setattr(
+            "app.main.roulette.resume_roulette_if_needed",
+            AsyncMock(side_effect=RuntimeError("roulette failed")),
+        )
+        monkeypatch.setattr("app.main.load_resident_kb", _DummyResidentKbLoader())
+        monkeypatch.setattr("app.main.get_session", _session_gen)
+        monkeypatch.setattr("app.main.get_ai_client", lambda: _DummyAiClient())
+        monkeypatch.setattr("app.main.set_ai_admin_notifier", lambda _fn: None)
+
+        await on_startup(bot)
+
+        startup_msg = bot.send_message.await_args_list[-1].args[1]
+        assert "Деградации запуска:" in startup_msg
+        assert "cleanup_database" in startup_msg
+        assert "apply_v11_stats_reset" in startup_msg
+        assert "heartbeat_job" in startup_msg
+        assert "_sync_places_from_sheets" in startup_msg
+        assert "resume_roulette_if_needed" in startup_msg
+
+    asyncio.run(_run())
+
+
 def test_main_does_not_raise_when_polling_network_error(monkeypatch) -> None:
     async def _run() -> None:
         from app import main as main_module


### PR DESCRIPTION
### Motivation
- Сделать запуск приложения устойчивым: критичные операции должны фейлить старт, а некритичные — логироваться и позволять процессу продолжить работу.
- Улучшить наблюдаемость при старте, чтобы админы получали список деградаций с читаемыми причинами.

### Description
- В `app/main.py::on_startup` добавлен накопитель `startup_degradations` и helper `_mark_degradation` для форматированного логирования причин деградаций.
- Для некритичных шагов добавлены отдельные `try/except` с вызовами `_mark_degradation` для `cleanup_database`, `apply_v11_stats_reset`, `heartbeat_job`, `load_resident_kb`, `seed_places`, `_sync_places_from_sheets`, `resume_roulette_if_needed` и инициализации/`probe` AI-клиента (`ai_client_probe`).
- В админ-уведомление о старте добавлен блок `Деградации запуска:` с перечислением шагов и причин, которые не поднялись.
- Добавлен smoke-тест `test_on_startup_collects_degradations_for_noncritical_steps` в `tests/test_startup_stability.py`, имитирующий исключения в некритичных сервисах.

### Testing
- Запущен `pytest -q tests/test_startup_stability.py` и все тесты прошли успешно (`9 passed`).
- Новый тест `test_on_startup_collects_degradations_for_noncritical_steps` подтверждает, что `on_startup` не падает при ошибках некритичных шагов и что админ-уведомление содержит список деградаций.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da13cbfea88326bd6cc1ea82763dc8)