### PR TITLE
Удалить публичные команды /21 и /21top из меню бота

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -811,8 +811,6 @@ async def on_startup_warmup(bot: Bot) -> None:
                     BotCommand(command="help", description="Справка и навигация по форуму"),
                     BotCommand(command="rules", description="Правила нашего сообщества"),
                     BotCommand(command="ai", description="Задать вопрос Жаботу"),
-                    BotCommand(command="21", description="Играть в блэкджек"),
-                    BotCommand(command="21top", description="Топ игроков недели"),
                     BotCommand(command="score", description="Мои монеты и статистика"),
                     BotCommand(command="предложить", description="Предложить место в инфраструктуре ЖК"),
                 ],


### PR DESCRIPTION
### Motivation
- Убрать игровые команды из публичного меню Telegram и убедиться, что описания оставшихся команд не ссылаются на игры.

### Description
- Из `app/main.py` в функции `_set_public_commands` удалены `BotCommand(command="21", ...)` и `BotCommand(command="21top", ...)`.

### Testing
- Выполнена автоматическая проверка содержимого `BotCommand(..., description=...)` в `app/main.py` с помощью небольшого Python-скрипта (`python - <<'PY' ...`) на предмет упоминаний «игр», «блэкджек», «топ игроков» и совпадений не найдено; изменения добавлены в индекс и успешно закоммичены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc4b112e483269a98443187458979)