### PR TITLE
feat: контекстные кнопки под ответами KB (Позвонить/Сайт/Ещё)

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -32,12 +32,22 @@ from app.services.chat_history import (
 )
 from app.services.faq import get_faq_answer, track_question, update_faq_rating
 from app.services.feedback import save_feedback
+from app.services.resident_kb import (
+    get_entries_by_category,
+    search_resident_kb,
+)
 from app.services.resident_profile import (
     parse_extracted_facts,
     update_profile,
 )
 from app.utils.admin import is_admin
 from app.utils.admin_help import ADMIN_HELP
+from app.utils.text import (
+    extract_phones,
+    extract_urls,
+    phone_to_tel_uri,
+    url_to_href,
+)
 
 logger = logging.getLogger(__name__)
 router = Router()
@@ -518,8 +528,12 @@ HELP_DELETE_TASKS: dict[tuple[int, int], asyncio.Task[None]] = {}
 AI_CHAT_HISTORY: dict[tuple[int, int], deque[str]] = {}
 AI_CHAT_HISTORY_LIMIT = 30
 LAST_AI_REPLY_TIME: dict[tuple[int, int], datetime] = {}
-# Кэш промпт→ответ для feedback кнопок (message_id → данные)
-_PENDING_FEEDBACK: dict[int, tuple[int, int, str, str, str]] = {}  # msg_id → (chat_id, user_id, prompt, reply, question_key)
+# Кэш промпт→ответ для feedback кнопок (message_id → данные).
+# Храним category для кнопки «Ещё про …» — лезть за ней в KB из callback данных дороже.
+_PENDING_FEEDBACK: dict[int, tuple[int, int, str, str, str, str]] = {}  # msg_id → (chat_id, user_id, prompt, reply, question_key, category)
+# Порог релевантности KB для включения контекстных кнопок («Ещё про …», телефон, сайт).
+# Ниже порога — KB-ответ слишком слабо связан с вопросом, кнопки только запутают.
+_KB_ACTION_SCORE_THRESHOLD = 0.6
 # Активное окно диалога: (chat_id, user_id, thread_id) → время последнего ответа бота
 # Если пользователь пишет в течение окна — продолжаем разговор без явного упоминания
 _ACTIVE_DIALOG: dict[tuple[int, int, int | None], datetime] = {}
@@ -810,9 +824,64 @@ async def _try_compress_history(chat_id: int, user_id: int) -> None:
         await replace_with_summary(session, chat_id, user_id, old_ids, summary)
 
 
