### PR TITLE
Improve profanity detection with word-level matching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app/ ./app/
 COPY scripts/ ./scripts/
 COPY data/ ./data/
+COPY quiz_questions_normalized.xlsx ./quiz_questions_normalized.xlsx
 
 # Копируем KB и seed в отдельную директорию, чтобы bind mount data/ не перекрывал их
 COPY data/resident_kb.json ./kb/resident_kb.json

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -1489,21 +1489,22 @@ def local_moderation(text: str) -> ModerationDecision:
 def normalize_for_profanity(text: str) -> str:
     lowered = text.lower().replace("ё", "е")
     lowered = lowered.translate(_LATIN_TO_CYR).translate(_DIGIT_TO_CYR)
-    lowered = re.sub(r"[^а-яa-z0-9]+", "", lowered)
-    return lowered
+    lowered = re.sub(r"[^а-яa-z0-9\s]+", "", lowered)
+    return " ".join(lowered.split())
 
 
 def detect_profanity(normalized: str) -> bool:
     if not normalized:
         return False
 
-    if normalized in _PROFANITY_RUNTIME["exceptions"]:
-        return False
-
-    if any(word in normalized for word in _PROFANITY_RUNTIME["exact"]):
-        return True
-
-    return any(normalized.startswith(prefix) or prefix in normalized for prefix in _PROFANITY_RUNTIME["prefixes"])
+    for word in normalized.split():
+        if word in _PROFANITY_RUNTIME["exceptions"]:
+            continue
+        if word in _PROFANITY_RUNTIME["exact"]:
+            return True
+        if any(word.startswith(prefix) for prefix in _PROFANITY_RUNTIME["prefixes"]):
+            return True
+    return False
 
 
 def detect_aggression_level(text: str) -> Literal["low", "high"]:


### PR DESCRIPTION
## Summary
Refactored the profanity detection logic to perform word-level matching instead of substring matching, improving accuracy and reducing false positives.

## Key Changes
- **normalize_for_profanity()**: Modified to preserve whitespace and normalize it to single spaces, enabling word-level analysis
  - Changed regex pattern from `[^а-яa-z0-9]+` to `[^а-яa-z0-9\s]+` to keep spaces
  - Added `" ".join(lowered.split())` to normalize multiple spaces into single spaces

- **detect_profanity()**: Refactored to check profanity rules on individual words rather than the entire normalized string
  - Changed from substring matching (`word in normalized`) to word-level iteration (`for word in normalized.split()`)
  - Exception words are now checked per-word and skipped if matched
  - Exact matches and prefix matches are now evaluated per-word instead of across the entire string
  - This prevents false positives where profanity words appear as substrings within innocent words

- **Dockerfile**: Added `quiz_questions_normalized.xlsx` to the Docker image build context for data availability

## Implementation Details
The refactoring changes the detection strategy from a greedy substring search to a precise word-boundary approach. For example, a word like "классный" (innocent) would no longer trigger a false positive if it contains a profanity substring, since the check now operates on individual words after splitting by whitespace.

https://claude.ai/code/session_01JV6jhU429VSVJKNS9VGVSm