### PR TITLE
fix: убрать мёртвые импорты + фикс прокси-ротации

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,10 @@ TOPIC_DUPLEX=18378
 # Утреннее приветствие с погодой и праздниками (8:00 в General)
 AI_DAILY_GREETING=false
 
+# Прокси для Telegram API (если api.telegram.org заблокирован).
+# Формат: socks5://user:pass@ip:1080  или  http://user:pass@ip:3128
+PROXY_MANUAL=
+
 # Google Sheets (импорт инфраструктуры)
 GOOGLE_SHEETS_SPREADSHEET_ID=1OsPh54Bn5fdkfsEJyKcbYZTcHnue3EWQ
 GOOGLE_SHEETS_WORKSHEET_NAME=Objects

--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,10 @@ TOPIC_DUPLEX=18378
 AI_DAILY_GREETING=false
 
 # Прокси для Telegram API (если api.telegram.org заблокирован).
-# Формат: socks5://user:pass@ip:1080  или  http://user:pass@ip:3128
+# PROXY_ENABLED=true  — автоматический поиск рабочих прокси из публичных списков
+# PROXY_MANUAL        — конкретный прокси (приоритет над PROXY_ENABLED)
+# Формат PROXY_MANUAL: socks5://user:pass@ip:1080  или  http://user:pass@ip:3128
+PROXY_ENABLED=false
 PROXY_MANUAL=
 
 # Google Sheets (импорт инфраструктуры)

--- a/.env.example
+++ b/.env.example
@@ -61,8 +61,6 @@ TOPIC_DUPLEX=18378
 
 # Утреннее приветствие с погодой и праздниками (8:00 в General)
 AI_DAILY_GREETING=false
-# Трафик-отчёт в Попутчиках (7:00 утро / 19:00 вечер, пн-пт)
-AI_TRAFFIC_REPORT=false
 
 # Google Sheets (импорт инфраструктуры)
 GOOGLE_SHEETS_SPREADSHEET_ID=1OsPh54Bn5fdkfsEJyKcbYZTcHnue3EWQ

--- a/app/config.py
+++ b/app/config.py
@@ -290,10 +290,6 @@ class Settings(BaseSettings):
     # Тихое обучение модерации: бот НЕ модерирует, а отправляет подозрительные
     # сообщения в лог-чат с кнопками для подтверждения действия администратором.
     moderation_training_mode: bool = False
-    # Плановые приветствия в форуме
-    ai_greeting_topic_id: int | None = None  # Топик для утреннего/вечернего приветствия
-    ai_morning_greeting: bool = False  # Включить утреннее приветствие (9:00)
-    ai_evening_greeting: bool = False  # Включить вечернее приветствие (20:00)
     # Утреннее приветствие с погодой и праздниками (8:00 в General)
     ai_daily_greeting: bool = False
     ai_summary_hour: int = 21

--- a/app/main.py
+++ b/app/main.py
@@ -191,8 +191,11 @@ class RetryOnFloodSession(AiohttpSession):
                 if self._proxy_manager:
                     new_proxy = self._proxy_manager.rotate()
                     try:
+                        # Закрываем текущую сессию — следующий вызов super().make_request
+                        # создаст новую с обновлённым proxy (AiohttpSession ленив).
+                        await self.close()
                         self.proxy = new_proxy
-                    except RuntimeError as proxy_exc:
+                    except Exception as proxy_exc:
                         logger.warning("Не удалось сменить прокси (%s), отключаю ротацию", proxy_exc)
                         self._proxy_manager = None
                 if network_attempts >= MAX_RETRIES_ON_NETWORK:
@@ -1123,7 +1126,6 @@ async def main() -> None:
     global _proxy_manager
     if settings.proxy_enabled or settings.proxy_manual:
         _proxy_manager = ProxyManager(
-            bot_token=settings.bot_token,
             working_pool_size=settings.proxy_working_pool_size,
             test_limit=settings.proxy_test_limit,
             state_path=Path(settings.proxy_state_path),

--- a/app/main.py
+++ b/app/main.py
@@ -63,7 +63,6 @@ from app.services.proxy import ProxyManager
 from app.services.daily_summary import build_ai_summary_context, build_daily_summary, build_response_report, render_daily_summary
 from app.services.daily_messages import send_morning_greeting
 from app.services.personalization import send_weekly_nudges
-from app.services.proactive import send_scheduled_greeting, send_weekly_update
 from app.services.sheets import sync_places_from_sheet
 from app.services.resident_kb import load_resident_kb
 
@@ -770,23 +769,6 @@ async def schedule_jobs(bot: Bot) -> AsyncIOScheduler:
         minute=0,
         args=[bot],
     )
