### PR TITLE
Add startup logging, DB validation, and performance monitoring

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+from logging.handlers import RotatingFileHandler
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -68,6 +69,29 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
+
+
+def _setup_file_logging() -> None:
+    """Добавляет RotatingFileHandler — пишем лог в файл рядом с БД."""
+    log_dir = settings.data_dir
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "bot.log"
+    handler = RotatingFileHandler(
+        log_file,
+        maxBytes=10 * 1024 * 1024,  # 10 МБ на файл
+        backupCount=5,
+        encoding="utf-8",
+    )
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter(
+        fmt="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    ))
+    logging.getLogger().addHandler(handler)
+    logger.info("Файловый лог: %s (ротация 10 МБ × 5 файлов)", log_file)
+
+
+_setup_file_logging()
 
 HEARTBEAT_INTERVAL_MIN = 10
 STOP_FLAG = settings.data_dir / ".stopped"
@@ -334,6 +358,40 @@ async def init_db(async_engine: AsyncEngine) -> None:
 
 
         await conn.run_sync(_ensure_columns)
+
+
+async def validate_db(async_engine: AsyncEngine) -> None:
+    """Проверяет целостность БД и логирует ключевые параметры при старте."""
+    logger.info("=== Проверка БД ===")
+    async with async_engine.begin() as conn:
+        if settings.database_url.startswith("sqlite+"):
+            # Целостность файла
+            rows = (await conn.execute(text("PRAGMA integrity_check"))).fetchall()
+            status = rows[0][0] if rows else "unknown"
+            if status == "ok":
+                logger.info("БД integrity_check: ok")
+            else:
+                details = "; ".join(r[0] for r in rows)
+                logger.error("БД integrity_check ПРОВАЛЕНА: %s", details)
+
+            # Режим журнала (ожидаем WAL)
+            jm = (await conn.execute(text("PRAGMA journal_mode"))).scalar()
+            logger.info("БД journal_mode: %s", jm)
+
+            # Примерный размер
+            page_count = (await conn.execute(text("PRAGMA page_count"))).scalar() or 0
+            page_size = (await conn.execute(text("PRAGMA page_size"))).scalar() or 0
+            db_size_kb = page_count * page_size // 1024
+            logger.info("БД размер: ~%d КБ (%d страниц)", db_size_kb, page_count)
+
+        # Список таблиц
+        def _list_tables(sync_conn: object) -> list[str]:
+            return inspect(sync_conn).get_table_names()
+
+        tables = await conn.run_sync(_list_tables)
+        logger.info("БД таблицы (%d): %s", len(tables), ", ".join(sorted(tables)))
+
+    logger.info("=== Проверка БД завершена ===")
 
 
 async def apply_v11_stats_reset(session: AsyncSession) -> None:
@@ -1004,6 +1062,10 @@ async def on_startup(bot: Bot) -> None:
             "Проверьте DATABASE_URL и права на директорию данных."
         )
         raise
+    try:
+        await validate_db(engine)
+    except Exception:  # noqa: BLE001
+        logger.exception("Ошибка при проверке БД (некритично, продолжаем).")
     try:
         await cleanup_database()
     except Exception:  # noqa: BLE001 - не блокируем старт из-за не-критичной очистки

--- a/app/main.py
+++ b/app/main.py
@@ -1016,6 +1016,10 @@ async def on_startup(bot: Bot) -> None:
     telegram_available = False
     tg_probe_note = ""
     import time as _time
+    _t_startup = _time.monotonic()
+
+    # ── Telegram API probe ────────────────────────────────────────────────────
+    _step_t = _time.monotonic()
     for attempt in range(1, 4):
         try:
             _t0 = _time.monotonic()
@@ -1054,6 +1058,10 @@ async def on_startup(bot: Bot) -> None:
                 len(settings.bot_token),
             )
             break
+    logger.info("⏱ tg_probe: %.2fs", _time.monotonic() - _step_t)
+
+    # ── БД: инициализация ────────────────────────────────────────────────────
+    _step_t = _time.monotonic()
     try:
         await init_db(engine)
     except Exception:
@@ -1062,24 +1070,38 @@ async def on_startup(bot: Bot) -> None:
             "Проверьте DATABASE_URL и права на директорию данных."
         )
         raise
+    logger.info("⏱ init_db: %.2fs", _time.monotonic() - _step_t)
+
+    # ── БД: проверка целостности ─────────────────────────────────────────────
+    _step_t = _time.monotonic()
     try:
         await validate_db(engine)
     except Exception:  # noqa: BLE001
         logger.exception("Ошибка при проверке БД (некритично, продолжаем).")
