### PR TITLE
Ограничить автосбор заявок в топике «Шлагбаум»

### DIFF
--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -43,6 +43,15 @@ _TOPIC_HINT_COOLDOWN = 600.0
 
 # Паттерны ссылок — признак того, что AI-проверка нужна
 _LINK_PATTERN = re.compile(r"https?://|www\.|t\.me/|@\w{3,}", re.IGNORECASE)
+_GATE_REQUEST_ACTION_WORDS = (
+    "заявк",
+    "переда",
+    "оформ",
+    "созда",
+    "диспетчер",
+    "эскал",
+    "помоги подать",
+)
 
 
 def _can_skip_ai_moderation(text: str) -> bool:
@@ -57,6 +66,12 @@ def _can_skip_ai_moderation(text: str) -> bool:
     if _LINK_PATTERN.search(text):
         return False
     return True
+
+
+def _should_collect_gate_request(text: str) -> bool:
+    """Определяет, нужно ли запускать сбор полей заявки в топике шлагбаума."""
+    lowered = text.lower()
+    return any(word in lowered for word in _GATE_REQUEST_ACTION_WORDS)
 
 # Runtime-флаг режима обучения (переопределяет settings.moderation_training_mode)
 _TRAINING_MODE_OVERRIDE: bool | None = None
@@ -295,12 +310,20 @@ async def run_moderation(message: Message, bot: Bot) -> int:
             try:
                 from app.services.ai_tasks import detect_gate_intent, extract_gate_request
                 intent = await detect_gate_intent(text, chat_id=chat_id, user_id=user_id)
-                if intent.is_gate_problem and intent.confidence >= 0.75:
+                if (
+                    intent.is_gate_problem
+                    and intent.confidence >= 0.75
+                    and _should_collect_gate_request(text)
+                ):
                     fields = await extract_gate_request(text, chat_id=chat_id, user_id=user_id)
                     if fields.missing_fields:
-                        missing_str = ", ".join(fields.missing_fields)
                         await safe_call(
-                            message.reply(f"Чтобы передать заявку, уточни: {missing_str}"),
+                            message.reply(
+                                "Чтобы передать заявку диспетчеру, напиши одним сообщением:\n"
+                                "• когда была проблема,\n"
+                                "• номер автомобиля,\n"
+                                "• что именно произошло."
+                            ),
                             log_ctx="gate_missing_fields",
                         )
                     elif fields.confidence >= 0.70:

--- a/tests/test_gate_topic_flow.py
+++ b/tests/test_gate_topic_flow.py
@@ -1,0 +1,15 @@
+"""Почему: в топике шлагбаума бот не должен запрашивать поля без явной просьбы оформить заявку."""
+
+from app.handlers.moderation import _should_collect_gate_request
+
+
+def test_gate_request_collection_requires_explicit_action_words() -> None:
+    assert not _should_collect_gate_request(
+        "Здравствуйте, кто знает номер ответственного за шлагбаум?"
+    )
+    assert not _should_collect_gate_request("Мне нужно увеличить лимит пропусков на завтра")
+
+
+def test_gate_request_collection_starts_on_request_to_submit_ticket() -> None:
+    assert _should_collect_gate_request("Помогите передать заявку диспетчеру по шлагбауму")
+    assert _should_collect_gate_request("Можно оформить заявку? шлагбаум не открывается")


### PR DESCRIPTION
### Motivation
- Уменьшить количество странных/лишних сообщений бота в топике `Шлагбаум`, когда пользователи задают общие вопросы или просят контакт, а не просят оформить заявку.
- Сделать поведение более ожидаемым: бот вмешивается только при явной просьбе передать/оформить заявку.

### Description
- Добавлен список триггерных слов ` _GATE_REQUEST_ACTION_WORDS` и хелпер ` _should_collect_gate_request(text: str)` в `app/handlers/moderation.py` для определения явной просьбы оформить заявку. 
- В обработчике модерации добавлено дополнительное условие — вызов `extract_gate_request(...)` теперь происходит только если `intent.is_gate_problem` и ` _should_collect_gate_request(text)` истинно. 
- Упрощён и локализован ответ при нехватке данных: бот теперь даёт понятную инструкцию на человеческом языке вместо перечисления технических полей. 
- Добавлен тест `tests/test_gate_topic_flow.py`, покрывающий поведение фильтра запуска сбора заявки. 

### Testing
- Запущено: `pytest -q tests/test_gate_topic_flow.py tests/moderation_dedup/test_moderation_dedup.py` и все тесты прошли успешно (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc87c9c348326aeaf4b7ae2f4e2ca)