### PR TITLE
Обновить сообщение при недостатке монет в обработчике экономики

### DIFF
--- a/app/handlers/economy.py
+++ b/app/handlers/economy.py
@@ -127,7 +127,7 @@ async def improvement_text_handler(message: Message, bot: Bot) -> None:
             await message.reply(
                 f"Недостаточно монет.\n"
                 f"Нужно: {IMPROVEMENT_CREATE_COST} монет, у вас: {balance}.\n"
-                f"Зарабатывайте в /21 и рулетке."
+                "Сейчас доступных игровых способов заработка нет."
             )
             return
         improvement = result


### PR DESCRIPTION
### Motivation
- Устранить неактуальную ссылку на игровые команды в тексте уведомления о нехватке монет и заменить её на безопасную нейтральную формулировку.

### Description
- В `app/handlers/economy.py` заменён текст ответа при недостатке баланса с упоминания "Зарабатывайте в /21 и рулетке." на нейтральную строку "Сейчас доступных игровых способов заработка нет.".

### Testing
- Выполнена проверка синтаксиса командой `python -m py_compile app/handlers/economy.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc6b71a64832692fe638fd2912055)