### PR TITLE
Снизить шум от шаблонных «не знаю» ответов при упоминаниях бота

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -319,6 +319,7 @@ WAITING_TIMEOUT = timedelta(minutes=2)
 HINT_COOLDOWN = timedelta(seconds=30)
 HELP_DELETE_TIMEOUT = timedelta(minutes=2)
 AI_MENTION_COOLDOWN = timedelta(seconds=20)
+AI_UNCERTAIN_REPLY_COOLDOWN = timedelta(minutes=10)
 
 # Дедупликация: предотвращаем повторные ответы одному и тому же пользователю.
 # Ключ — (chat_id, user_id, norm_prompt): разные жители могут спросить одно и то же
@@ -329,6 +330,15 @@ _DEDUP_MAX = 300
 # Множество обработанных message_id для предотвращения двойной обработки
 _PROCESSED_MSG_IDS: set[int] = set()
 _PROCESSED_MSG_IDS_MAX = 500
+_LAST_UNCERTAIN_REPLY_TIME: dict[tuple[int, int, int | None], datetime] = {}
+
+_UNCERTAIN_REPLY_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bне\s+знаю\b", re.IGNORECASE),
+    re.compile(r"\bнет\s+(?:точного\s+)?ответа\b", re.IGNORECASE),
+    re.compile(r"\bнет\s+данн(?:ых|ой)\b", re.IGNORECASE),
+    re.compile(r"\bне\s+уверен\b", re.IGNORECASE),
+    re.compile(r"\bне\s+хочу\s+гадать\b", re.IGNORECASE),
+)
 
 
 def _is_duplicate_prompt(chat_id: int, user_id: int, prompt: str) -> bool:
@@ -361,6 +371,38 @@ def _mark_prompt_answered(chat_id: int, user_id: int, prompt: str) -> None:
     if not normalized:
         return
     _RECENT_RESPONSES[(chat_id, user_id, normalized)] = datetime.now(timezone.utc)
+
+
+def _is_uncertain_reply(reply: str) -> bool:
+    """Определяет ответы низкой информативности («не знаю» и аналоги)."""
+    normalized = " ".join((reply or "").split())
+    if not normalized:
+        return False
+    return any(pattern.search(normalized) for pattern in _UNCERTAIN_REPLY_PATTERNS)
+
+
+def _should_skip_uncertain_reply(
+    *,
+    chat_id: int,
+    user_id: int,
+    thread_id: int | None,
+    prompt: str,
+    reply: str,
+) -> bool:
+    """Снижает спам неинформативными ответами в чате."""
+    if not _is_uncertain_reply(reply):
+        return False
+
+    if "?" not in prompt:
+        return True
+
+    key = (chat_id, user_id, thread_id)
+    now = datetime.now(timezone.utc)
+    last_sent = _LAST_UNCERTAIN_REPLY_TIME.get(key)
+    if last_sent and now - last_sent < AI_UNCERTAIN_REPLY_COOLDOWN:
+        return True
+    _LAST_UNCERTAIN_REPLY_TIME[key] = now
+    return False
 
 
 def _mark_message_processed(message_id: int) -> None:
@@ -1495,6 +1537,20 @@ async def mention_help(message: Message, bot: Bot) -> None:
                 reply = build_local_assistant_reply(prompt, context=context)
                 logger.warning("AI вернул пустой ответ на упоминание, использован локальный fallback.")
 
+            if _should_skip_uncertain_reply(
+                chat_id=message.chat.id,
+                user_id=message.from_user.id,
+                thread_id=message.message_thread_id,
+                prompt=prompt,
+                reply=reply,
+            ):
+                logger.info(
+                    "OUT: MENTION_REPLY_SKIPPED_UNCERTAIN prompt=%r reply=%r",
+                    prompt[:80],
+                    reply[:120],
+                )
+                return
+
             await _remember_ai_exchange_persistent(
                 message.chat.id, message.from_user.id, prompt, reply,
             )
@@ -1547,11 +1603,7 @@ async def mention_help(message: Message, bot: Bot) -> None:
             except Exception:
                 logger.exception("Не удалось отправить даже fallback-ответ на упоминание.")
     else:
-        # Упомянули без вопроса — подсказываем, как пользоваться
-        await message.reply(
-            "Привет! Задай вопрос — и я постараюсь помочь 😊\n"
-            "Например: «@бот где ближайшая аптека?»"
-        )
+        logger.info("OUT: MENTION_REPLY_SKIPPED_EMPTY_PROMPT")
     logger.info("OUT: MENTION_REPLY")
 
 

--- a/tests/test_help_ai_context.py
+++ b/tests/test_help_ai_context.py
@@ -7,10 +7,14 @@ from app.handlers.help import (
     AI_CHAT_HISTORY,
     AI_CHAT_HISTORY_LIMIT,
     AI_RATE_LIMIT_TEXT,
+    AI_UNCERTAIN_REPLY_COOLDOWN,
     LAST_AI_REPLY_TIME,
+    _LAST_UNCERTAIN_REPLY_TIME,
     _extract_ai_prompt,
     _get_ai_context,
     _is_ai_reply_rate_limited,
+    _is_uncertain_reply,
+    _should_skip_uncertain_reply,
     _remember_ai_exchange,
     ai_command,
     mention_help,
@@ -81,6 +85,7 @@ class _DummyBot:
 def setup_function() -> None:
     AI_CHAT_HISTORY.clear()
     LAST_AI_REPLY_TIME.clear()
+    _LAST_UNCERTAIN_REPLY_TIME.clear()
 
 
 def test_ai_context_remembers_previous_messages() -> None:
@@ -175,3 +180,26 @@ def test_mention_help_returns_rate_limit_message(monkeypatch) -> None:
     asyncio.run(mention_help(message, _DummyBot()))
 
     assert message.replies == [AI_RATE_LIMIT_TEXT]
+
+
+def test_uncertain_reply_detection() -> None:
+    assert _is_uncertain_reply("Честно, не знаю.")
+    assert _is_uncertain_reply("По этому у меня нет данных.")
+    assert not _is_uncertain_reply("По шлагбауму: откройте приложение «Дворецкий».")
+
+
+def test_uncertain_reply_is_throttled_for_repeated_questions() -> None:
+    payload = dict(
+        chat_id=1,
+        user_id=2,
+        thread_id=3,
+        prompt="Где телепорт?",
+        reply="Не знаю по этому вопросу.",
+    )
+    assert _should_skip_uncertain_reply(**payload) is False
+    assert _should_skip_uncertain_reply(**payload) is True
+
+    _LAST_UNCERTAIN_REPLY_TIME[(1, 2, 3)] = (
+        datetime.now(timezone.utc) - AI_UNCERTAIN_REPLY_COOLDOWN - timedelta(seconds=1)
+    )
+    assert _should_skip_uncertain_reply(**payload) is False


### PR DESCRIPTION
### Motivation

- Снизить количество неинформативных «не знаю»/«нет данных» ответов бота, которые засоряют чат и выглядят как спам. 
- Не допускать вклиниваний бота в обсуждение при пустых упоминаниях без реального вопроса.

### Description

- Добавлены константа `AI_UNCERTAIN_REPLY_COOLDOWN` и хранилище `_LAST_UNCERTAIN_REPLY_TIME` в `app/handlers/help.py` для троттлинга неинформативных ответов. 
- Добавлены шаблоны низкой информативности `_UNCERTAIN_REPLY_PATTERNS` и вспомогательная логика в виде функций ` _is_uncertain_reply` и `_should_skip_uncertain_reply` в `app/handlers/help.py` для детекции и подавления таких ответов. 
- В обработчике упоминаний (`mention_help`) перед отправкой ответа добавлена проверка `_should_skip_uncertain_reply`, и при срабатывании бот теперь молчит (логирует пропуск) вместо повторного «не знаю». 
- Убрана автоматическая отправка подсказки на пустое упоминание бота; в таком случае теперь просто логируется пропуск, чтобы снизить вклинивания в чат. 
- Добавлены/обновлены тесты в `tests/test_help_ai_context.py` для проверки детекции неинформативных ответов и механизма троттлинга.

### Testing

- Запущены тесты: `pytest -q tests/test_help_ai_context.py tests/test_ai_module.py tests/test_resident_assistant.py` и все тесты прошли успешно (`60 passed`).
- Модифицированные модули: `app/handlers/help.py` и тесты `tests/test_help_ai_context.py`, и проверена интеграция с существующей логикой упоминаний и fallback-ответов.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1e540cbc83268282773b31e7e3b1)