### PR TITLE
Add silent topic support for rides/carpools

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -345,6 +345,9 @@ class Settings(BaseSettings):
     topic_neighbors: int | None = None
     topic_market: int | None = None
     topic_duplex: int | None = None
+    # Топик «Попутчики»: бот не отвечает (по запросу пользователя),
+    # но модерация продолжает работать.
+    topic_rides: int | None = None
 
     @field_validator(
         "topic_rules",
@@ -366,6 +369,7 @@ class Settings(BaseSettings):
         "topic_neighbors",
         "topic_market",
         "topic_duplex",
+        "topic_rides",
         mode="before",
     )
     @classmethod

--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -55,6 +55,13 @@ _BOT_PROFILE_CACHE: User | None = None
 _ASSISTANT_CHAT_IDS = {settings.forum_chat_id, settings.admin_log_chat_id}
 
 
+def _is_silent_topic(topic_id: int | None) -> bool:
+    """Топики, где бот молчит по запросу пользователей (модерация продолжает работать)."""
+    if topic_id is None:
+        return False
+    return settings.topic_rides is not None and topic_id == settings.topic_rides
+
+
 async def _get_bot_profile(bot: Bot) -> User:
     """Почему: снижаем число вызовов Telegram API при частых упоминаниях."""
 
@@ -1193,6 +1200,8 @@ async def ai_command(message: Message) -> None:
     if message.chat.id not in _ASSISTANT_CHAT_IDS:
         await message.reply("Команда /ai работает только в форуме ЖК и чате логов.")
         return
+    if _is_silent_topic(message.message_thread_id):
+        return
     if message.from_user is None or message.from_user.is_bot:
         return
     if not settings.ai_feature_assistant:
@@ -1345,6 +1354,12 @@ async def mention_help(message: Message, bot: Bot) -> None:
         logger.info(
             "MENTION_SKIPPED reason=wrong_chat chat_id=%s",
             message.chat.id,
+        )
+        return
+    if _is_silent_topic(message.message_thread_id):
+        logger.info(
+            "MENTION_SKIPPED reason=silent_topic topic_id=%s",
+            message.message_thread_id,
         )
         return
     if message.from_user is None:

--- a/app/services/proactive.py
+++ b/app/services/proactive.py
@@ -156,6 +156,10 @@ async def maybe_proactive_reply(message: Message, bot: Bot) -> bool:
     chat_id = message.chat.id
     topic_id = message.message_thread_id
 
+    # Топики, где бот молчит по запросу (например, «Попутчики»).
+    if settings.topic_rides is not None and topic_id == settings.topic_rides:
+        return False
+
     # Cooldown
     if _is_on_cooldown(chat_id, topic_id):
         return False
@@ -208,6 +212,9 @@ def _init_excluded_topics() -> None:
         _EXCLUDED_TOPIC_IDS.add(settings.topic_rules)
     if settings.topic_important is not None:
         _EXCLUDED_TOPIC_IDS.add(settings.topic_important)
+    # Попутчики — пользователи попросили, чтобы бот не вмешивался
+    if settings.topic_rides is not None:
+        _EXCLUDED_TOPIC_IDS.add(settings.topic_rides)
 
 
 def _is_comment_cooldown(chat_id: int, topic_id: int | None) -> bool:


### PR DESCRIPTION
## Summary
Add support for a "silent topic" where the bot doesn't respond to messages at the user's request, while moderation features continue to work normally. This is implemented for the rides/carpools topic.

## Key Changes
- **New helper function** `_is_silent_topic()` in `handlers/help.py` to check if a topic should be silent
- **Updated AI command handler** to skip processing in silent topics
- **Updated mention help handler** to skip processing in silent topics with logging
- **Updated proactive reply service** to exclude silent topics from automatic responses
- **Added configuration option** `topic_rides` in `config.py` to specify the rides/carpools topic ID
- **Integrated silent topic into excluded topics list** to prevent proactive bot engagement

## Implementation Details
- Silent topics are checked via `message.message_thread_id` comparison with configured topic ID
- The feature gracefully handles `None` values for both the topic ID setting and message thread ID
- Moderation features are unaffected - only bot assistance/responses are disabled
- Logging is added to track when mentions are skipped due to silent topic status

https://claude.ai/code/session_01ViSYcj2sC3ESJcvVD3v1LV