### PR TITLE
Перенести мат-словарь в runtime и подключить /reload_profanity

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -34,13 +34,13 @@ from app.services.ai_module import (
     is_ai_runtime_enabled,
     set_ai_runtime_enabled,
     resolve_provider_mode,
+    reload_profanity_runtime,
 )
 from app.handlers.moderation import is_training_mode, set_training_mode
 from app.services.ai_usage import next_reset_delta
 from app.services.rag import add_rag_message, build_canonical_text, get_rag_count, systematize_rag
 
 from app.services.admin_stats_reset import reset_runtime_statistics
-from app.utils.profanity import load_profanity, load_profanity_exceptions
 
 router = Router()
 logger = logging.getLogger(__name__)
@@ -379,11 +379,12 @@ async def training_off(message: Message, bot: Bot) -> None:
 async def reload_profanity(message: Message, bot: Bot) -> None:
     if not await _ensure_admin(message, bot):
         return
-    words = load_profanity()
-    exceptions = load_profanity_exceptions()
+    runtime_sizes = reload_profanity_runtime()
     await message.reply(
-        "Словари перечитаны с диска. "
-        f"Мат-словарь: {len(words)}, исключения: {len(exceptions)}."
+        "Словари перечитаны и применены в AI runtime. "
+        f"exact: {runtime_sizes['exact']}, "
+        f"prefixes: {runtime_sizes['prefixes']}, "
+        f"exceptions: {runtime_sizes['exceptions']}."
     )
 
 

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -23,6 +23,7 @@ from app.services.ai_usage import add_usage, can_consume_ai, get_usage_stats
 from app.services.faq import get_faq_answer
 from app.services.resident_kb import build_resident_answer, build_resident_context, search_resident_kb
 from app.services.web_search import format_search_context, search_duckduckgo, should_search_web
+from app.utils.profanity import reload_profanity_runtime as reload_profanity_runtime_dict
 from app.utils.time import now_tz
 
 logger = logging.getLogger(__name__)
@@ -620,6 +621,9 @@ class AiProbeResult:
 class AiRuntimeStatus:
     last_error: str | None
     last_error_at: datetime | None
+    profanity_exact_count: int = 0
+    profanity_prefix_count: int = 0
+    profanity_exceptions_count: int = 0
 
 
 @dataclass(slots=True)
@@ -1491,11 +1495,16 @@ def normalize_for_profanity(text: str) -> str:
 
 
 def detect_profanity(normalized: str) -> bool:
-    roots = (
-        "хуй", "пизд", "еб", "бля", "бле", "сук", "муд", "гандон",
-        "нах", "пох", "хер", "хрен", "шалав", "манд", "говн",
-    )
-    return any(root in normalized for root in roots)
+    if not normalized:
+        return False
+
+    if normalized in _PROFANITY_RUNTIME["exceptions"]:
+        return False
+
+    if any(word in normalized for word in _PROFANITY_RUNTIME["exact"]):
+        return True
+
+    return any(normalized.startswith(prefix) or prefix in normalized for prefix in _PROFANITY_RUNTIME["prefixes"])
 
 
 def detect_aggression_level(text: str) -> Literal["low", "high"]:
@@ -2127,6 +2136,22 @@ _AI_RUNTIME_ENABLED: bool = True
 _ADMIN_ALERT_NOTIFIER: Callable[[str], Awaitable[None]] | None = None
 _LAST_ERROR: str | None = None
 _LAST_ERROR_AT: datetime | None = None
+_PROFANITY_RUNTIME: dict[str, set[str]] = {"exact": set(), "prefixes": set(), "exceptions": set()}
+
+
+def reload_profanity_runtime() -> dict[str, int]:
+    """Перезагружает runtime-словарь мата и возвращает применённые размеры."""
+
+    global _PROFANITY_RUNTIME
+    _PROFANITY_RUNTIME = reload_profanity_runtime_dict()
+    return {
+        "exact": len(_PROFANITY_RUNTIME["exact"]),
+        "prefixes": len(_PROFANITY_RUNTIME["prefixes"]),
+        "exceptions": len(_PROFANITY_RUNTIME["exceptions"]),
+    }
+
+
+reload_profanity_runtime()
 
 
 async def _can_use_remote_ai(chat_id: int) -> tuple[bool, str | None]:
@@ -2151,7 +2176,13 @@ async def _add_remote_usage(chat_id: int, tokens: int) -> None:
 
 
 def get_ai_runtime_status() -> AiRuntimeStatus:
-    return AiRuntimeStatus(last_error=_LAST_ERROR, last_error_at=_LAST_ERROR_AT)
+    return AiRuntimeStatus(
+        last_error=_LAST_ERROR,
+        last_error_at=_LAST_ERROR_AT,
+        profanity_exact_count=len(_PROFANITY_RUNTIME["exact"]),
+        profanity_prefix_count=len(_PROFANITY_RUNTIME["prefixes"]),
+        profanity_exceptions_count=len(_PROFANITY_RUNTIME["exceptions"]),
+    )
 
 
 def resolve_provider_mode() -> Literal["remote", "stub"]:

--- a/app/utils/profanity.py
+++ b/app/utils/profanity.py
@@ -3,6 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TypedDict
+
+
+class ProfanityRuntime(TypedDict):
+    exact: set[str]
+    prefixes: set[str]
+    exceptions: set[str]
 
 
 PROFANITY_PATH = Path(__file__).resolve().parent.parent / "data" / "profanity.txt"
@@ -50,3 +57,33 @@ def split_profanity_words(words: set[str]) -> tuple[set[str], set[str]]:
         else:
             exact.add(word)
     return exact, prefixes
+
+
+_PROFANITY_RUNTIME: ProfanityRuntime = {"exact": set(), "prefixes": set(), "exceptions": set()}
+
+
+def build_profanity_runtime(words: set[str], exceptions: set[str]) -> ProfanityRuntime:
+    """Собирает runtime-словарь для быстрых проверок в памяти."""
+
+    exact, prefixes = split_profanity_words(words)
+    return {"exact": exact, "prefixes": prefixes, "exceptions": exceptions}
+
+
+def reload_profanity_runtime() -> ProfanityRuntime:
+    """Перезагружает runtime-словарь с диска и возвращает его."""
+
+    global _PROFANITY_RUNTIME
+    words = load_profanity()
+    exceptions = load_profanity_exceptions()
+    _PROFANITY_RUNTIME = build_profanity_runtime(words, exceptions)
+    return get_profanity_runtime()
+
+
+def get_profanity_runtime() -> ProfanityRuntime:
+    """Возвращает копию runtime-словаря (чтобы не мутировали снаружи)."""
+
+    return {
+        "exact": set(_PROFANITY_RUNTIME["exact"]),
+        "prefixes": set(_PROFANITY_RUNTIME["prefixes"]),
+        "exceptions": set(_PROFANITY_RUNTIME["exceptions"]),
+    }

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -23,6 +23,7 @@ from app.services.ai_module import (
     is_ai_runtime_enabled,
     set_ai_runtime_enabled,
     resolve_provider_mode,
+    reload_profanity_runtime,
 )
 
 
@@ -84,6 +85,27 @@ def test_detects_masked_profanity() -> None:
     normalized = normalize_for_profanity("Да ты б*л_я!")
     assert detect_profanity(normalized)
 
+
+def test_reload_profanity_runtime_changes_detect_behavior(monkeypatch) -> None:
+    from app.services import ai_module
+
+    original_loader = ai_module.reload_profanity_runtime_dict
+    monkeypatch.setattr(
+        "app.services.ai_module.reload_profanity_runtime_dict",
+        lambda: {"exact": {"грубость"}, "prefixes": set(), "exceptions": set()},
+    )
+    reload_profanity_runtime()
+    assert detect_profanity(normalize_for_profanity("Это грубость"))
+
+    monkeypatch.setattr(
+        "app.services.ai_module.reload_profanity_runtime_dict",
+        lambda: {"exact": set(), "prefixes": set(), "exceptions": set()},
+    )
+    reload_profanity_runtime()
+    assert not detect_profanity(normalize_for_profanity("Это грубость"))
+
+    monkeypatch.setattr("app.services.ai_module.reload_profanity_runtime_dict", original_loader)
+    reload_profanity_runtime()
 
 def test_masks_personal_data() -> None:
     masked = mask_personal_data("Иван Иванов, +79991234567, test@example.com")


### PR DESCRIPTION
### Motivation
- Убрать хардкод списка «корней» ненормативной лексики в `ai_module` и позволить динамически загружать/перезагружать словарь с диска для оперативных правок модерации.

### Description
- Добавлен runtime-словарь в `app/utils/profanity.py` с функциями `build_profanity_runtime()`, `reload_profanity_runtime()` и `get_profanity_runtime()`; словарь хранит `exact`, `prefixes` и `exceptions`.
- В `app/services/ai_module.py` убран хардкод `roots` в `detect_profanity()` и логика проверки теперь использует `_PROFANITY_RUNTIME` (учёт точных слов, префиксов и исключений). 
- В `ai_module` добавлен публичный `reload_profanity_runtime()` который перечитывает словарь из `app.utils.profanity` и возвращает фактически применённые размеры (`exact`, `prefixes`, `exceptions`), а также расширён `AiRuntimeStatus` полями с размерами словаря.
- В `app/handlers/admin.py::reload_profanity` вызов обновлён для использования `ai_module.reload_profanity_runtime()` и ответ команды теперь показывает применённые размеры runtime-словаря.
- Добавлен тест `test_reload_profanity_runtime_changes_detect_behavior` в `tests/test_ai_module.py`, который проверяет, что изменение словаря + `reload` реально меняет поведение `detect_profanity()`.

### Testing
- Запущен целевой набор тестов для новой логики: `pytest tests/test_ai_module.py -q -k "reload_profanity_runtime_changes_detect_behavior or detects_masked_profanity_with_latin_and_digits"` — прогоны успешно прошли (2 passed).
- Запущен тест админского RAG бота: `pytest tests/test_admin_rag_bot.py -q` — прошёл успешно (1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da13d22ec08326b5b1e8e7cd7e3b33)