### PR TITLE
feat: еженедельные персональные DM-нажъмы по ResidentProfile

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -280,6 +280,11 @@ class Settings(BaseSettings):
     ai_feature_proactive: bool = True
     # Профили жителей: бот запоминает факты о пользователях из диалогов
     ai_feature_profiles: bool = True
+    # Еженедельные персональные косания в DM по фактам из профиля. Off-by-default:
+    # требует, чтобы пользователь ранее писал боту в личку (иначе TelegramForbidden).
+    ai_feature_weekly_nudge: bool = False
+    weekly_nudge_max_per_run: int = 20  # верхний лимит DM за один запуск джобы
+    weekly_nudge_min_days_between: int = 30  # одному пользователю — не чаще раза в N дней
     # Адаптация тона под настроение чата
     ai_feature_mood: bool = True
     # Тихое обучение модерации: бот НЕ модерирует, а отправляет подозрительные

--- a/app/handlers/personalization.py
+++ b/app/handlers/personalization.py
@@ -1,0 +1,86 @@
+"""Почему: дать жителю простой способ отключить/включить еженедельные DM-нажъмы."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+from sqlalchemy import select
+
+from app.db import get_session
+from app.models import ResidentProfile
+
+logger = logging.getLogger(__name__)
+router = Router()
+
+
+def _load_facts(raw: str | None) -> dict:
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+async def _set_nudge_flag(user_id: int, *, opt_out: bool) -> int:
+    """Обновляет nudge_opt_out во всех профилях пользователя. Возвращает число
+    затронутых профилей (обычно 0 или 1, может быть больше при нескольких чатах).
+    """
+
+    touched = 0
+    async for session in get_session():
+        rows = await session.execute(
+            select(ResidentProfile).where(ResidentProfile.user_id == user_id)
+        )
+        for profile in rows.scalars():
+            facts = _load_facts(profile.facts_json)
+            if opt_out:
+                facts["nudge_opt_out"] = True
+            else:
+                facts.pop("nudge_opt_out", None)
+                # Включение опт-ина одновременно сбрасывает unreachable —
+                # житель явно общается с ботом, значит DM работает.
+                facts.pop("nudge_unreachable", None)
+            profile.facts_json = json.dumps(facts, ensure_ascii=False)
+            touched += 1
+        await session.commit()
+        break
+    return touched
+
+
+@router.message(Command("off_nudges"))
+async def off_nudges(message: Message) -> None:
+    if message.from_user is None or message.chat.type != "private":
+        return
+    touched = await _set_nudge_flag(message.from_user.id, opt_out=True)
+    if touched == 0:
+        await message.answer(
+            "Готово: я и так ничего вам персонально не присылал. Если что — пишите в группу."
+        )
+        return
+    await message.answer(
+        "Готово — больше не буду присылать персональные сообщения. "
+        "Если передумаете, напишите /on_nudges."
+    )
+    logger.info("NUDGE_OPT_OUT: user_id=%s profiles=%d", message.from_user.id, touched)
+
+
+@router.message(Command("on_nudges"))
+async def on_nudges(message: Message) -> None:
+    if message.from_user is None or message.chat.type != "private":
+        return
+    touched = await _set_nudge_flag(message.from_user.id, opt_out=False)
+    if touched == 0:
+        await message.answer(
+            "У меня пока нет вашего профиля — напишите что-нибудь в группе, и я начну запоминать."
+        )
+        return
+    await message.answer(
+        "Готово — снова смогу присылать вам редкие персональные подсказки."
+    )
+    logger.info("NUDGE_OPT_IN: user_id=%s profiles=%d", message.from_user.id, touched)

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ from app.handlers import (
     games,
     help as help_handler,
     moderation,
+    personalization as personalization_handler,
     roulette,
     shop,
     text_publish,
@@ -59,6 +60,7 @@ from app.services.ai_module import clear_assistant_cache, close_ai_client, get_a
 from app.services.proxy import ProxyManager
 from app.services.daily_summary import build_ai_summary_context, build_daily_summary, build_response_report, render_daily_summary
 from app.services.daily_messages import send_morning_greeting, send_traffic_report
+from app.services.personalization import send_weekly_nudges
 from app.services.proactive import send_scheduled_greeting, send_weekly_update
 from app.services.resident_kb import load_resident_kb
 
@@ -349,6 +351,17 @@ async def init_db(async_engine: AsyncEngine) -> None:
 
             # Миграция resident_profiles (создаётся через create_all,
             # но проверяем на всякий случай)
+            if inspector.has_table("resident_profiles"):
+                columns = {
+                    column["name"]
+                    for column in inspector.get_columns("resident_profiles")
+                }
+                if "last_nudge_at" not in columns:
+                    sync_conn.execute(
+                        text(
+                            "ALTER TABLE resident_profiles ADD COLUMN last_nudge_at DATETIME"
+                        )
+                    )
 
 
         await conn.run_sync(_ensure_columns)
@@ -739,6 +752,18 @@ async def schedule_jobs(bot: Bot) -> AsyncIOScheduler:
         "cron",
         day_of_week="mon",
         hour=10,
+        minute=0,
+        args=[bot],
+    )
+    # Еженедельные персональные DM-нажъмы (по фактам из ResidentProfile).
+    # Off-by-default через ai_feature_weekly_nudge — внутри функции стоит ранний return.
+    # Вторник 11:00 — середина рабочей недели, не путается с проактивными
+    # утренними/вечерними коммуникациями и понедельничным weekly update.
+    scheduler.add_job(
+        send_weekly_nudges,
+        "cron",
+        day_of_week="tue",
+        hour=11,
         minute=0,
         args=[bot],
     )
@@ -1189,6 +1214,7 @@ async def main() -> None:
     dp.include_router(economy_handler.router)  # инициативы жителей (доработки бота)
     dp.include_router(roulette.router)  # рулетка (команда /bet)
     dp.include_router(text_publish.router)  # отправка текста от лица бота в выбранный топик
+    dp.include_router(personalization_handler.router)  # /off_nudges, /on_nudges (только в DM)
     dp.include_router(moderation.router)  # модерация (catch-all, пропускает FSM)
     # stats.router убран — статистика через middleware
 

--- a/app/models.py
+++ b/app/models.py
@@ -269,6 +269,9 @@ class ResidentProfile(Base):
     chat_id: Mapped[int] = mapped_column(Integer, primary_key=True)
     display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     facts_json: Mapped[str] = mapped_column(Text, default="{}")
+    # Когда боту последний раз отправили еженедельный персональный нажъм. NULL —
+    # ни разу не отправляли. Используется для rate-limit выборки кандидатов.
+    last_nudge_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, index=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc),
     )

--- a/app/services/personalization.py
+++ b/app/services/personalization.py
@@ -1,0 +1,291 @@
+"""Почему: мягкие еженедельные DM-косания по фактам из профиля повышают вовлечённость.
+
+Бот раз в неделю отбирает жителей, у которых уже сохранены релевантные факты
+(интересы, питомцы, машина, дети), и присылает в личку короткое напоминание
+вида «вы интересовались X — спросите, если что». Это не реклама и не спам:
+- off-by-default через feature flag,
+- ограничено N жителями за запуск (по умолчанию 20),
+- не чаще одного DM в 30 дней одному человеку,
+- безболезненный опт-аут командой /off_nudges,
+- если Telegram запрещает DM (житель не писал боту в личку) — помечаем
+  профиль unreachable и больше не пытаемся.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from aiogram import Bot
+from aiogram.exceptions import TelegramForbiddenError, TelegramRetryAfter
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.db import get_session
+from app.models import ResidentProfile
+from app.services.resident_kb import search_resident_kb
+
+logger = logging.getLogger(__name__)
+
+
+# Поля профиля, по которым мы способны сформулировать осмысленный нажъм.
+# Порядок важен — первый найденный определяет тему сообщения.
+_FACT_PRIORITIES = ("interests", "pets", "family", "car")
+
+# Минимальный score из KB, чтобы добавить teaser-строчку из базы знаний.
+# Ниже порога — отправляем нажъм без teaser'а.
+_KB_TEASER_SCORE = 0.5
+
+
+@dataclass(slots=True)
+class NudgeCandidate:
+    user_id: int
+    chat_id: int
+    display_name: str | None
+    facts: dict
+    last_nudge_at: datetime | None
+
+
+def _parse_facts(raw: str | None) -> dict:
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _is_opted_out(facts: dict) -> bool:
+    return bool(facts.get("nudge_opt_out") or facts.get("nudge_unreachable"))
+
+
+def _first_actionable_fact(facts: dict) -> tuple[str, str] | None:
+    """Возвращает (label, value) или None, если ни один факт не годится для нажъса."""
+
+    for key in _FACT_PRIORITIES:
+        value = facts.get(key)
+        if value is None:
+            continue
+        if isinstance(value, list):
+            non_empty = [str(v).strip() for v in value if str(v).strip()]
+            if not non_empty:
+                continue
+            return key, non_empty[0]
+        text_value = str(value).strip()
+        if not text_value:
+            continue
+        # family — нажъм имеет смысл только если упомянут ребёнок/дети.
+        if key == "family" and not any(
+            w in text_value.lower() for w in ("ребён", "ребен", "дети", "малыш", "школьник", "садик")
+        ):
+            continue
+        return key, text_value
+    return None
+
+
+def _kb_teaser(query: str) -> str:
+    """Возвращает короткую первую содержательную строку из лучшего ответа KB.
+
+    Пустая строка — KB ничего уверенного не нашла; нажъм отправим без teaser'а.
+    """
+
+    try:
+        result = search_resident_kb(query, top_k=1)
+    except Exception:  # noqa: BLE001
+        logger.debug("KB search failed для teaser'а нажъса.", exc_info=True)
+        return ""
+    if not result.matches:
+        return ""
+    best = result.matches[0]
+    if best.score < _KB_TEASER_SCORE:
+        return ""
+    for raw_line in best.entry.answer.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        # Пропускаем строки-заголовки/буллеты/контактные иконки — нужен живой текст.
+        if line[0] in {"📞", "🌐", "•", "—", "-", "*", "#", "▪", "▫"}:
+            continue
+        if len(line) < 12:
+            continue
+        return line[:200]
+    return ""
+
+
+def build_nudge_message(facts: dict, *, display_name: str | None = None) -> str | None:
+    """Собирает текст еженедельного нажъса. None — фактов недостаточно."""
+
+    if _is_opted_out(facts):
+        return None
+    fact = _first_actionable_fact(facts)
+    if fact is None:
+        return None
+    _, value = fact
+
+    # Имя берём только до первого пробела (Иван Иванов → Иван), чтобы
+    # обращение не выглядело формально-фамильным.
+    name_part = ""
+    if display_name:
+        first = display_name.strip().split()[0] if display_name.strip() else ""
+        if first and not first.startswith("@"):
+            name_part = f", {first}"
+
+    intros = (
+        "Привет{name}! Помню, вам близка тема «{topic}».",
+        "Привет{name}! Вы как-то спрашивали про «{topic}».",
+        "Привет{name}! Думал тут — кажется, вам интересна тема «{topic}».",
+    )
+    intro = random.choice(intros).format(name=name_part, topic=value[:60])
+
+    teaser = _kb_teaser(value)
+    teaser_block = f"\n\nКстати: {teaser}" if teaser else ""
+
+    outro = (
+        "\n\nЕсли захотите подробнее — спросите меня в группе через @-упоминание "
+        "или прямо здесь, в личке. Чтобы такие сообщения не приходили — пришлите /off_nudges."
+    )
+
+    return (intro + teaser_block + outro)[:1000]
+
+
+async def select_nudge_candidates(
+    session: AsyncSession,
+    *,
+    chat_id: int,
+    limit: int,
+    min_days_between: int,
+) -> list[NudgeCandidate]:
+    """Отбирает жителей для рассылки на этой неделе.
+
+    Сортировка: сначала те, кому вообще не писали (last_nudge_at IS NULL),
+    затем по возрастанию last_nudge_at. Это даёт честный round-robin.
+    """
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=min_days_between)
+    stmt = (
+        select(ResidentProfile)
+        .where(ResidentProfile.chat_id == chat_id)
+        .order_by(ResidentProfile.last_nudge_at.asc().nulls_first(), ResidentProfile.user_id)
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+
+    selected: list[NudgeCandidate] = []
+    for row in rows:
+        last_nudge = row.last_nudge_at
+        # SQLite возвращает datetime без tzinfo — нормализуем для сравнения с cutoff.
+        if last_nudge is not None:
+            if last_nudge.tzinfo is None:
+                last_nudge = last_nudge.replace(tzinfo=timezone.utc)
+            if last_nudge > cutoff:
+                continue
+        facts = _parse_facts(row.facts_json)
+        if _is_opted_out(facts):
+            continue
+        if _first_actionable_fact(facts) is None:
+            continue
+        selected.append(NudgeCandidate(
+            user_id=row.user_id,
+            chat_id=row.chat_id,
+            display_name=row.display_name,
+            facts=facts,
+            last_nudge_at=row.last_nudge_at,
+        ))
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+async def _mark_nudge_attempt(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    chat_id: int,
+    unreachable: bool = False,
+) -> None:
+    """Обновляет last_nudge_at и, при необходимости, помечает профиль как unreachable."""
+
+    profile = await session.get(ResidentProfile, {"user_id": user_id, "chat_id": chat_id})
+    if profile is None:
+        return
+    profile.last_nudge_at = datetime.now(timezone.utc)
+    if unreachable:
+        facts = _parse_facts(profile.facts_json)
+        facts["nudge_unreachable"] = True
+        profile.facts_json = json.dumps(facts, ensure_ascii=False)
+    await session.commit()
+
+
+async def send_weekly_nudges(bot: Bot) -> None:
+    """Точка входа для APScheduler. Безопасна при отключённом feature flag."""
+
+    if not settings.ai_feature_weekly_nudge:
+        logger.info("WEEKLY_NUDGE: пропуск — ai_feature_weekly_nudge=false.")
+        return
+
+    limit = max(1, int(settings.weekly_nudge_max_per_run))
+    min_days = max(1, int(settings.weekly_nudge_min_days_between))
+
+    sent = 0
+    forbidden = 0
+    skipped = 0
+
+    async for session in get_session():
+        candidates = await select_nudge_candidates(
+            session,
+            chat_id=settings.forum_chat_id,
+            limit=limit,
+            min_days_between=min_days,
+        )
+        if not candidates:
+            logger.info("WEEKLY_NUDGE: подходящих кандидатов нет.")
+            break
+
+        logger.info("WEEKLY_NUDGE: отобрано %d кандидатов (limit=%d).", len(candidates), limit)
+
+        for cand in candidates:
+            text = build_nudge_message(cand.facts, display_name=cand.display_name)
+            if text is None:
+                skipped += 1
+                continue
+            try:
+                await bot.send_message(cand.user_id, text)
+                await _mark_nudge_attempt(
+                    session, user_id=cand.user_id, chat_id=cand.chat_id,
+                )
+                sent += 1
+                logger.info("WEEKLY_NUDGE: sent user_id=%s", cand.user_id)
+            except TelegramForbiddenError:
+                # Житель ни разу не писал боту в личку — Telegram не даёт инициировать диалог.
+                # Помечаем профиль, чтобы не тратить квоту в следующий раз.
+                forbidden += 1
+                await _mark_nudge_attempt(
+                    session, user_id=cand.user_id, chat_id=cand.chat_id, unreachable=True,
+                )
+                logger.info(
+                    "WEEKLY_NUDGE: TelegramForbidden user_id=%s — помечен unreachable.",
+                    cand.user_id,
+                )
+            except TelegramRetryAfter as exc:
+                # Telegram попросил подождать — прерываем рассылку, продолжим в следующий запуск.
+                logger.warning(
+                    "WEEKLY_NUDGE: rate limited (retry after %ss), останавливаемся.",
+                    getattr(exc, "retry_after", "?"),
+                )
+                break
+            except Exception:  # noqa: BLE001
+                # Любая другая ошибка — не дожимаем профиль, чтобы попробовать в следующий раз.
+                logger.exception(
+                    "WEEKLY_NUDGE: ошибка отправки user_id=%s — не помечаем профиль.",
+                    cand.user_id,
+                )
+        break
+
+    logger.info(
+        "WEEKLY_NUDGE: завершено. sent=%d forbidden=%d skipped=%d",
+        sent, forbidden, skipped,
+    )

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1,0 +1,183 @@
+"""Тесты еженедельных персональных нажъмов в DM."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.models import ResidentProfile
+from app.services.personalization import (
+    _first_actionable_fact,
+    _is_opted_out,
+    build_nudge_message,
+    select_nudge_candidates,
+)
+
+
+def _facts(**kw) -> dict:
+    return kw
+
+
+def _make_session_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _setup_db(engine):
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+# --- _first_actionable_fact ---
+
+def test_first_actionable_fact_picks_interests_first():
+    facts = _facts(interests=["школа"], pets="собака", car="ниссан")
+    assert _first_actionable_fact(facts) == ("interests", "школа")
+
+
+def test_first_actionable_fact_skips_empty_interests():
+    facts = _facts(interests=[], pets="собака")
+    assert _first_actionable_fact(facts) == ("pets", "собака")
+
+
+def test_first_actionable_fact_family_only_with_kid_keywords():
+    # семья без упоминания детей — не actionable
+    assert _first_actionable_fact(_facts(family="живём вдвоём")) is None
+    # семья с ребёнком — годится
+    assert _first_actionable_fact(_facts(family="с ребёнком")) == ("family", "с ребёнком")
+
+
+def test_first_actionable_fact_returns_none_for_empty_profile():
+    assert _first_actionable_fact({}) is None
+    assert _first_actionable_fact({"name": "Иван", "building": "2"}) is None
+
+
+# --- _is_opted_out ---
+
+def test_opted_out_blocks_nudge():
+    assert _is_opted_out({"nudge_opt_out": True}) is True
+    assert _is_opted_out({"nudge_unreachable": True}) is True
+    assert _is_opted_out({"interests": ["школа"]}) is False
+
+
+# --- build_nudge_message ---
+
+def test_build_nudge_message_returns_text_for_actionable_profile():
+    text = build_nudge_message(_facts(interests=["школа"]), display_name="Иван Петров")
+    assert text is not None
+    assert "Иван" in text
+    assert "школа" in text
+    assert "/off_nudges" in text
+    # Не должно протекать второе слово имени (фамилия).
+    assert "Петров" not in text
+
+
+def test_build_nudge_message_returns_none_when_no_facts():
+    assert build_nudge_message({}, display_name="Кто-то") is None
+
+
+def test_build_nudge_message_returns_none_when_opted_out():
+    facts = _facts(interests=["школа"], nudge_opt_out=True)
+    assert build_nudge_message(facts, display_name="Иван") is None
+
+
+def test_build_nudge_message_handles_no_display_name():
+    text = build_nudge_message(_facts(pets="собака"))
+    assert text is not None
+    # Без имени фраза остаётся грамматически корректной (без хвоста ", None").
+    assert "None" not in text
+    assert "собака" in text
+
+
+# --- select_nudge_candidates ---
+
+@pytest.mark.asyncio
+async def test_select_skips_opted_out_and_unactionable():
+    engine, factory = _make_session_factory()
+    await _setup_db(engine)
+    async with factory() as session:
+        session.add_all([
+            # actionable
+            ResidentProfile(
+                user_id=1, chat_id=100, display_name="A",
+                facts_json=json.dumps({"interests": ["школа"]}),
+            ),
+            # opted out
+            ResidentProfile(
+                user_id=2, chat_id=100, display_name="B",
+                facts_json=json.dumps({
+                    "interests": ["школа"], "nudge_opt_out": True,
+                }),
+            ),
+            # unreachable
+            ResidentProfile(
+                user_id=3, chat_id=100, display_name="C",
+                facts_json=json.dumps({
+                    "interests": ["школа"], "nudge_unreachable": True,
+                }),
+            ),
+            # no actionable fact
+            ResidentProfile(
+                user_id=4, chat_id=100, display_name="D",
+                facts_json=json.dumps({"name": "Дмитрий"}),
+            ),
+        ])
+        await session.commit()
+        result = await select_nudge_candidates(
+            session, chat_id=100, limit=10, min_days_between=30,
+        )
+    assert [c.user_id for c in result] == [1]
+
+
+@pytest.mark.asyncio
+async def test_select_respects_min_days_between():
+    engine, factory = _make_session_factory()
+    await _setup_db(engine)
+    now = datetime.now(timezone.utc)
+    async with factory() as session:
+        session.add_all([
+            # 10 дней назад — слишком недавно
+            ResidentProfile(
+                user_id=1, chat_id=100, display_name="A",
+                facts_json=json.dumps({"interests": ["школа"]}),
+                last_nudge_at=now - timedelta(days=10),
+            ),
+            # 60 дней назад — годится
+            ResidentProfile(
+                user_id=2, chat_id=100, display_name="B",
+                facts_json=json.dumps({"interests": ["школа"]}),
+                last_nudge_at=now - timedelta(days=60),
+            ),
+            # никогда — годится
+            ResidentProfile(
+                user_id=3, chat_id=100, display_name="C",
+                facts_json=json.dumps({"interests": ["школа"]}),
+            ),
+        ])
+        await session.commit()
+        result = await select_nudge_candidates(
+            session, chat_id=100, limit=10, min_days_between=30,
+        )
+    # NULL last_nudge_at идёт первым (round-robin), затем 60-дневный.
+    assert [c.user_id for c in result] == [3, 2]
+
+
+@pytest.mark.asyncio
+async def test_select_respects_limit():
+    engine, factory = _make_session_factory()
+    await _setup_db(engine)
+    async with factory() as session:
+        for i in range(5):
+            session.add(ResidentProfile(
+                user_id=i + 1, chat_id=100, display_name=f"U{i}",
+                facts_json=json.dumps({"interests": ["школа"]}),
+            ))
+        await session.commit()
+        result = await select_nudge_candidates(
+            session, chat_id=100, limit=2, min_days_between=30,
+        )
+    assert len(result) == 2


### PR DESCRIPTION
## Что и зачем

Бот уже несколько месяцев собирает факты о жителях (интересы, питомцы, семья, машина), но до сих пор не использовал их для инициативы. Этот PR добавляет мягкий канал возврата: раз в неделю бот отбирает небольшую группу жителей с релевантными фактами и отправляет в личку короткое напоминание вида «вы как-то спрашивали про X — пишите, если что».

### Пример сообщения

```
Привет, Иван! Помню, вам близка тема «школа».

Кстати: школа №5 на ул. Центральной, директор Мария Петровна,
запись через портал Госуслуги.

Если захотите подробнее — спросите меня в группе через @-упоминание
или прямо здесь, в личке. Чтобы такие сообщения не приходили — пришлите
/off_nudges.
```

## Дизайн (консервативный, off-by-default)

| Параметр | Значение | Зачем |
|---|---|---|
| `ai_feature_weekly_nudge` | `False` | Включается через env после проверки |
| `weekly_nudge_max_per_run` | `20` | Макс. DM за один запуск |
| `weekly_nudge_min_days_between` | `30` | Минимум дней между DM одному человеку |
| Cron | вт 11:00 | Не пересекается с утренними/вечерними коммуникациями и понедельничным weekly update |

### Отбор кандидатов

`select_nudge_candidates()`:
1. `chat_id == forum_chat_id`.
2. `last_nudge_at IS NULL OR last_nudge_at ≤ cutoff` (сортировка `NULLS FIRST, user_id` — честный round-robin).
3. Не помечен как `nudge_opt_out` или `nudge_unreachable`.
4. Есть actionable-факт: `interests[0]` / `pets` / `family` с упоминанием ребёнка / `car`.

### Генерация текста

`build_nudge_message(facts, display_name)`:
- 3 случайных варианта вступления (чтобы не повторялось).
- Имя — только первое слово (Иван Петров → «Иван», без фамильного «Петров»).
- Опциональный teaser: первая содержательная строка лучшего ответа из KB, если `search_resident_kb score ≥ 0.5`. Пропускаем заголовки/буллеты.
- Хвост с инструкцией `/off_nudges`.

### Доставка

`send_weekly_nudges(bot)`:
- `TelegramForbiddenError` (житель никогда не писал боту в DM) → профиль помечается `nudge_unreachable=True` в `facts_json`, больше не тратим на него квоту.
- `TelegramRetryAfter` → прерываем запуск, продолжим на следующей неделе.
- Любая другая ошибка → **не** дожимаем `last_nudge_at`, дадим шанс в следующий раз.

### Опт-аут / опт-ин

`/off_nudges` и `/on_nudges` работают **только в DM**. Флаг пишется во все профили `user_id` (на случай нескольких чатов). `/on_nudges` также сбрасывает `nudge_unreachable` — житель явно общается с ботом, значит DM работает.

## Изменения

- `app/models.py`: `+last_nudge_at: DateTime | None` (indexed) на `resident_profiles`.
- `app/main.py`: `ALTER TABLE` миграция в `_ensure_columns`, `scheduler.add_job(send_weekly_nudges, cron, tue, 11:00)`, регистрация `personalization_handler.router`.
- `app/config.py`: `ai_feature_weekly_nudge` + `weekly_nudge_max_per_run` + `weekly_nudge_min_days_between`.
- `app/services/personalization.py` (новый): `select_nudge_candidates`, `build_nudge_message`, `send_weekly_nudges`. SQLite-naive datetime нормализуется перед сравнением с cutoff.
- `app/handlers/personalization.py` (новый): `/off_nudges`, `/on_nudges`. Работают только в private chat.
- `tests/test_personalization.py` (новый): 12 тестов.

## Тесты

`148 passed, 1 skipped` (было 136 — +12 новых). Покрыто:

- `_first_actionable_fact`: приоритет `interests`, пустые списки, `family` без ребёнка, пустой профиль.
- `_is_opted_out`: `opt_out` и `unreachable` флаги.
- `build_nudge_message`: текст для actionable-профиля (без протечки фамилии), `None` для пустого, `None` для opted-out, корректное форматирование без имени.
- `select_nudge_candidates`: пропуск opt-out / unreachable / без фактов, `min_days_between`, round-robin `NULLS FIRST`, `limit`.

## План проверки после мержа

Перед включением фичи:

- [ ] Миграция применилась (колонка `last_nudge_at` в `resident_profiles`).
- [ ] `/off_nudges` в личке с ботом отвечает нейтрально, если профиля нет.
- [ ] `/off_nudges` в группе не реагирует (нет спама в общем чате).

Для включения (на сервере):

```bash
# в /opt/alexbot/docker-compose.yaml
AI_FEATURE_WEEKLY_NUDGE=true
```

Первая итерация прилетит в ближайший вторник 11:00. Смотрим в логи по `WEEKLY_NUDGE:` — там видны `sent / forbidden / skipped` счётчики.