### PR TITLE
fix(ci): читаемые права .env на раннере перед scp (600 → 644)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,9 @@ jobs:
             exit 1
           fi
           printf '%s\n' "${BOT_ENV}" > .env
-          chmod 600 .env
+          # 644, чтобы scp-action (пакует файлы в своём контейнере под другим uid)
+          # смог прочитать файл. Строгие права 600 ставятся на сервере при деплое.
+          chmod 644 .env
 
       # Копируем docker-compose.yaml и .env на сервер.
       - name: Copy deploy files to server


### PR DESCRIPTION
## Проблема
Джоба `deploy` падала на шаге **Copy deploy files to server**:
```
tar: can't open '.env': Permission denied
```
`appleboy/scp-action` пакует файлы `tar`-ом внутри своего Docker-контейнера под другим uid и не мог прочитать `.env`, созданный с правами `chmod 600` на раннере.

## Фикс
На раннере `.env` получает права `644` (раннер приватный и эфемерный, секрет не светится). Строгие права `600` по-прежнему ставятся **на сервере** в ssh-шаге деплоя.

Одна строка в `.github/workflows/build.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_