-def _feedback_keyboard(bot_message_id: int) -> InlineKeyboardMarkup:
-    """Создаёт inline-кнопки для оценки ответа ИИ."""
-    return InlineKeyboardMarkup(inline_keyboard=[[
+def _category_label(category: str) -> str:
+    """Возвращает человекочитаемый ярлык категории для кнопки «Ещё про …»."""
+
+    cleaned = (category or "").strip().replace("_", " ")
+    if not cleaned:
+        return ""
+    # Оставляем максимум 16 символов, чтобы кнопка не растягивалась.
+    truncated = cleaned if len(cleaned) <= 16 else cleaned[:15].rstrip() + "…"
+    return truncated
+
+
+def _build_kb_action_keyboard(
+    bot_message_id: int,
+    *,
+    reply_text: str,
+    category: str,
+) -> InlineKeyboardMarkup:
+    """Строит клавиатуру с контекстными действиями (Позвонить/Сайт/Ещё) и оценкой.
+
+    Если в ответе нет ни телефона, ни сайта, ни подходящей категории —
+    клавиатура сводится к классическим 👍/👎.
+    """
+
+    rows: list[list[InlineKeyboardButton]] = []
+
+    contextual: list[InlineKeyboardButton] = []
+    phones = extract_phones(reply_text)
+    if phones:
+        # Берём первый номер — в сообщении обычно один главный контакт.
+        contextual.append(
+            InlineKeyboardButton(
+                text="\U0001f4de Позвонить",
+                callback_data=f"{FEEDBACK_PREFIX}:call:{bot_message_id}",
+            )
+        )
+
+    urls = extract_urls(reply_text)
+    if urls:
+        contextual.append(
+            InlineKeyboardButton(
+                text="\U0001f310 Сайт",
+                url=url_to_href(urls[0]),
+            )
+        )
+
+    if contextual:
+        rows.append(contextual)
+
+    cat_label = _category_label(category)
+    if cat_label:
+        rows.append([
+            InlineKeyboardButton(
+                text=f"\U0001f4ac Ещё про {cat_label}",
+                callback_data=f"{FEEDBACK_PREFIX}:more:{bot_message_id}",
+            )
+        ])
+
+    rows.append([
         InlineKeyboardButton(
             text="\U0001f44d",
             callback_data=f"{FEEDBACK_PREFIX}:up:{bot_message_id}",
@@ -821,7 +890,29 @@ def _feedback_keyboard(bot_message_id: int) -> InlineKeyboardMarkup:
             text="\U0001f44e",
             callback_data=f"{FEEDBACK_PREFIX}:down:{bot_message_id}",
         ),
-    ]])
+    ])
+
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def _resolve_kb_category(prompt: str, context: list[str] | None = None) -> str:
+    """Определяет канонiческую категорию KB для промпта.
+
+    Пустая строка — нет достаточно уверенного совпадения; контекстные кнопки
+    в этом случае не строятся.
+    """
+
+    try:
+        result = search_resident_kb(prompt, context=context or [], top_k=1)
+    except Exception:  # noqa: BLE001 — KB не должен ломать основной поток
+        logger.debug("KB search failed при определении категории.", exc_info=True)
+        return ""
+    if not result.matches:
+        return ""
+    best = result.matches[0]
+    if best.score < _KB_ACTION_SCORE_THRESHOLD:
+        return ""
+    return best.entry.category or ""
 
 
 def _extract_ai_prompt(message: Message) -> str:
@@ -1174,14 +1265,24 @@ async def ai_command(message: Message) -> None:
         except Exception:
             logger.warning("Не удалось обновить FAQ-трекинг для /ai.")
 
-        # Отправляем ответ с кнопками оценки
-        sent = await message.reply(reply, reply_markup=_feedback_keyboard(0))
-        # Обновляем кнопки с реальным message_id
+        # Определяем категорию KB для контекстных кнопок (Позвонить/Сайт/Ещё про …)
+        kb_category = _resolve_kb_category(prompt, context)
+
+        # Отправляем ответ с кнопками оценки + контекстными действиями
+        sent = await message.reply(
+            reply,
+            reply_markup=_build_kb_action_keyboard(0, reply_text=reply, category=kb_category),
+        )
         _PENDING_FEEDBACK[sent.message_id] = (
             message.chat.id, message.from_user.id, prompt[:1000], reply[:800], question_key,
+            kb_category,
         )
         try:
-            await sent.edit_reply_markup(reply_markup=_feedback_keyboard(sent.message_id))
+            await sent.edit_reply_markup(
+                reply_markup=_build_kb_action_keyboard(
+                    sent.message_id, reply_text=reply, category=kb_category,
+                ),
+            )
         except Exception:
             logger.debug("Не удалось обновить reply_markup фидбэк-кнопок.", exc_info=True)
     except Exception:
@@ -1417,13 +1518,24 @@ async def mention_help(message: Message, bot: Bot) -> None:
             except Exception:
                 logger.warning("Не удалось обновить FAQ-трекинг при упоминании.")
 
