### PR TITLE
Refactor proxy manager: add persistence, SOCKS support, pool management

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -247,9 +247,15 @@ class Settings(BaseSettings):
     timezone: str = "Europe/Moscow"
     build_version: str = "dev"
 
-    # Прокси для доступа к Telegram API (автоматический подбор из GitHub-списков)
+    # Прокси для доступа к Telegram API.
+    # Поддерживается либо автоподбор HTTP/SOCKS-прокси из публичных GitHub-списков,
+    # либо ручной адрес через PROXY_MANUAL (имеет приоритет).
     proxy_enabled: bool = False
     proxy_refresh_interval_min: int = 30
+    proxy_manual: str | None = None  # напр. socks5://user:pass@host:1080
+    proxy_working_pool_size: int = 5
+    proxy_test_limit: int = 500
+    proxy_state_path: str = "data/working_proxies.json"
 
     ai_enabled: bool = True
     ai_api_url: str | None = None

--- a/app/main.py
+++ b/app/main.py
@@ -651,7 +651,7 @@ def _cleanup_flood_tracker() -> None:
 
 async def schedule_jobs(bot: Bot) -> AsyncIOScheduler:
     scheduler = AsyncIOScheduler(timezone=settings.timezone)
-    if settings.proxy_enabled and _proxy_manager is not None:
+    if _proxy_manager is not None:
         scheduler.add_job(
             _proxy_manager.refresh_and_find,
             "interval",
@@ -1130,18 +1130,40 @@ async def main() -> None:
 
     # Инициализация прокси (до создания бота, чтобы сессия сразу получила адрес)
     global _proxy_manager
-    if settings.proxy_enabled:
-        _proxy_manager = ProxyManager()
-        logger.info("Прокси включены, загружаю список…")
-        count = await _proxy_manager.refresh()
-        if count > 0:
-            found = await _proxy_manager.find_working()
-            if not found:
+    if settings.proxy_enabled or settings.proxy_manual:
+        _proxy_manager = ProxyManager(
+            bot_token=settings.bot_token,
+            working_pool_size=settings.proxy_working_pool_size,
+            test_limit=settings.proxy_test_limit,
+            state_path=Path(settings.proxy_state_path),
+            manual_proxy=settings.proxy_manual,
+        )
+        if settings.proxy_manual:
+            logger.info("Прокси: ручной адрес задан, автоподбор пропущен")
+            ok = await _proxy_manager.validate_working_pool()
+            if not ok:
+                logger.warning(
+                    "Ручной прокси не отвечает, всё равно пробуем через него "
+                    "(Telegram может быть временно недоступен для прокси)"
+                )
+        else:
+            logger.info("Прокси включены, ищу рабочие…")
+            # Сначала пробуем прокси, которые уже были рабочими в прошлом запуске
+            if _proxy_manager.count > 0:
+                await _proxy_manager.validate_working_pool()
+            if _proxy_manager.count < settings.proxy_working_pool_size:
+                count = await _proxy_manager.refresh()
+                if count > 0:
+                    await _proxy_manager.find_working()
+            if _proxy_manager.count == 0:
                 logger.warning("Рабочий прокси не найден, работаем без прокси")
                 _proxy_manager = None
-        else:
-            logger.warning("Не удалось загрузить прокси-листы, работаем без прокси")
-            _proxy_manager = None
+            else:
+                logger.info(
+                    "Прокси: в пуле %d рабочих, текущий %s",
+                    _proxy_manager.count,
+                    _proxy_manager.get_current(),
+                )
 
     try:
         bot = Bot(token=settings.bot_token, session=RetryOnFloodSession(proxy_manager=_proxy_manager))

--- a/app/services/proxy.py
+++ b/app/services/proxy.py
@@ -1,142 +1,269 @@
-"""Автоматический подбор и ротация прокси из публичных GitHub-списков."""
+"""Автоподбор рабочих прокси для Telegram Bot API.
+
+Поддерживает HTTP/HTTPS/SOCKS4/SOCKS5 (через aiohttp_socks).
+Хранит пул проверенных рабочих прокси, сохраняет между перезапусками.
+
+ВАЖНО: Telegram Bot API работает по HTTPS, поэтому MTProto-прокси здесь
+не подходят — они только для клиентов Telegram (Telegram app, Pyrogram,
+Telethon).
+"""
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import random
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
 
 import aiohttp
+from aiohttp_socks import ProxyConnector
 
 logger = logging.getLogger(__name__)
 
-# Публичные репозитории с прокси, обновляются каждые 10–30 минут
-_PROXY_SOURCES: tuple[str, ...] = (
-    "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/http.txt",
-    "https://raw.githubusercontent.com/monosans/proxy-list/main/proxies/http.txt",
-    "https://raw.githubusercontent.com/proxifly/free-proxy-list/main/proxies/protocols/http/data.txt",
-    "https://raw.githubusercontent.com/clarketm/proxy-list/master/proxy-list-raw.txt",
-)
 
-_TEST_URL = "https://api.telegram.org"
-_TEST_TIMEOUT = 6.0
+_SOURCES: dict[str, tuple[str, ...]] = {
+    "http": (
+        "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/http.txt",
+        "https://raw.githubusercontent.com/monosans/proxy-list/main/proxies/http.txt",
+        "https://raw.githubusercontent.com/proxifly/free-proxy-list/main/proxies/protocols/http/data.txt",
+        "https://raw.githubusercontent.com/clarketm/proxy-list/master/proxy-list-raw.txt",
+    ),
+    "socks4": (
+        "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/socks4.txt",
+        "https://raw.githubusercontent.com/monosans/proxy-list/main/proxies/socks4.txt",
+        "https://raw.githubusercontent.com/proxifly/free-proxy-list/main/proxies/protocols/socks4/data.txt",
+    ),
+    "socks5": (
+        "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/socks5.txt",
+        "https://raw.githubusercontent.com/monosans/proxy-list/main/proxies/socks5.txt",
+        "https://raw.githubusercontent.com/proxifly/free-proxy-list/main/proxies/protocols/socks5/data.txt",
+    ),
+}
+
 _FETCH_TIMEOUT = 15.0
-_CONCURRENCY = 30
+_TEST_TIMEOUT = 8.0
+_CONCURRENCY = 80
+_SCAN_GLOBAL_TIMEOUT = 90.0
+
+
+def _parse_proxy_line(line: str, scheme: str) -> Optional[str]:
+    """`host:port` или `scheme://host:port` → нормализованный URL."""
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+    if "://" in line:
+        return line
+    if ":" not in line:
+        return None
+    return f"{scheme}://{line}"
+
+
+@dataclass
+class _Pool:
+    working: list[str] = field(default_factory=list)
+    candidates: list[str] = field(default_factory=list)
 
 
 class ProxyManager:
-    """Хранит пул HTTP-прокси, умеет обновлять список и находить рабочий."""
+    """Управляет пулом прокси для Telegram Bot API.
 
-    def __init__(self) -> None:
-        self._proxies: list[str] = []
-        self._index: int = 0
+    Публичный API:
+      - `get_current()` / `rotate()` — отдают прокси из пула рабочих.
+      - `refresh()` — тянет свежий список кандидатов из GitHub.
+      - `find_working()` — пополняет пул рабочих (тестирует кандидатов).
+      - `validate_working_pool()` — выбрасывает из пула отвалившиеся.
+      - `refresh_and_find()` — цикл для планировщика.
+    """
+
+    def __init__(
+        self,
+        *,
+        bot_token: Optional[str] = None,
+        working_pool_size: int = 5,
+        test_limit: int = 500,
+        state_path: Optional[Path] = None,
+        manual_proxy: Optional[str] = None,
+    ) -> None:
+        self._bot_token = bot_token
+        self._pool_size = max(1, working_pool_size)
+        self._test_limit = max(50, test_limit)
+        self._state_path = state_path
+        self._manual_proxy = manual_proxy.strip() if manual_proxy else None
+        self._pool = _Pool()
+        self._index = 0
         self._lock = asyncio.Lock()
+        if self._manual_proxy:
+            logger.info("Прокси: используется ручной адрес из конфига")
+            self._pool.working = [self._manual_proxy]
+        else:
+            self._load_state()
 
     # ------------------------------------------------------------------
     # Публичный API
     # ------------------------------------------------------------------
 
+    def get_current(self) -> Optional[str]:
+        if not self._pool.working:
+            return None
+        return self._pool.working[self._index % len(self._pool.working)]
+
+    def rotate(self) -> Optional[str]:
+        if not self._pool.working:
+            return None
+        self._index = (self._index + 1) % len(self._pool.working)
+        proxy = self._pool.working[self._index]
+        logger.info("Прокси: ротация → %s", proxy)
+        return proxy
+
+    @property
+    def count(self) -> int:
+        return len(self._pool.working)
+
     async def refresh(self) -> int:
-        """Загружает свежие прокси из всех источников. Возвращает кол-во."""
+        if self._manual_proxy:
+            return 0
         collected: set[str] = set()
         timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             tasks = [
-                asyncio.create_task(self._fetch_source(session, url))
-                for url in _PROXY_SOURCES
+                self._fetch_source(session, url, scheme)
+                for scheme, urls in _SOURCES.items()
+                for url in urls
             ]
             results = await asyncio.gather(*tasks, return_exceptions=True)
+        for r in results:
+            if isinstance(r, set):
+                collected |= r
 
-        for res in results:
-            if isinstance(res, set):
-                collected |= res
-
-        proxies = list(collected)
-        random.shuffle(proxies)
+        cands = list(collected)
+        random.shuffle(cands)
         async with self._lock:
-            self._proxies = proxies
-            self._index = 0
+            working_set = set(self._pool.working)
+            self._pool.candidates = [p for p in cands if p not in working_set]
 
-        logger.info("Прокси: загружено %d адресов из %d источников", len(proxies), len(_PROXY_SOURCES))
-        return len(proxies)
+        logger.info(
+            "Прокси: загружено %d кандидатов, в пуле рабочих %d",
+            len(self._pool.candidates),
+            len(self._pool.working),
+        )
+        return len(self._pool.candidates)
 
-    async def find_working(self, max_test: int = 150) -> bool:
-        """Конкурентно проверяет первые max_test прокси, ставит индекс на первый рабочий."""
+    async def validate_working_pool(self) -> int:
+        if self._manual_proxy:
+            ok = await self._test_proxy(self._manual_proxy)
+            if not ok:
+                logger.warning("Прокси: ручной прокси %s не отвечает", self._manual_proxy)
+            return 1 if ok else 0
+
         async with self._lock:
-            candidates = list(enumerate(self._proxies[:max_test]))
+            to_test = list(self._pool.working)
+        if not to_test:
+            return 0
 
+        results = await asyncio.gather(
+            *(self._test_proxy(p) for p in to_test),
+            return_exceptions=True,
+        )
+        alive = [p for p, ok in zip(to_test, results) if ok is True]
+        async with self._lock:
+            self._pool.working = alive
+            if alive and self._index >= len(alive):
+                self._index = 0
+
+        logger.info(
+            "Прокси: ревалидация пула — живых %d/%d", len(alive), len(to_test),
+        )
+        self._save_state()
+        return len(alive)
+
+    async def find_working(self, target: Optional[int] = None) -> int:
+        if self._manual_proxy:
+            return 0
+
+        target = target or self._pool_size
+        async with self._lock:
+            remaining = max(0, target - len(self._pool.working))
+            candidates = self._pool.candidates[: self._test_limit]
+
+        if remaining == 0:
+            return 0
         if not candidates:
-            logger.warning("Прокси: список пуст, нечего проверять")
-            return False
+            logger.warning("Прокси: нет кандидатов для проверки")
+            return 0
 
         sem = asyncio.Semaphore(_CONCURRENCY)
-        found_index: list[Optional[int]] = [None]
-        stop_event = asyncio.Event()
+        found: list[str] = []
+        done = asyncio.Event()
 
-        async def test_one(i: int, proxy: str) -> None:
+        async def worker(proxy: str) -> None:
+            if done.is_set():
+                return
             async with sem:
-                if stop_event.is_set():
+                if done.is_set():
                     return
-                ok = await self._test_proxy(proxy)
-                if ok and not stop_event.is_set():
-                    found_index[0] = i
-                    stop_event.set()
+                if await self._test_proxy(proxy):
+                    if not done.is_set():
+                        found.append(proxy)
+                        if len(found) >= remaining:
+                            done.set()
 
-        tasks = [asyncio.create_task(test_one(i, p)) for i, p in candidates]
+        tasks = [asyncio.create_task(worker(p)) for p in candidates]
+
+        async def cancel_on_done() -> None:
+            await done.wait()
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
+
+        canceller = asyncio.create_task(cancel_on_done())
         try:
             await asyncio.wait_for(
-                asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED),
-                timeout=_TEST_TIMEOUT * 2 + 5,
+                asyncio.gather(*tasks, return_exceptions=True),
+                timeout=_SCAN_GLOBAL_TIMEOUT,
             )
         except asyncio.TimeoutError:
-            pass
+            logger.warning("Прокси: глобальный таймаут поиска (%.0fs)", _SCAN_GLOBAL_TIMEOUT)
         finally:
-            for t in tasks:
-                t.cancel()
-            await asyncio.gather(*tasks, return_exceptions=True)
+            canceller.cancel()
+            await asyncio.gather(canceller, return_exceptions=True)
 
-        idx = found_index[0]
-        if idx is not None:
-            async with self._lock:
-                self._index = idx
-            logger.info("Прокси: рабочий найден — %s", self._proxies[idx])
-            return True
+        async with self._lock:
+            for p in found:
+                if p not in self._pool.working:
+                    self._pool.working.append(p)
+            working_set = set(self._pool.working)
+            self._pool.candidates = [
+                p for p in self._pool.candidates if p not in working_set
+            ]
 
-        logger.warning("Прокси: рабочий не найден среди %d проверенных", len(candidates))
-        return False
-
-    def get_current(self) -> Optional[str]:
-        """Возвращает текущий прокси или None если список пуст."""
-        if not self._proxies:
-            return None
-        return self._proxies[self._index]
-
-    def rotate(self) -> Optional[str]:
-        """Переходит к следующему прокси и возвращает его."""
-        if not self._proxies:
-            return None
-        self._index = (self._index + 1) % len(self._proxies)
-        proxy = self._proxies[self._index]
-        logger.info("Прокси: ротация → %s", proxy)
-        return proxy
+        logger.info(
+            "Прокси: найдено %d новых рабочих (проверено %d), всего в пуле %d",
+            len(found),
+            len(candidates),
+            len(self._pool.working),
+        )
+        self._save_state()
+        return len(found)
 
     async def refresh_and_find(self) -> None:
-        """Обновляет список и ищет рабочий — для вызова из планировщика."""
-        count = await self.refresh()
-        if count > 0:
+        await self.validate_working_pool()
+        if self._manual_proxy:
+            return
+        await self.refresh()
+        if len(self._pool.working) < self._pool_size:
             await self.find_working()
-
-    @property
-    def count(self) -> int:
-        return len(self._proxies)
 
     # ------------------------------------------------------------------
     # Внутренние методы
     # ------------------------------------------------------------------
 
     @staticmethod
-    async def _fetch_source(session: aiohttp.ClientSession, url: str) -> set[str]:
+    async def _fetch_source(
+        session: aiohttp.ClientSession, url: str, scheme: str,
+    ) -> set[str]:
         try:
             async with session.get(url) as resp:
                 if resp.status != 200:
@@ -145,23 +272,67 @@ class ProxyManager:
         except Exception as exc:
             logger.debug("Прокси: не удалось загрузить %s: %s", url, exc)
             return set()
-
-        result: set[str] = set()
+        out: set[str] = set()
         for line in text.splitlines():
-            line = line.strip()
-            if line and ":" in line and not line.startswith("#"):
-                # Принимаем «host:port» и «http://host:port»
-                if not line.startswith("http"):
-                    line = f"http://{line}"
-                result.add(line)
-        return result
+            parsed = _parse_proxy_line(line, scheme)
+            if parsed:
+                out.add(parsed)
+        return out
 
