### PR TITLE
Add weekly digest service import

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -63,6 +63,7 @@ from app.services.proxy import ProxyManager
 from app.services.daily_summary import build_ai_summary_context, build_daily_summary, build_response_report, render_daily_summary
 from app.services.daily_messages import send_morning_greeting
 from app.services.personalization import send_weekly_nudges
+from app.services.weekly_digest import send_weekly_digest
 from app.services.sheets import sync_places_from_sheet
 from app.services.resident_kb import load_resident_kb
 


### PR DESCRIPTION
## Summary
Added import for the new weekly digest service to make the `send_weekly_digest` function available in the main application module.

## Changes
- Imported `send_weekly_digest` from `app.services.weekly_digest` module

## Details
This import addition enables the main application to utilize the weekly digest functionality, which appears to be a new service for sending periodic digest communications to users. The import is placed alongside other similar communication services (daily summaries, morning greetings, and weekly nudges), suggesting this is part of the application's notification and engagement system.

https://claude.ai/code/session_01KidtkHnsgCvKQ4pqBRS7JW