-            # Отправляем с кнопками оценки
-            sent = await message.reply(reply, reply_markup=_feedback_keyboard(0))
+            # Определяем категорию KB для контекстных кнопок
+            kb_category = _resolve_kb_category(prompt, context)
+
+            # Отправляем с кнопками оценки + контекстными действиями
+            sent = await message.reply(
+                reply,
+                reply_markup=_build_kb_action_keyboard(0, reply_text=reply, category=kb_category),
+            )
             _PENDING_FEEDBACK[sent.message_id] = (
                 message.chat.id, message.from_user.id, prompt[:1000], reply[:800], question_key,
+                kb_category,
             )
             try:
-                await sent.edit_reply_markup(reply_markup=_feedback_keyboard(sent.message_id))
+                await sent.edit_reply_markup(
+                    reply_markup=_build_kb_action_keyboard(
+                        sent.message_id, reply_text=reply, category=kb_category,
+                    ),
+                )
             except Exception:
                 logger.debug("Не удалось обновить reply_markup фидбэк-кнопок.", exc_info=True)
             # Открываем окно активного диалога: пользователь может продолжить без упоминания
@@ -1460,7 +1572,7 @@ async def mention_help(message: Message, bot: Bot) -> None:
 
 @router.callback_query(F.data.startswith(f"{FEEDBACK_PREFIX}:"))
 async def ai_feedback_callback(callback: CallbackQuery) -> None:
-    """Обработчик кнопок оценки ответа ИИ."""
+    """Обработчик кнопок оценки и контекстных действий под ответом ИИ."""
     if callback.data is None or callback.from_user is None or callback.message is None:
         await callback.answer()
         return
@@ -1470,21 +1582,60 @@ async def ai_feedback_callback(callback: CallbackQuery) -> None:
         await callback.answer()
         return
 
-    direction = parts[1]  # up / down
+    action = parts[1]  # up / down / call / more
     try:
         bot_msg_id = int(parts[2])
     except ValueError:
         await callback.answer()
         return
 
-    rating = 1 if direction == "up" else -1
-
     pending = _PENDING_FEEDBACK.get(bot_msg_id)
     if pending is None:
-        await callback.answer("Оценка уже недоступна.")
+        await callback.answer("Ответ устарел — кнопки недоступны.")
         return
 
-    chat_id, original_user_id, prompt_text, reply_text, question_key = pending
+    chat_id, original_user_id, prompt_text, reply_text, question_key, kb_category = pending
+
+    # Контекстные действия — не трогают БД фидбэка.
+    if action == "call":
+        phones = extract_phones(reply_text)
+        if not phones:
+            await callback.answer("Номер не найден в ответе.", show_alert=False)
+            return
+        shown = "\n".join(phones[:3])
+        await callback.answer(
+            f"Телефон:\n{shown}\n\nНажмите на номер в сообщении, чтобы позвонить.",
+            show_alert=True,
+        )
+        return
+
+    if action == "more":
+        entries = get_entries_by_category(kb_category, limit=5) if kb_category else []
+        # Не показываем запись, дублирующую уже отправленный ответ.
+        filtered = [e for e in entries if e.answer.strip() != reply_text.strip()]
+        if not filtered:
+            await callback.answer("Больше вопросов по теме пока нет.", show_alert=False)
+            return
+        lines = ["Ещё вопросы по теме:"]
+        for e in filtered[:5]:
+            sample = e.question_patterns[0] if e.question_patterns else e.answer[:80]
+            sample = sample.strip().rstrip(".")
+            if len(sample) > 80:
+                sample = sample[:79] + "…"
+            lines.append(f"• {sample}")
+        lines.append("\nСпросите любой из них — я отвечу.")
+        try:
+            await callback.message.reply("\n".join(lines))
+        except Exception:
+            logger.debug("Не удалось отправить список «Ещё про …».", exc_info=True)
+        await callback.answer()
+        return
+
+    if action not in {"up", "down"}:
+        await callback.answer()
+        return
+
+    rating = 1 if action == "up" else -1
 
     # Сохраняем feedback в БД
     try:

--- a/app/services/resident_kb.py
+++ b/app/services/resident_kb.py
@@ -286,6 +286,17 @@ def build_resident_answer(query: str, *, context: list[str] | None = None) -> st
     return "\n\n".join(unique_answers[:2])[:1200]
 
 
+def get_entries_by_category(category: str, *, limit: int = 5) -> list[ResidentKbEntry]:
+    """Возвращает записи KB одной категории, отсортированные по приоритету."""
+
+    if not category:
+        return []
+    normalized = category.lower().strip()
+    matched = [e for e in load_resident_kb() if e.category.lower().strip() == normalized]
+    matched.sort(key=lambda e: (-e.priority, e.id))
+    return matched[:limit]
+
+
 def build_resident_context(query: str, *, context: list[str] | None = None, top_k: int = 6) -> str:
     result = search_resident_kb(query, context=context, top_k=top_k)
     if not result.matches:

--- a/app/utils/text.py
+++ b/app/utils/text.py
@@ -8,6 +8,90 @@ import re
 LINK_PATTERN = re.compile(r"https?://\S+|www\.\S+|t\.me/\S+", re.IGNORECASE)
 MENTION_PATTERN = re.compile(r"@\w{3,}")
 
+# Телефон: +7 (495) 401-60-06 / 8 495 401 60 06 / 8-800-100-20-30.
+_PHONE_PATTERN = re.compile(
+    r"(?:\+7|8)[\s\-\u00a0]*\(?\d{3}\)?[\s\-\u00a0]*\d{3}[\s\-\u00a0]*\d{2}[\s\-\u00a0]*\d{2}"
+)
+# Короткие номера (3-4 цифры): 112, 103, 8-800 уже ловится выше.
+_SHORT_PHONE_PATTERN = re.compile(r"(?<![\w\d])(?:112|101|102|103|104|112)(?![\w\d])")
+
+# URL: http(s)://..., www.foo.ru, а также голые домены вида site.ru/путь.
+_URL_HTTP_PATTERN = re.compile(r"https?://\S+", re.IGNORECASE)
+_URL_WWW_PATTERN = re.compile(r"(?<![\w@])www\.[\w\-.]+\.[a-zа-я]{2,}(?:/\S*)?", re.IGNORECASE)
+_URL_BARE_PATTERN = re.compile(
+    r"(?<![\w@/])(?:[a-z0-9][\w\-]*\.)+(?:ru|com|org|net|su|рф|info|pro|online|store|io)(?:/\S*)?",
+    re.IGNORECASE,
+)
+
+
+def extract_phones(text: str) -> list[str]:
+    """Возвращает уникальные телефонные номера из текста в исходном виде."""
+
+    if not text:
+        return []
+    seen: set[str] = set()
+    found: list[str] = []
+    for match in _PHONE_PATTERN.finditer(text):
+        phone = match.group(0).strip()
+        digits = re.sub(r"\D", "", phone)
+        if digits in seen:
+            continue
+        seen.add(digits)
+        found.append(phone)
+    return found
+
+
+def phone_to_tel_uri(phone: str) -> str:
+    """Нормализует номер до tel:+7XXXXXXXXXX."""
+
+    digits = re.sub(r"\D", "", phone)
+    if not digits:
+        return ""
+    if digits.startswith("8") and len(digits) == 11:
+        digits = "7" + digits[1:]
+    if len(digits) == 10:
+        digits = "7" + digits
+    return f"tel:+{digits}"
+
+
+def extract_urls(text: str) -> list[str]:
+    """Возвращает уникальные URL из текста (http, www, голые домены)."""
+
+    if not text:
+        return []
+    candidates: list[str] = []
+    for pat in (_URL_HTTP_PATTERN, _URL_WWW_PATTERN, _URL_BARE_PATTERN):
+        for match in pat.finditer(text):
+            candidates.append(match.group(0))
+
+    seen: set[str] = set()
+    found: list[str] = []
+    for raw in candidates:
+        cleaned = raw.rstrip(").,;:!?»\"'")
+        if not cleaned:
+            continue
+        key = cleaned.lower().rstrip("/")
+        if key in seen:
+            continue
+        # Отсекаем поглощённые подстроки (голый домен внутри http://домен/).
+        if any(key in other_key for other_key in seen):
+            continue
+        seen.add(key)
+        found.append(cleaned)
+    return found
+
+
+def url_to_href(url: str) -> str:
+    """Добавляет https:// если его не хватает, чтобы Telegram открывал кнопку."""
+
+    if not url:
+        return ""
+    if url.lower().startswith(("http://", "https://")):
+        return url
+    if url.lower().startswith("www."):
+        return "https://" + url
+    return "https://" + url
+
 
 def contains_forbidden_link(text: str) -> bool:
     """Возвращает True, если найден любой линк."""


