### PR TITLE
Improve docker-compose env extraction: multiple paths, service discovery, and env_file path support

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,10 @@ from pydantic import AliasChoices, Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-SERVER_COMPOSE_PATH = Path("/opt/alexbot/docker-compose.yaml")
+SERVER_COMPOSE_PATHS: tuple[Path, ...] = (
+    Path("/opt/alexbot/docker-compose.yaml"),
+    Path("/opt/alexbot/docker-compose.yml"),
+)
 REQUIRED_ENV_FIELDS: tuple[str, ...] = (
     "BOT_TOKEN",
     "FORUM_CHAT_ID",
@@ -34,7 +37,11 @@ def _resolve_compose_value(raw_value: str) -> str:
 
 def _read_env_file_values(compose_path: Path, env_file_item: str) -> dict[str, str]:
     """Читает переменные из env_file, если файл существует."""
-    env_file_path = (compose_path.parent / env_file_item).resolve()
+    env_file_candidate = Path(env_file_item).expanduser()
+    if env_file_candidate.is_absolute():
+        env_file_path = env_file_candidate.resolve()
+    else:
+        env_file_path = (compose_path.parent / env_file_candidate).resolve()
     if not env_file_path.exists():
         return {}
 
@@ -47,8 +54,8 @@ def _read_env_file_values(compose_path: Path, env_file_item: str) -> dict[str, s
     return result
 
 
-def _extract_compose_bot_env(compose_path: Path) -> dict[str, str]:
-    """Извлекает environment/env_file для сервиса bot из docker-compose.yaml."""
+def _extract_compose_service_env(compose_path: Path, service_name: str) -> dict[str, str]:
+    """Извлекает environment/env_file для указанного сервиса из docker-compose."""
     if not compose_path.exists():
         return {}
 
@@ -67,13 +74,13 @@ def _extract_compose_bot_env(compose_path: Path) -> dict[str, str]:
         if not stripped or stripped.startswith("#"):
             continue
 
-        if stripped == "bot:" and indent == 2:
+        if stripped == f"{service_name}:" and indent == 2:
             in_bot = True
             in_environment = False
             in_env_file = False
             continue
 
-        if in_bot and indent <= 2 and stripped.endswith(":") and stripped != "bot:":
+        if in_bot and indent <= 2 and stripped.endswith(":") and stripped != f"{service_name}:":
             in_bot = False
             in_environment = False
             in_env_file = False
@@ -126,15 +133,66 @@ def _extract_compose_bot_env(compose_path: Path) -> dict[str, str]:
                 continue
 
         if in_env_file and indent == 6 and stripped.startswith("-"):
-            env_file_item = stripped.removeprefix("-").strip().strip("'\"")
-            result.update(_read_env_file_values(compose_path, env_file_item))
+            env_file_item = stripped.removeprefix("-").strip()
+            if env_file_item.startswith("path:"):
+                env_file_path = env_file_item.partition(":")[2].strip().strip("'\"")
+                if env_file_path:
+                    result.update(_read_env_file_values(compose_path, env_file_path))
+                continue
+            env_file_path = env_file_item.strip("'\"")
+            if env_file_path:
+                result.update(_read_env_file_values(compose_path, env_file_path))
 
     return result
 
 
+def _extract_compose_bot_env(compose_path: Path) -> dict[str, str]:
+    """Извлекает env для целевого сервиса бота (bot/alexbot или первого валидного)."""
+    if not compose_path.exists():
+        return {}
+
+    lines = compose_path.read_text(encoding="utf-8").splitlines()
+    services: list[str] = []
+    in_services = False
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped == "services:" and indent == 0:
+            in_services = True
+            continue
+        if in_services and indent == 0 and stripped.endswith(":") and stripped != "services:":
+            in_services = False
+        if in_services and indent == 2 and stripped.endswith(":"):
+            services.append(stripped[:-1].strip())
+
+    preferred = ["bot", "alexbot"]
+    checked: list[str] = []
+    best_match: dict[str, str] = {}
+
+    for service in [*preferred, *services]:
+        if service in checked:
+            continue
+        checked.append(service)
+        env = _extract_compose_service_env(compose_path, service)
+        if not env:
+            continue
+        if all(env.get(field) for field in REQUIRED_ENV_FIELDS):
+            return env
+        if len(env) > len(best_match):
+            best_match = env
+    return best_match
+
+
 def _inject_env_from_server_compose() -> None:
     """Подхватывает env из /opt/alexbot/docker-compose.yaml как источник истины."""
-    compose_env = _extract_compose_bot_env(SERVER_COMPOSE_PATH)
+    compose_env: dict[str, str] = {}
+    for compose_path in SERVER_COMPOSE_PATHS:
+        compose_env = _extract_compose_bot_env(compose_path)
+        if compose_env:
+            break
     for key, value in compose_env.items():
         if not value:
             continue

--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,11 @@ REQUIRED_ENV_FIELDS: tuple[str, ...] = (
 )
 
 
+def _has_required_bot_env(env: dict[str, str]) -> bool:
+    """Проверяет наличие обязательных переменных бота."""
+    return all(env.get(field) for field in REQUIRED_ENV_FIELDS)
+
+
 def _resolve_compose_value(raw_value: str) -> str:
     """Упрощённо резолвит ${VAR} и ${VAR:-default} из docker-compose."""
     value = raw_value.strip().strip("'\"")
@@ -179,7 +184,7 @@ def _extract_compose_bot_env(compose_path: Path) -> dict[str, str]:
         env = _extract_compose_service_env(compose_path, service)
         if not env:
             continue
-        if all(env.get(field) for field in REQUIRED_ENV_FIELDS):
+        if _has_required_bot_env(env):
             return env
         if len(env) > len(best_match):
             best_match = env
@@ -189,10 +194,17 @@ def _extract_compose_bot_env(compose_path: Path) -> dict[str, str]:
 def _inject_env_from_server_compose() -> None:
     """Подхватывает env из /opt/alexbot/docker-compose.yaml как источник истины."""
     compose_env: dict[str, str] = {}
+    fallback_env: dict[str, str] = {}
     for compose_path in SERVER_COMPOSE_PATHS:
         compose_env = _extract_compose_bot_env(compose_path)
-        if compose_env:
+        if not compose_env:
+            continue
+        if _has_required_bot_env(compose_env):
             break
+        if len(compose_env) > len(fallback_env):
+            fallback_env = compose_env
+    if not _has_required_bot_env(compose_env):
+        compose_env = fallback_env
     for key, value in compose_env.items():
         if not value:
             continue

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -188,7 +188,7 @@ def test_inject_env_from_server_compose_keeps_existing_process_env(monkeypatch, 
         encoding="utf-8",
     )
 
-    monkeypatch.setattr("app.config.SERVER_COMPOSE_PATH", compose)
+    monkeypatch.setattr("app.config.SERVER_COMPOSE_PATHS", (compose,))
     monkeypatch.setenv("BOT_TOKEN", "from-env")
     monkeypatch.delenv("FORUM_CHAT_ID", raising=False)
     monkeypatch.delenv("ADMIN_LOG_CHAT_ID", raising=False)
@@ -214,9 +214,108 @@ def test_inject_env_from_server_compose_skips_empty_values(monkeypatch, tmp_path
         encoding="utf-8",
     )
 
-    monkeypatch.setattr("app.config.SERVER_COMPOSE_PATH", compose)
+    monkeypatch.setattr("app.config.SERVER_COMPOSE_PATHS", (compose,))
     monkeypatch.delenv("AI_KEY", raising=False)
 
     _inject_env_from_server_compose()
 
     assert "AI_KEY" not in os.environ
+
+
+def test_inject_env_from_server_compose_fallback_to_yml(monkeypatch, tmp_path) -> None:
+    yaml_path = tmp_path / "docker-compose.yaml"
+    yml_path = tmp_path / "docker-compose.yml"
+    yaml_path.write_text("services: {}\n", encoding="utf-8")
+    yml_path.write_text(
+        """services:
+  bot:
+    image: test
+    environment:
+      - BOT_TOKEN=from-yml
+      - FORUM_CHAT_ID=-100001
+      - ADMIN_LOG_CHAT_ID=-100002
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("app.config.SERVER_COMPOSE_PATHS", (yaml_path, yml_path))
+    monkeypatch.delenv("BOT_TOKEN", raising=False)
+    monkeypatch.delenv("FORUM_CHAT_ID", raising=False)
+    monkeypatch.delenv("ADMIN_LOG_CHAT_ID", raising=False)
+
+    _inject_env_from_server_compose()
+
+    assert os.environ["BOT_TOKEN"] == "from-yml"
+    assert os.environ["FORUM_CHAT_ID"] == "-100001"
+    assert os.environ["ADMIN_LOG_CHAT_ID"] == "-100002"
+
+
+def test_extract_compose_bot_env_from_env_file_path_mapping(tmp_path) -> None:
+    compose = tmp_path / "docker-compose.yaml"
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "BOT_TOKEN=from-path-mapping\nFORUM_CHAT_ID=-100301\nADMIN_LOG_CHAT_ID=-100302\n",
+        encoding="utf-8",
+    )
+    compose.write_text(
+        """services:
+  bot:
+    image: test
+    env_file:
+      - path: .env
+        required: true
+""",
+        encoding="utf-8",
+    )
+
+    env = _extract_compose_bot_env(compose)
+
+    assert env["BOT_TOKEN"] == "from-path-mapping"
+    assert env["FORUM_CHAT_ID"] == "-100301"
+    assert env["ADMIN_LOG_CHAT_ID"] == "-100302"
+
+
+def test_extract_compose_bot_env_supports_alexbot_service_name(tmp_path) -> None:
+    compose = tmp_path / "docker-compose.yaml"
+    compose.write_text(
+        """services:
+  alexbot:
+    image: test
+    environment:
+      - BOT_TOKEN=from-alexbot
+      - FORUM_CHAT_ID=-100901
+      - ADMIN_LOG_CHAT_ID=-100902
+""",
+        encoding="utf-8",
+    )
+
+    env = _extract_compose_bot_env(compose)
+
+    assert env["BOT_TOKEN"] == "from-alexbot"
+    assert env["FORUM_CHAT_ID"] == "-100901"
+    assert env["ADMIN_LOG_CHAT_ID"] == "-100902"
+
+
+def test_extract_compose_bot_env_finds_first_service_with_required_vars(tmp_path) -> None:
+    compose = tmp_path / "docker-compose.yaml"
+    compose.write_text(
+        """services:
+  watchtower:
+    image: containrrr/watchtower
+    environment:
+      - WATCHTOWER_CLEANUP=true
+  resident_bot:
+    image: test
+    environment:
+      - BOT_TOKEN=from-resident-bot
+      - FORUM_CHAT_ID=-100991
+      - ADMIN_LOG_CHAT_ID=-100992
+""",
+        encoding="utf-8",
+    )
+
+    env = _extract_compose_bot_env(compose)
+
+    assert env["BOT_TOKEN"] == "from-resident-bot"
+    assert env["FORUM_CHAT_ID"] == "-100991"
+    assert env["ADMIN_LOG_CHAT_ID"] == "-100992"

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -250,6 +250,44 @@ def test_inject_env_from_server_compose_fallback_to_yml(monkeypatch, tmp_path) -
     assert os.environ["ADMIN_LOG_CHAT_ID"] == "-100002"
 
 
+def test_inject_env_from_server_compose_continues_until_required_vars_found(
+    monkeypatch, tmp_path
+) -> None:
+    yaml_path = tmp_path / "docker-compose.yaml"
+    yml_path = tmp_path / "docker-compose.yml"
+    yaml_path.write_text(
+        """services:
+  watchtower:
+    image: containrrr/watchtower
+    environment:
+      - WATCHTOWER_CLEANUP=true
+""",
+        encoding="utf-8",
+    )
+    yml_path.write_text(
+        """services:
+  bot:
+    image: test
+    environment:
+      - BOT_TOKEN=from-yml-required
+      - FORUM_CHAT_ID=-100111
+      - ADMIN_LOG_CHAT_ID=-100222
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("app.config.SERVER_COMPOSE_PATHS", (yaml_path, yml_path))
+    monkeypatch.delenv("BOT_TOKEN", raising=False)
+    monkeypatch.delenv("FORUM_CHAT_ID", raising=False)
+    monkeypatch.delenv("ADMIN_LOG_CHAT_ID", raising=False)
+
+    _inject_env_from_server_compose()
+
+    assert os.environ["BOT_TOKEN"] == "from-yml-required"
+    assert os.environ["FORUM_CHAT_ID"] == "-100111"
+    assert os.environ["ADMIN_LOG_CHAT_ID"] == "-100222"
+
+
 def test_extract_compose_bot_env_from_env_file_path_mapping(tmp_path) -> None:
     compose = tmp_path / "docker-compose.yaml"
     env_file = tmp_path / ".env"


### PR DESCRIPTION
### Motivation

- Make config extraction more robust by supporting both `docker-compose.yaml` and `docker-compose.yml` and by discovering the correct service to read env vars from instead of assuming a fixed service name.
- Handle env_file entries and absolute/expanded file paths in compose to properly load environment variables referenced by docker-compose.

### Description

- Replace `SERVER_COMPOSE_PATH` with `SERVER_COMPOSE_PATHS` and iterate over potential compose filenames to find the first existing file with usable env values.
- Generalize service extraction with `_extract_compose_service_env(compose_path, service_name)` and add `_extract_compose_bot_env` that discovers services, prefers `bot` and `alexbot`, and selects the best match containing required fields.
- Improve `_read_env_file_values` to expand `~`, accept absolute paths, and support `env_file` entries that use `path:` mapping or plain filenames.
- Update compose parsing logic to handle different `env_file` syntaxes and compose placeholder resolution, and update tests accordingly while adding new tests for `.yml` fallback, `path:` mapping, `alexbot` service name, and selecting the first valid service.

### Testing

- Ran the config tests via `pytest tests/test_config_settings.py` which exercise compose parsing and env injection behavior and all tests passed.
- Ran the full test suite with `pytest` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da18007aa883269c33b7260034fb70)