-    try:
-        await cleanup_database()
-    except Exception:  # noqa: BLE001 - не блокируем старт из-за не-критичной очистки
-        logger.exception("Очистка БД при старте завершилась с ошибкой.")
-    # Применяем миграции
+    logger.info("⏱ validate_db: %.2fs", _time.monotonic() - _step_t)
+
+    # ── БД: очистка старых данных — в фон, не блокируем старт ───────────────
+    _run_background_task(cleanup_database(), name="startup_cleanup_database")
+
+    # ── Миграции ─────────────────────────────────────────────────────────────
+    _step_t = _time.monotonic()
     try:
         async for session in get_session():
             await apply_v11_stats_reset(session)
     except Exception:  # noqa: BLE001
         logger.exception("Не удалось выполнить миграцию v1.1 (некритично, продолжаем).")
+    logger.info("⏱ migrations: %.2fs", _time.monotonic() - _step_t)
+
+    # ── Heartbeat ────────────────────────────────────────────────────────────
+    _step_t = _time.monotonic()
     try:
         await heartbeat_job(bot)
     except Exception:  # noqa: BLE001
         logger.exception("Ошибка heartbeat при старте (некритично, продолжаем).")
+    logger.info("⏱ heartbeat: %.2fs", _time.monotonic() - _step_t)
+
+    # ── Команды бота в меню Telegram ─────────────────────────────────────────
+    _step_t = _time.monotonic()
     if telegram_available:
         # Публичные команды для всех пользователей
         await bot.set_my_commands(
@@ -1116,8 +1138,6 @@ async def on_startup(bot: Bot) -> None:
                     BotCommand(command="reload_profanity", description="Перечитать мат-словари"),
                     BotCommand(command="reset_routing_state", description="Сбросить ожидания роутинга"),
                     BotCommand(command="reset_stats", description="Сбросить статистику"),
-    
-
                     BotCommand(command="form", description="Форма для шлагбаума"),
                     BotCommand(command="text", description="Текст от лица бота"),
                     BotCommand(command="umnij_start", description="Запустить викторину"),
@@ -1132,19 +1152,22 @@ async def on_startup(bot: Bot) -> None:
             )
         except Exception:  # noqa: BLE001 - не блокируем старт, если не удалось зарегистрировать
             logger.warning("Не удалось зарегистрировать админ-команды в Telegram меню.")
-    # Сброс кэшей при старте, чтобы не использовать устаревшие данные
+    logger.info("⏱ set_commands: %.2fs", _time.monotonic() - _step_t)
+
+    # ── Кэши и база знаний ───────────────────────────────────────────────────
+    _step_t = _time.monotonic()
     cleared = clear_assistant_cache()
     if cleared:
         logger.info("Сброшен AI-кэш: %d записей.", cleared)
     load_resident_kb.cache_clear()  # Сброс lru_cache, чтобы подхватить актуальный файл
-
-    # Проверяем и прогреваем каноническую базу знаний жителей
     try:
         load_resident_kb()
     except Exception:
         logger.exception("Не удалось загрузить базу знаний жителей (resident_kb.json).")
+    logger.info("⏱ resident_kb: %.2fs", _time.monotonic() - _step_t)
 
-    # Очистка устаревших и seed инфраструктуры из JSON
+    # ── Seed инфраструктуры из JSON ──────────────────────────────────────────
+    _step_t = _time.monotonic()
     try:
         from scripts.seed_places import purge_old_places, seed_places
         async for session in get_session():
@@ -1155,8 +1178,10 @@ async def on_startup(bot: Bot) -> None:
                 logger.info("Инфраструктура: удалено %s, добавлено %s объектов.", purged, seeded)
     except Exception:
         logger.exception("Ошибка seed инфраструктуры.")
+    logger.info("⏱ seed_places: %.2fs", _time.monotonic() - _step_t)
 
-    # Загрузка вопросов викторины из XLSX (при наличии файла)
+    # ── Вопросы викторины из XLSX ────────────────────────────────────────────
+    _step_t = _time.monotonic()
     try:
         from app.services.quiz_loader import sync_questions_from_xlsx
         async for session in get_session():
@@ -1166,24 +1191,31 @@ async def on_startup(bot: Bot) -> None:
             break
     except Exception:  # noqa: BLE001
         logger.exception("Не удалось загрузить вопросы викторины (некритично, продолжаем).")