### PR DESCRIPTION
## Что и зачем

После KB-ответа бота («УК ВЕК: +7 495 401-60-06, сайт ukvek-sity.ru») сейчас под сообщением только 👍/👎. Добавляем контекстные действия «в один тап».

**Что видит житель под ответом:**

```
[📞 Позвонить]   [🌐 Сайт]
[💬 Ещё про ук]
[👍] [👎]
```

Если в ответе нет ни телефона, ни ссылки, ни уверенной KB-категории — клавиатура сводится к 👍/👎 как раньше.

## Изменения

- `app/utils/text.py`: `extract_phones`, `phone_to_tel_uri`, `extract_urls`, `url_to_href`. Регексы покрывают `+7 (495)…`, `8-800-…`, голые домены (`ukvek-sity.ru`) и полноценные URL.
- `app/services/resident_kb.py`: `get_entries_by_category(category, limit)` — топ записей одной категории, сортированный по `priority`.
- `app/handlers/help.py`:
  - `_build_kb_action_keyboard(msg_id, reply_text, category)` — строит все 3 возможных ряда.
  - `_resolve_kb_category(prompt, context)` — вытаскивает категорию из `search_resident_kb`, порог `score ≥ 0.6`, чтобы не пристёгивать кнопки к нерелевантным ответам (например, чистые приветствия).
  - В `_PENDING_FEEDBACK` добавлено поле `category` (нужно для `more`, чтобы не раздувать `callback_data` до 64-байтного лимита).
  - Callback-обработчик `ai_feedback_callback` диспатчит `call` и `more` (поверх существующих `up`/`down`):
    - `call` — `answerCallbackQuery(show_alert=True)` с найденными номерами. Telegram не поддерживает `tel:` в inline-кнопках, поэтому показываем номер и напоминаем, что номер в самом сообщении кликабелен на мобильнике.
    - `more` — постит новое сообщение со списком до 5 смежных вопросов из той же категории (первый `question_pattern` у каждой записи; дубликат уже отправленного ответа исключён).
- Кнопка «Сайт» — честный `InlineKeyboardButton(url=…)`, ведёт в браузер.

## Тесты

- Все существующие: `136 passed, 1 skipped` (142 сек).
- Smoke: извлечение телефонов/URL, построение клавиатуры в полном и вырожденном случае, `_resolve_kb_category` отсеивает «привет как дела», `_category_label('детская_площадка')` → «детская площадка».

## План проверки после мержа

- [ ] `@бот куда писать если сломался шлагбаум` → в ответе видны [📞][🌐][💬 Ещё про шлагбаум][👍][👎].
- [ ] `@бот привет как дела` → только 👍/👎.
- [ ] Тап по `[📞 Позвонить]` показывает номер в alert.
- [ ] Тап по `[🌐 Сайт]` открывает браузер.
- [ ] Тап по `[💬 Ещё про …]` присылает список смежных вопросов.
- [ ] Оценка 👍/👎 по-прежнему сохраняется, клавиатура после оценки пропадает.