### PR TITLE
Ускорить старт бота и сократить задержки AI-ответов

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,8 @@ AI_KEY=
 OPENROUTER_API_KEY=
 AI_API_KEY=
 AI_MODEL=anthropic/claude-haiku-4.5
-AI_TIMEOUT_SECONDS=20
-AI_RETRIES=2
+AI_TIMEOUT_SECONDS=12
+AI_RETRIES=1
 
 # Суточные лимиты AI (по chat_id, по локальной дате TIMEZONE)
 # AI_DAILY_REQUEST_LIMIT: максимум успешных AI-вызовов в сутки

--- a/app/config.py
+++ b/app/config.py
@@ -257,8 +257,8 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("AI_MODEL", "ai_model"),
     )
     ai_max_tokens: int = 800
-    ai_timeout_seconds: int = 20
-    ai_retries: int = 2
+    ai_timeout_seconds: int = 12
+    ai_retries: int = 1
     ai_daily_request_limit: int = 2000
     ai_daily_token_limit: int = 400000
     ai_feature_moderation: bool = True

--- a/app/main.py
+++ b/app/main.py
@@ -165,6 +165,7 @@ class RetryOnFloodSession(AiohttpSession):
 
 
 OFFLINE_THRESHOLD_MIN = 30
+STARTUP_AI_PROBE_TIMEOUT_SECONDS = 5
 
 
 async def init_db(async_engine: AsyncEngine) -> None:
@@ -1069,12 +1070,23 @@ async def on_startup(bot: Bot) -> None:
     if settings.ai_enabled and settings.ai_key:
         source_note = " (по умолчанию, AI_MODEL не задан)" if settings.ai_model_is_default else ""
         ai_mode = f"AI: OpenRouter ({settings.ai_model}){source_note}"
-        probe = await get_ai_client().probe()
-        if probe.ok:
-            ai_probe_note = f"API: ✅ доступен ({probe.latency_ms} ms)"
+        try:
+            probe = await asyncio.wait_for(
+                get_ai_client().probe(),
+                timeout=STARTUP_AI_PROBE_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            ai_probe_note = (
+                "API: ⚠️ проверка превышает лимит старта "
+                f"({STARTUP_AI_PROBE_TIMEOUT_SECONDS} c)"
+            )
+            logger.warning("AI probe timeout on startup after %s seconds.", STARTUP_AI_PROBE_TIMEOUT_SECONDS)
         else:
-            ai_probe_note = f"API: ❌ недоступен — {probe.details}"
-        logger.info("AI probe: ok=%s details=%s latency_ms=%s", probe.ok, probe.details, probe.latency_ms)
+            if probe.ok:
+                ai_probe_note = f"API: ✅ доступен ({probe.latency_ms} ms)"
+            else:
+                ai_probe_note = f"API: ❌ недоступен — {probe.details}"
+            logger.info("AI probe: ok=%s details=%s latency_ms=%s", probe.ok, probe.details, probe.latency_ms)
     elif not settings.ai_enabled:
         ai_mode = "AI: отключен (AI_ENABLED=false)"
         ai_probe_note = ""

--- a/tests/test_startup_stability.py
+++ b/tests/test_startup_stability.py
@@ -182,6 +182,36 @@ def test_on_startup_runs_places_sync_in_background(monkeypatch) -> None:
     asyncio.run(_run())
 
 
+def test_on_startup_limits_ai_probe_time(monkeypatch) -> None:
+    async def _run() -> None:
+        from app import main as main_module
+
+        bot = AsyncMock()
+
+        async def _empty_async_gen():
+            if False:
+                yield
+
+        class SlowClient:
+            async def probe(self):  # type: ignore[no-untyped-def]
+                await asyncio.sleep(0.2)
+                return None
+
+        monkeypatch.setattr(main_module, "STARTUP_AI_PROBE_TIMEOUT_SECONDS", 0.01)
+        monkeypatch.setattr(main_module, "init_db", AsyncMock())
+        monkeypatch.setattr(main_module, "cleanup_database", AsyncMock())
+        monkeypatch.setattr(main_module, "get_session", _empty_async_gen)
+        monkeypatch.setattr(main_module, "heartbeat_job", AsyncMock())
+        monkeypatch.setattr(main_module, "get_ai_client", lambda: SlowClient())
+        monkeypatch.setattr(main_module, "set_ai_admin_notifier", lambda _fn: None)
+        monkeypatch.setattr(main_module.settings, "ai_enabled", True)
+        monkeypatch.setattr(main_module.settings, "ai_key", "test-key")
+
+        await asyncio.wait_for(main_module.on_startup(bot), timeout=0.2)
+
+    asyncio.run(_run())
+
+
 def test_main_does_not_raise_when_polling_api_error(monkeypatch) -> None:
     async def _run() -> None:
         from app import main as main_module


### PR DESCRIPTION
### Motivation
- Уменьшить время старта бота и минимизировать долгие ожидания при недоступном или медленном AI-провайдере.
- Сделать поведение «fail-fast» для AI-вызовов, чтобы медленный probe или длительные ретраи не блокировали основную работу бота.

### Description
- Добавлен лимит `STARTUP_AI_PROBE_TIMEOUT_SECONDS = 5` и оборачивание вызова `get_ai_client().probe()` в `asyncio.wait_for(...)` с обработкой `asyncio.TimeoutError`, чтобы таймаут probe на старте не блокировал запуск и логгировать предупреждение при превышении лимита (`app/main.py`).
- Уменьшены дефолтные AI-параметры для более быстрого отклика: `ai_timeout_seconds` с `20` → `12` и `ai_retries` с `2` → `1` (`app/config.py`).
- Синхронизирован пример окружения: обновлено `.env.example` для новых значений `AI_TIMEOUT_SECONDS` и `AI_RETRIES`.
- Добавлен модульный тест `test_on_startup_limits_ai_probe_time`, который проверяет, что медленный `probe()` не блокирует `on_startup` (`tests/test_startup_stability.py`).

### Testing
- Запущены тесты `pytest -q tests/test_config_settings.py tests/test_startup_stability.py` и получили все успешные прогоны: `26 passed`.
- Проверена сборка и статические правки конфигурации (обновлён `.env.example`) — тесты подтвердили совместимость с изменёнными дефолтами.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db470195588326a6186831dcf9b394)