-    @staticmethod
-    async def _test_proxy(proxy: str) -> bool:
+    async def _test_proxy(self, proxy_url: str) -> bool:
+        # getMe с токеном даёт однозначный ответ: 200 — прокси работает и токен валиден;
+        # 401/404 — прокси работает (Telegram ответил). Главное — не exception/5xx.
+        if self._bot_token:
+            url = f"https://api.telegram.org/bot{self._bot_token}/getMe"
+        else:
+            url = "https://api.telegram.org"
         try:
-            timeout = aiohttp.ClientTimeout(total=_TEST_TIMEOUT)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(_TEST_URL, proxy=proxy) as resp:
-                    return resp.status < 500
+            connector = ProxyConnector.from_url(proxy_url)
         except Exception:
             return False
+        timeout = aiohttp.ClientTimeout(total=_TEST_TIMEOUT)
+        try:
+            async with aiohttp.ClientSession(
+                connector=connector, timeout=timeout,
+            ) as session:
+                async with session.get(url) as resp:
+                    return 200 <= resp.status < 500
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
+    # Persistence: живые прокси выживают между перезапусками бота
+    # ------------------------------------------------------------------
+
+    def _load_state(self) -> None:
+        if not self._state_path or not self._state_path.exists():
+            return
+        try:
+            data = json.loads(self._state_path.read_text(encoding="utf-8"))
+            working = data.get("working", [])
+            if isinstance(working, list):
+                self._pool.working = [
+                    str(p) for p in working if isinstance(p, str)
+                ]
+                if self._pool.working:
+                    logger.info(
+                        "Прокси: восстановлено %d рабочих из %s",
+                        len(self._pool.working),
+                        self._state_path,
+                    )
+        except Exception as exc:
+            logger.warning("Прокси: не удалось прочитать state: %s", exc)
+
+    def _save_state(self) -> None:
+        if not self._state_path or self._manual_proxy:
+            return
+        try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = json.dumps(
+                {"working": self._pool.working},
+                ensure_ascii=False,
+                indent=2,
+            )
+            self._state_path.write_text(payload, encoding="utf-8")
+        except Exception as exc:
+            logger.warning("Прокси: не удалось сохранить state: %s", exc)