-    # Плановые приветствия жителей
-    if settings.ai_morning_greeting:
-        scheduler.add_job(
-            send_scheduled_greeting,
-            "cron",
-            hour=9,
-            minute=0,
-            args=[bot, "morning"],
-        )
-    if settings.ai_evening_greeting:
-        scheduler.add_job(
-            send_scheduled_greeting,
-            "cron",
-            hour=20,
-            minute=0,
-            args=[bot, "evening"],
-        )
     # Утреннее приветствие с погодой и праздниками (8:00 каждый день)
     if settings.ai_daily_greeting:
         scheduler.add_job(

--- a/app/services/proxy.py
+++ b/app/services/proxy.py
@@ -44,9 +44,9 @@ _SOURCES: dict[str, tuple[str, ...]] = {
 }
 
 _FETCH_TIMEOUT = 15.0
-_TEST_TIMEOUT = 8.0
-_CONCURRENCY = 80
-_SCAN_GLOBAL_TIMEOUT = 90.0
+_TEST_TIMEOUT = 6.0
+_CONCURRENCY = 30  # меньше параллельных соединений — меньше нагрузка на сервер
+_SCAN_GLOBAL_TIMEOUT = 120.0
 
 
 def _parse_proxy_line(line: str, scheme: str) -> Optional[str]:
@@ -81,13 +81,11 @@ class ProxyManager:
     def __init__(
         self,
         *,
-        bot_token: Optional[str] = None,
         working_pool_size: int = 5,
         test_limit: int = 500,
         state_path: Optional[Path] = None,
         manual_proxy: Optional[str] = None,
     ) -> None:
-        self._bot_token = bot_token
         self._pool_size = max(1, working_pool_size)
         self._test_limit = max(50, test_limit)
         self._state_path = state_path
@@ -280,12 +278,10 @@ class ProxyManager:
         return out
 
     async def _test_proxy(self, proxy_url: str) -> bool:
-        # getMe с токеном даёт однозначный ответ: 200 — прокси работает и токен валиден;
-        # 401/404 — прокси работает (Telegram ответил). Главное — не exception/5xx.
-        if self._bot_token:
-            url = f"https://api.telegram.org/bot{self._bot_token}/getMe"
-        else:
-            url = "https://api.telegram.org"
+        # Проверяем доступность api.telegram.org без токена — любой HTTP-ответ (200-499)
+        # означает что прокси работает и Telegram отвечает. Используем HEAD чтобы не
+        # тратить трафик и не триггерить rate-limit по токену.
+        url = "https://api.telegram.org"
         try:
             connector = ProxyConnector.from_url(proxy_url)
         except Exception:
@@ -295,7 +291,7 @@ class ProxyManager:
             async with aiohttp.ClientSession(
                 connector=connector, timeout=timeout,
             ) as session:
-                async with session.get(url) as resp:
+                async with session.head(url) as resp:
                     return 200 <= resp.status < 500
         except Exception:
             return False

--- a/app/services/weekly_digest.py
+++ b/app/services/weekly_digest.py
@@ -41,7 +41,6 @@ def _build_topic_name_map() -> dict[int, str]:
         (settings.topic_pets, "Питомцы"),
         (settings.topic_parents, "Мамы и папы"),
         (settings.topic_realty, "Недвижимость"),
-        (settings.topic_rides, "Попутчики"),
         (settings.topic_services, "Услуги"),
         (settings.topic_uk, "УК"),
         (settings.topic_smoke, "Курилка"),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,9 @@ services:
       - AI_API_URL=${AI_API_URL:-https://openrouter.ai/api/v1}
       - AI_KEY=${AI_KEY:-}
       - AI_MODEL=${AI_MODEL:-anthropic/claude-haiku-4.5}
+      # Прокси для Telegram API. Формат: socks5://user:pass@ip:1080
+      # Оставьте пустым если прокси не нужен.
+      - PROXY_MANUAL=${PROXY_MANUAL:-}
 
   watchtower:
     image: containrrr/watchtower

--- a/scripts/setup_proxy_server.sh
+++ b/scripts/setup_proxy_server.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Скрипт настройки SOCKS5-прокси (3proxy) на чистом Ubuntu 24.04
+# Запускать от root на Hetzner VPS:
+#   curl -sSL https://raw.githubusercontent.com/.../setup_proxy.sh | bash
+#
+# После запуска скрипт напечатает строку PROXY_MANUAL для .env
+
+set -euo pipefail
+
+PROXY_USER="${PROXY_USER:-alexbot}"
+PROXY_PASS="${PROXY_PASS:-$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20)}"
+PROXY_PORT="${PROXY_PORT:-1080}"
+
+echo "==> Устанавливаю 3proxy..."
+apt-get update -qq
+apt-get install -y -qq 3proxy
+
+echo "==> Настраиваю конфиг..."
+mkdir -p /etc/3proxy
+cat > /etc/3proxy/3proxy.cfg <<EOF
+# DNS-серверы
+nserver 1.1.1.1
+nserver 8.8.8.8
+
+# Аутентификация по логину/паролю
+auth strong
+users ${PROXY_USER}:CL:${PROXY_PASS}
+allow ${PROXY_USER}
+
+# Лог
+log /var/log/3proxy.log D
+
+# SOCKS5 на порту ${PROXY_PORT}
+socks -p${PROXY_PORT}
+EOF
+
+echo "==> Запускаю 3proxy..."
+systemctl enable 3proxy
+systemctl restart 3proxy
+
+echo "==> Открываю порт в фаерволе (ufw)..."
+if command -v ufw &>/dev/null; then
+    ufw allow "${PROXY_PORT}/tcp" comment "3proxy SOCKS5" || true
+fi
+
+# Пауза чтобы сервис поднялся
+sleep 2
+
+# Проверка
+if ss -tlnp | grep -q ":${PROXY_PORT}"; then
+    echo ""
+    echo "=================================================="
+    echo "  3proxy запущен и слушает порт ${PROXY_PORT}"
+    echo "=================================================="
+    echo ""
+    SERVER_IP=$(curl -s4 https://api.ipify.org 2>/dev/null || hostname -I | awk '{print $1}')
+    echo "  Добавьте в .env на боте:"
+    echo ""
+    echo "  PROXY_MANUAL=socks5://${PROXY_USER}:${PROXY_PASS}@${SERVER_IP}:${PROXY_PORT}"
+    echo ""
+    echo "  Или в docker-compose.yaml:"
+    echo "  - PROXY_MANUAL=socks5://${PROXY_USER}:${PROXY_PASS}@${SERVER_IP}:${PROXY_PORT}"
+    echo "=================================================="
+else
+    echo "ОШИБКА: 3proxy не запустился. Смотри: systemctl status 3proxy"
+    exit 1
+fi


### PR DESCRIPTION
## 🚨 Критичный фикс — бот не стартует

**Проблема:** `ImportError: cannot import name 'send_scheduled_greeting' from 'app.services.proactive'`

Функции `send_scheduled_greeting` и `send_weekly_update` были удалены из `proactive.py` в PR #233, но импорт в `main.py` остался — бот падает при старте.

## Изменения

### Критичные (бот не стартует без этого)
- Удалить сломанный импорт `send_scheduled_greeting, send_weekly_update` из `main.py`
- Убрать мёртвые scheduler-блоки `ai_morning_greeting / ai_evening_greeting`
- Удалить мёртвые поля конфига: `ai_greeting_topic_id`, `ai_morning_greeting`, `ai_evening_greeting`
- Убрать `settings.topic_rides` из `weekly_digest.py` (поле удалено из конфига)

### Прокси (cherry-pick из `claude/fix-proxy-session`)
- **Фикс ротации**: `await self.close()` перед сменой прокси — без этого `self.proxy = new_proxy` не работал (сессия уже создана)
- **Безопасность**: тест прокси через `HEAD api.telegram.org` без токена бота (раньше токен уходил через чужой прокси)
- Параметры: `_CONCURRENCY` 80→30, `_TEST_TIMEOUT` 8→6
- `.env.example` с документацией `PROXY_ENABLED`

## После мержа

Добавить в `.env` на сервере:
```
PROXY_ENABLED=true
```

CI автоматически пересоберёт образ и задеплоит.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5nYyjtUftnWdByzR6awLG)_