+    logger.info("⏱ quiz_loader: %.2fs", _time.monotonic() - _step_t)
 
-    # Импорт инфраструктуры из Google Sheets не должен блокировать запуск polling.
+    # ── Google Sheets — в фон ────────────────────────────────────────────────
     _run_background_task(_sync_places_from_sheets(), name="startup_sync_places")
 
-    # Проверяем пропущенные розыгрыши лотереи
+    # ── Пропущенные лотереи ──────────────────────────────────────────────────
+    _step_t = _time.monotonic()
     try:
         await recover_missed_lottery_draws(bot)
     except Exception:  # noqa: BLE001
         logger.exception("Не удалось провести пропущенные розыгрыши лотереи (некритично, продолжаем).")
+    logger.info("⏱ lottery_recovery: %.2fs", _time.monotonic() - _step_t)
 
-    # Возобновляем рулетку, если бот перезагрузился в игровое время
+    # ── Рулетка ──────────────────────────────────────────────────────────────
+    _step_t = _time.monotonic()
     try:
         await roulette.resume_roulette_if_needed(bot)
     except Exception:  # noqa: BLE001
         logger.exception("Не удалось возобновить рулетку при старте (некритично, продолжаем).")
+    logger.info("⏱ roulette_resume: %.2fs", _time.monotonic() - _step_t)
 
-    # Инициализируем AI-клиент и логируем режим работы
+    # ── AI клиент + probe ────────────────────────────────────────────────────
+    _step_t = _time.monotonic()
     get_ai_client()
+    ai_probe_note = ""
     if settings.ai_enabled and settings.ai_key:
         source_note = " (по умолчанию, AI_MODEL не задан)" if settings.ai_model_is_default else ""
         ai_mode = f"AI: OpenRouter ({settings.ai_model}){source_note}"
@@ -1206,11 +1238,14 @@ async def on_startup(bot: Bot) -> None:
             logger.info("AI probe: ok=%s details=%s latency_ms=%s", probe.ok, probe.details, probe.latency_ms)
     elif not settings.ai_enabled:
         ai_mode = "AI: отключен (AI_ENABLED=false)"
-        ai_probe_note = ""
     else:
         ai_mode = "AI: отключен (AI_KEY не задан)"
-        ai_probe_note = ""
     logger.info("AI модуль: %s", ai_mode)
+    logger.info("⏱ ai_probe: %.2fs", _time.monotonic() - _step_t)
+
+    logger.info("⏱ ИТОГО on_startup: %.2fs", _time.monotonic() - _t_startup)
+
+    # ── Сообщение о запуске ──────────────────────────────────────────────────
     if telegram_available:
         lines = [f"🟢 Бот запущен", f"Версия: {settings.build_version}", ai_mode]
         if tg_probe_note:

--- a/app/services/quiz_loader.py
+++ b/app/services/quiz_loader.py
@@ -8,16 +8,19 @@ from xml.etree import ElementTree
 from zipfile import ZipFile
 
 from aiogram import Bot