### PR DESCRIPTION
## Summary
Significantly enhanced the proxy management system to support multiple proxy types (HTTP/HTTPS/SOCKS4/SOCKS5), implement a working proxy pool with persistence across restarts, and add manual proxy configuration. The manager now maintains a pool of verified working proxies rather than just rotating through a single list.

## Key Changes

### Proxy Manager Architecture
- **Pool-based management**: Replaced single proxy list with a `_Pool` dataclass containing `working` (verified proxies) and `candidates` (untested proxies)
- **Persistence**: Added JSON-based state file to preserve working proxies between bot restarts (`_load_state()` / `_save_state()`)
- **Manual proxy support**: Added `manual_proxy` parameter to allow explicit proxy configuration, bypassing auto-discovery
- **Configurable pool size**: New `working_pool_size` parameter to maintain a target number of verified proxies

### Protocol Support
- **Multi-protocol sources**: Expanded `_SOURCES` to include separate lists for HTTP, SOCKS4, and SOCKS5 proxies from GitHub repositories
- **SOCKS support**: Integrated `aiohttp_socks.ProxyConnector` to handle SOCKS4/SOCKS5 proxies alongside HTTP/HTTPS
- **Proxy URL normalization**: Added `_parse_proxy_line()` helper to normalize various proxy formats (host:port, scheme://host:port)

### Testing & Validation
- **Improved proxy testing**: Enhanced `_test_proxy()` to use bot token for more reliable validation (getMe endpoint returns 200 for working proxies, 401/404 if proxy works but token invalid)
- **Pool validation**: New `validate_working_pool()` method to periodically check if proxies in the working pool are still alive
- **Concurrent testing**: Increased `_CONCURRENCY` from 30 to 80 and added global timeout (`_SCAN_GLOBAL_TIMEOUT`) for batch testing
- **Smart candidate limiting**: `find_working()` now respects `test_limit` to avoid overwhelming the system

### API Changes
- `find_working()`: Changed return type from `bool` to `int` (returns count of newly found proxies), added `target` parameter
- `refresh()`: Now returns count of candidates loaded
- `get_current()`: New method to get current proxy without rotating
- `count` property: Returns size of working pool
- `refresh_and_find()`: Refactored to validate existing pool first, then refresh and find if needed

### Configuration
- Added new settings in `config.py`:
  - `proxy_manual`: Optional manual proxy URL (takes precedence over auto-discovery)
  - `proxy_working_pool_size`: Target number of working proxies (default: 5)
  - `proxy_test_limit`: Maximum proxies to test per scan (default: 500)
  - `proxy_state_path`: Path to persistence file (default: data/working_proxies.json)

### Initialization Flow
- Updated `main.py` to initialize ProxyManager with new parameters
- Changed startup logic to validate previously working proxies first, then refresh and find if pool is below target size
- Improved logging to show pool status and current proxy

## Notable Implementation Details
- Uses `asyncio.Semaphore` with early termination when target number of working proxies is found
- Separates candidates from working proxies to avoid re-testing known good proxies
- Handles both manual proxy mode (no auto-discovery) and auto-discovery mode
- Gracefully degrades to no-proxy mode if no working proxies can be found

https://claude.ai/code/session_01PbgQiZUiWHiJ8JMobfvQaK