### PR TITLE
Improve AI response handling and image generation robustness

### DIFF
--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -86,14 +86,13 @@ def _extract_response_content(data: dict[str, object]) -> str:
                 continue
             if not isinstance(item, dict):
                 continue
+            # Пропускаем reasoning/thinking-блоки — они не должны попадать в ответ.
+            # Инлайн-вариант <think>...</think> обрабатывается в _strip_think_tags.
+            if item.get("type") in ("reasoning", "thinking"):
+                continue
             text_part = item.get("text")
             if isinstance(text_part, str) and text_part.strip():
                 parts.append(text_part)
-                continue
-            if item.get("type") == "reasoning":
-                reasoning_part = item.get("reasoning")
-                if isinstance(reasoning_part, str) and reasoning_part.strip():
-                    parts.append(reasoning_part)
         return "\n".join(parts)
     return str(content_raw)
 
@@ -975,7 +974,9 @@ class OpenRouterProvider:
             "modalities": ["image", "text"],
         }
         logger.info("AI image request -> model=%s chat_id=%s", model_id, chat_id)
-        response = await self._client.post("/chat/completions", json=payload, headers=headers)
+        # Генерация картинок занимает значительно дольше текста — используем отдельный таймаут.
+        image_timeout = httpx.Timeout(120.0)
+        response = await self._client.post("/chat/completions", json=payload, headers=headers, timeout=image_timeout)
         response.raise_for_status()
         data = response.json()
 
@@ -1014,6 +1015,13 @@ class OpenRouterProvider:
                 raise RuntimeError("Пустые данные base64 в image-ответе")
             import base64 as _base64
             return _base64.b64decode(b64)
+
+        # OpenRouter может вернуть обычный HTTPS-URL вместо base64 — скачиваем.
+        if raw_url.startswith("https://") or raw_url.startswith("http://"):
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as dl_client:
+                img_response = await dl_client.get(raw_url)
+                img_response.raise_for_status()
+                return img_response.content
 
         raise RuntimeError(f"Неподдерживаемый формат image URL: {raw_url[:80]}")
 


### PR DESCRIPTION
## Summary
This PR refactors the AI response content extraction logic and enhances image generation reliability by adding proper timeout handling and support for HTTP(S) image URLs.

## Key Changes

- **Response content extraction**: Simplified the logic for filtering out reasoning/thinking blocks by consolidating the type checks and removing the separate reasoning field extraction. Added clarifying comments about inline `<think>` tag handling.

- **Image generation timeout**: Added a dedicated 120-second timeout for image generation requests, since image generation takes significantly longer than text generation. This prevents premature timeout errors on slower image generation operations.

- **HTTP(S) image URL support**: Added fallback handling for when OpenRouter returns standard HTTPS/HTTP URLs instead of base64-encoded images. The client now downloads the image from the provided URL with a 60-second timeout.

## Implementation Details

- The reasoning/thinking block filtering now checks for both "reasoning" and "thinking" types upfront, eliminating the need for separate handling logic
- Image downloads use a separate `AsyncClient` instance with appropriate timeout to avoid blocking the main client
- Error handling is preserved with `raise_for_status()` calls for both image generation and download operations

https://claude.ai/code/session_018s6EMFteydJkhcLbAshjso