### PR TITLE
Disable games module at startup and mock asyncio.sleep in startup stability test

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -36,7 +36,6 @@ from app.handlers import (
     ai_admin,
     economy as economy_handler,
     forms,
-    games,
     help as help_handler,
     moderation,
     personalization as personalization_handler,
@@ -639,14 +638,6 @@ async def schedule_jobs(bot: Bot) -> AsyncIOScheduler:
         hour="0,6,12,18",
         minute=30,
     )
-    # Блэкджек: правила за минуту до старта
-    scheduler.add_job(
-        games.announce_blackjack_rules,
-        "cron",
-        hour=21,
-        minute=59,
-        args=[bot],
-    )
     # Еженедельные персональные DM-нажъмы (по фактам из ResidentProfile).
     # Off-by-default через ai_feature_weekly_nudge — внутри функции стоит ранний return.
     # Вторник 11:00 — середина рабочей недели, не путается с проактивными
@@ -1094,7 +1085,7 @@ async def main() -> None:
     dp.include_router(help_handler.router)  # mention-help (catch-all, не блокирует)
     dp.include_router(admin.router)  # админ-команды
     dp.include_router(ai_admin.router)  # AI-команды для админов (/meme, /poster и др.)
-    dp.include_router(games.router)  # игры (команды /21, /score)
+    # games.router отключен: игровой модуль исключен из запуска диспетчера
     dp.include_router(forms.router)  # формы с FSM (перед модерацией!)
     dp.include_router(shop.router)  # магазин монет (FSM, перед economy)
     dp.include_router(economy_handler.router)  # инициативы жителей (доработки бота)

--- a/tests/test_startup_stability.py
+++ b/tests/test_startup_stability.py
@@ -96,6 +96,7 @@ def test_main_does_not_raise_when_polling_network_error(monkeypatch) -> None:
         monkeypatch.setattr(main_module, "schedule_jobs", AsyncMock(return_value=None))
         monkeypatch.setattr(main_module, "close_ai_client", AsyncMock())
         monkeypatch.setattr(main_module, "_run_background_task", lambda coro, *, name: coro.close())
+        monkeypatch.setattr(main_module.asyncio, "sleep", AsyncMock())
 
         await main_module.main()
 


### PR DESCRIPTION
### Motivation
- Temporarily remove the games subsystem from the bot startup so the dispatcher and scheduler don't reference the game module at runtime.
- Prevent test hangs/delays in startup stability tests that exercise the polling retry loop by mocking out `asyncio.sleep`.

### Description
- Removed `games` from the router inclusion path by commenting out the `dp.include_router(games.router)` line and adding a clarifying comment about the games module being excluded from the dispatcher.
- Removed the scheduled job that called `games.announce_blackjack_rules` so the scheduler no longer references the games module at cron time.
- Updated `tests/test_startup_stability.py` to patch `asyncio.sleep` with an `AsyncMock` in `test_main_does_not_raise_when_polling_network_error` to avoid real sleeping during the test.

### Testing
- Ran `tests/test_startup_stability.py::test_main_does_not_raise_when_polling_network_error` and the related startup stability tests against the modified code, and they completed successfully with the `asyncio.sleep` mock in place.
- Existing test expectations for session closing and error handling continued to pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc54815b88326ada83482738d8149)