-from sqlalchemy import delete
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import QuizQuestion, QuizUsedQuestion
+from app.models import MigrationFlag, QuizQuestion, QuizUsedQuestion
 
 _QUIZ_XLSX_PRIMARY = Path(__file__).resolve().parents[2] / "quiz_questions_normalized.xlsx"
 _QUIZ_XLSX_FALLBACK = Path(__file__).resolve().parents[2] / "viktorinavopros_QA.xlsx"
 QUIZ_XLSX_PATH = _QUIZ_XLSX_PRIMARY if _QUIZ_XLSX_PRIMARY.exists() else _QUIZ_XLSX_FALLBACK
 QUIZ_TEXT_PATH = Path(__file__).resolve().parents[1] / "data" / "quiz_questions.txt"
 _NS = {"x": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+
+# Префикс флага хранит mtime файла; если флаг есть — файл не менялся
+_MTIME_FLAG_PREFIX = "quiz_mtime_"
 
 logger = logging.getLogger(__name__)
 
@@ -91,11 +94,24 @@ async def sync_questions_from_xlsx(session: AsyncSession) -> tuple[int, int]:
     if not QUIZ_XLSX_PATH.exists():
         return 0, 0
 
+    # Пропускаем импорт, если файл не менялся и вопросы уже есть в БД
+    current_mtime = str(int(QUIZ_XLSX_PATH.stat().st_mtime))
+    flag_key = f"{_MTIME_FLAG_PREFIX}{current_mtime}"
+    existing_flag = await session.get(MigrationFlag, flag_key)
+    if existing_flag is not None:
+        count = (await session.execute(select(func.count(QuizQuestion.id)))).scalar() or 0
+        if count > 0:
+            logger.info(
+                "Викторина: XLSX не изменился, пропускаем импорт (%d вопросов в БД).", count
+            )
+            return 0, 0
+
     try:
         source = _read_xlsx_questions(QUIZ_XLSX_PATH)
     except Exception:  # noqa: BLE001 - битый/неполный XLSX не должен валить бота
         logger.exception("Не удалось прочитать XLSX-файл викторины: %s", QUIZ_XLSX_PATH)
         return 0, 0
+
     unique: list[tuple[str, str]] = []
     seen: set[str] = set()
     for question, answer in source:
@@ -105,12 +121,21 @@ async def sync_questions_from_xlsx(session: AsyncSession) -> tuple[int, int]:
         seen.add(normalized)
         unique.append((question, answer))
 
+    # Удаляем старые mtime-флаги этого файла
+    await session.execute(
+        delete(MigrationFlag).where(MigrationFlag.key.like(f"{_MTIME_FLAG_PREFIX}%"))
+    )
+
     await session.execute(delete(QuizQuestion))
     # Сбрасываем список использованных вопросов, чтобы все загруженные
     # вопросы снова стали доступны для викторины
     await session.execute(delete(QuizUsedQuestion))
     for question, answer in unique:
         session.add(QuizQuestion(question=question, answer=answer))
+
+    # Сохраняем флаг текущего mtime — при следующем старте импорт пропустим
+    session.add(MigrationFlag(key=flag_key))
+
     await session.commit()
     return len(source), len(unique)
 

--- a/scripts/seed_places.py
+++ b/scripts/seed_places.py
@@ -65,6 +65,12 @@ async def seed_places(session: AsyncSession) -> int:
     if not data:
         return 0
 
+    # Один запрос вместо N+1: загружаем все существующие ключи разом
+    existing_rows = (
+        await session.execute(select(Place.name, Place.address, Place.category))
+    ).all()
+    existing_keys = {(row.name, row.address, row.category) for row in existing_rows}
+
     added = 0
     for item in data:
         name = item.get("name")
@@ -72,18 +78,7 @@ async def seed_places(session: AsyncSession) -> int:
         category = item.get("category")
         if not all((name, address, category)):
             continue
-
-        existing = (
-            await session.execute(
-                select(Place).where(
-                    Place.name == name,
-                    Place.address == address,
-                    Place.category == category,
-                )
-            )
-        ).scalar_one_or_none()
-
-        if existing is not None:
+        if (name, address, category) in existing_keys:
             continue
 
         place = Place(


### PR DESCRIPTION
## Summary
Enhanced bot startup sequence with comprehensive logging, database integrity validation, and performance timing for each initialization step. Also optimized quiz loader and place seeding with caching and batch queries.

## Key Changes

### Logging & Monitoring
- Added `RotatingFileHandler` for persistent file-based logging (10 MB per file, 5 backups)
- Implemented `validate_db()` function to check SQLite integrity, journal mode, and database size at startup
- Added performance timing for each startup phase (Telegram probe, DB init, migrations, AI probe, etc.)
- Total startup time is now logged for visibility

### Startup Sequence Improvements
- Moved `cleanup_database()` to background task to avoid blocking startup
- Wrapped all non-critical startup operations in try-except with appropriate logging
- Organized startup code with clear section headers for readability
- Added detailed logging for each initialization step with execution time

### Quiz Loader Optimization
- Implemented mtime-based caching: skips XLSX import if file hasn't changed and questions already exist in DB
- Stores migration flag with file modification time to detect changes
- Cleans up old mtime flags before importing new questions
- Reduces unnecessary database operations on repeated startups

### Place Seeding Optimization
- Changed from N+1 queries to single batch query: loads all existing places once instead of checking each item individually
- Uses set-based lookup for O(1) duplicate detection instead of database queries per item

## Implementation Details
- File logging is initialized immediately after logger setup
- Each startup phase is timed independently and logged with `⏱` prefix for easy filtering
- Database validation is non-blocking (exceptions are caught and logged)
- Background tasks use existing `_run_background_task()` helper to avoid startup delays
- Quiz loader caching uses `MigrationFlag` table with `_MTIME_FLAG_PREFIX` convention

https://claude.ai/code/session_01NebZ3hpU38yNXVNjdbXJjE