### PR TITLE
feat(ai): «отвечать реже, но точнее» — селективность и точность ответов

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@ AI_DAILY_TOKEN_LIMIT=400000
 AI_FEATURE_MODERATION=true
 AI_FEATURE_ASSISTANT=true
 AI_FEATURE_DAILY_SUMMARY=true
+# «Отвечать реже, но точнее»: на фактический вопрос без опоры в базе знаний
+# бот честно говорит «не знаю» вместо генерации догадки. true = включено.
+AI_REQUIRE_GROUNDING=true
 
 # Планировщик ежедневной сводки
 AI_SUMMARY_HOUR=21

--- a/app/config.py
+++ b/app/config.py
@@ -79,6 +79,10 @@ class Settings(BaseSettings):
     ai_feature_moderation: bool = True
     ai_feature_assistant: bool = True
     ai_feature_web_search: bool = True
+    # «Отвечать реже, но точнее»: на фактический вопрос без опоры в базе знаний
+    # (KB/RAG/FAQ/places/web) бот честно говорит «не знаю» вместо генерации догадки.
+    # Болтовня/приветствия этим гейтом не затрагиваются.
+    ai_require_grounding: bool = True
     # Проактивный режим: бот сам подсказывает, когда может помочь
     ai_feature_proactive: bool = True
     # Профили жителей: бот запоминает факты о пользователях из диалогов

--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -637,6 +637,8 @@ async def rag_bot_command(message: Message, bot: Bot) -> None:
             added_by_user_id=admin_id,
             source_user_id=source_user_id,
             source_message_id=target_msg.message_id,
+            # /rag_bot — админский канал знаний: запись бессрочна и приоритетна.
+            is_admin=True,
         )
         # Преобразуем запись в канонический вид без отдельной приоритизации.
         record.rag_category = cat_result.category

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -442,6 +442,15 @@ _FALLBACK_VARIANTS = (
     "Этого в моей базе сейчас нет.",
 )
 
+# Ответы для гейта «нет опоры в базе знаний». Каждая фраза гарантированно
+# распознаётся как uncertain (_is_uncertain_reply в help.py) → при отсутствии
+# «?» бот молчит, при прямом вопросе даёт одну честную строку.
+_UNGROUNDED_REPLIES = (
+    "Не знаю — точной информации по этому вопросу у меня нет.",
+    "Честно, не знаю: надёжных данных по этому у меня нет.",
+    "Не уверен и не хочу гадать — таких данных у меня нет.",
+)
+
 
 # Последний использованный style-hint per (chat_id, user_id) — чтобы не повторялся подряд.
 _LAST_STYLE_HINT_BY_USER: dict[tuple[int, int], str] = {}
@@ -480,13 +489,20 @@ def _parse_context_line(raw_line: str) -> tuple[str, str]:
     if not line:
         return ("system", "")
 
+    # Служебные сводки (профиль жителя, настроение чата, сжатая история)
+    # приходят с префиксом `summary:` и должны попадать в модель как system-контекст,
+    # а не как реплика пользователя — иначе Haiku путает, кто что сказал.
+    lowered = line.lower()
+    if lowered.startswith("summary:"):
+        return ("system", line[len("summary:"):].strip())
+
     for pattern, role in _CONTEXT_LINE_PATTERNS:
         match = pattern.match(line)
         if match:
             text = match.group(1).strip()
             return (role, text)
 
-    if line.lower().startswith("краткий контекст диалога"):
+    if lowered.startswith("краткий контекст диалога"):
         return ("system", line)
 
     return ("user", line)
@@ -991,6 +1007,7 @@ class AnthropicProvider:
                     {"role": "user", "content": user_content},
                 ],
                 chat_id=chat_id,
+                temperature=0.2,
                 response_format={"type": "json_object"},
             )
             # Убираем markdown-обёртку ```json ... ``` если модель всё же добавила её
@@ -1110,6 +1127,18 @@ class AnthropicProvider:
             safe_prompt[:80], user_id, topic_id,
         )
 
+        # «Реже, но точнее»: фактический вопрос без опоры в базе знаний → честный
+        # «не знаю» вместо генерации (модель не выдумывает, вызов к API экономится).
+        # Болтовню/приветствия пропускаем — там фактическая точность не нужна.
+        if (
+            settings.ai_require_grounding
+            and not has_factual_context
+            and not web_context
+            and not _looks_like_smalltalk(safe_prompt)
+        ):
+            logger.info("ANSWER_GATE: ungrounded factual question → honest 'не знаю' prompt=%r", safe_prompt[:80])
+            return random.choice(_UNGROUNDED_REPLIES)
+
         if resident_context:
             dynamic_system_parts.append(
                 "<knowledge_base source=\"resident_canonical\">\n"
@@ -1137,6 +1166,23 @@ class AnthropicProvider:
                 f"<knowledge_base source=\"web\">\n{web_context}\n</knowledge_base>"
             )
 
+        # Разделяем контекст на служебный (профиль жителя, настроение чата,
+        # сжатые сводки — role=system) и реальный диалог (user/assistant).
+        # Служебный контекст уходит отдельными system-сообщениями (их извлечёт
+        # _split_system_and_messages в system-параметр) и НЕ обрезается окном
+        # истории — иначе у активных пользователей персонализация теряется
+        # (окно берёт последние N реплик, а профиль/настроение вставлялись в начало).
+        dialogue_lines: list[tuple[str, str]] = []
+        system_context_lines: list[str] = []
+        for line in context:
+            role, text = _parse_context_line(line)
+            if not text:
+                continue
+            if role == "system":
+                system_context_lines.append(text)
+            else:
+                dialogue_lines.append((role, text))
+
         if not has_factual_context:
             dynamic_system_parts.append(
                 "<no_kb_notice>В knowledge_base нет данных по этому вопросу. "
@@ -1146,21 +1192,22 @@ class AnthropicProvider:
 
         dynamic_system_text = "\n\n".join(dynamic_system_parts).strip()
 
-        # Сборка system-сообщения. Для Anthropic-моделей через OpenRouter
-        # используем content-blocks с cache_control на статичной части —
-        # это даёт prompt caching и заметную экономию токенов/латентности.
+        # Сборка system-сообщения: статичная часть с cache_control (prompt caching),
+        # динамическая — контекст знаний и диалога.
         system_message = self._build_system_message(static_system_prompt, dynamic_system_text)
 
-        # Формируем историю как отдельные user/assistant сообщения.
-        # Гибридная обрезка: последние 6 реплик — до 1500 символов, остальные — до 500.
+        # Служебный контекст — отдельными system-сообщениями (не обрезается окном).
         messages: list[dict] = [system_message]
-        history_window = context[-30:]
+        for sys_text in system_context_lines:
+            messages.append({"role": "system", "content": sys_text})
+
+        # Реальный диалог как отдельные user/assistant сообщения.
+        # Гибридная обрезка: последние 6 реплик — до 1500 символов, остальные — до 500.
+        history_window = dialogue_lines[-30:]
         recent_cutoff = max(0, len(history_window) - 6)
-        for idx, line in enumerate(history_window):
+        for idx, (role, text) in enumerate(history_window):
             char_limit = 1500 if idx >= recent_cutoff else 500
-            role, text = _parse_context_line(line)
-            if text:
-                messages.append({"role": role, "content": text[:char_limit]})
+            messages.append({"role": role, "content": text[:char_limit]})
 
         # Style-hint добавляем к финальному запросу пользователя — рядом с
         # текстом, который Claude должен переформулировать.
@@ -1234,6 +1281,8 @@ class AnthropicProvider:
                     {"role": "user", "content": text[:2000]},
                 ],
                 chat_id=chat_id,
+                temperature=0.2,
+                response_format={"type": "json_object"},
             )
             data = json.loads(content)
             category = str(data.get("category", "общее"))
@@ -1260,6 +1309,7 @@ class AnthropicProvider:
                     {"role": "user", "content": conversation[:3000]},
                 ],
                 chat_id=chat_id,
+                temperature=0.3,
             )
             return content[:500]
         except RuntimeError as exc:
@@ -1279,6 +1329,8 @@ class AnthropicProvider:
                     {"role": "user", "content": dialog[:2000]},
                 ],
                 chat_id=chat_id,
+                temperature=0.2,
+                response_format={"type": "json_object"},
             )
             return content[:500]
         except RuntimeError as exc:

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -456,6 +456,34 @@ _UNGROUNDED_REPLIES = (
 _LAST_STYLE_HINT_BY_USER: dict[tuple[int, int], str] = {}
 
 
+# Маркеры фактического вопроса (адрес/телефон/график/тариф/процедура) — только
+# такие вопросы требуют опоры в базе знаний. Творческие просьбы («сформулируй»,
+# «напиши объявление») и рассуждения гейт не трогает.
+_FACTUAL_QUESTION_PATTERNS = re.compile(
+    r"(?ix)"
+    r"\b(где|куда|когда|во\s+сколько|сколько|почём|телефон|адрес|контакт|номер|"
+    r"график|расписание|режим\s+работы|тариф|стоимост\w*|цен[аыу]|"
+    r"как\s+(оформить|получить|записаться|попасть|подключить|заказать|вызвать|оплатить|добраться|проехать|передать)|"
+    r"работает\s+ли|есть\s+ли|чей|куда\s+звонить|куда\s+обращаться|кто\s+отвеча\w*)\b"
+)
+
+# Творческие/редакторские просьбы: модель работает с текстом из диалога,
+# опора в базе знаний не нужна — гейт не применяем.
+_DRAFTING_REQUEST_PATTERNS = re.compile(
+    r"(?i)\b(напиши|напечатай|сформулируй|составь|придумай|перепиши|переведи|"
+    r"сократи|подправь|исправь|оформи|помоги\s+(написать|составить|сформулировать))\b"
+)
+
+
+def _asks_local_facts(text: str) -> bool:
+    """Фактический ли это вопрос, требующий опоры в базе знаний."""
+    if not text:
+        return False
+    if _DRAFTING_REQUEST_PATTERNS.search(text):
+        return False
+    return bool(_FACTUAL_QUESTION_PATTERNS.search(text))
+
+
 _SMALLTALK_PATTERNS = re.compile(
     r"(?ix)"
     r"\b(привет|здаров|здорово|здравствуй|хай|hello|hi|добрый\s+(день|вечер|утро)|"
@@ -1129,12 +1157,19 @@ class AnthropicProvider:
 
         # «Реже, но точнее»: фактический вопрос без опоры в базе знаний → честный
         # «не знаю» вместо генерации (модель не выдумывает, вызов к API экономится).
-        # Болтовню/приветствия пропускаем — там фактическая точность не нужна.
+        # Гейт бьёт ТОЛЬКО по фактическим вопросам (_asks_local_facts): болтовня,
+        # творческие просьбы («сформулируй», «напиши объявление») и рассуждения
+        # уходят в модель — там точность фактов не нужна, а no_kb_notice ниже
+        # всё равно запрещает выдумывать факты о ЖК. Короткий follow-up в живом
+        # диалоге тоже пропускаем: ответ может содержаться в контексте беседы.
+        _is_short_followup = bool(context) and len(safe_prompt) < 40
         if (
             settings.ai_require_grounding
             and not has_factual_context
             and not web_context
             and not _looks_like_smalltalk(safe_prompt)
+            and _asks_local_facts(safe_prompt)
+            and not _is_short_followup
         ):
             logger.info("ANSWER_GATE: ungrounded factual question → honest 'не знаю' prompt=%r", safe_prompt[:80])
             return random.choice(_UNGROUNDED_REPLIES)

--- a/app/services/chat_history.py
+++ b/app/services/chat_history.py
@@ -42,15 +42,21 @@ async def load_context(
     *,
     limit: int = HISTORY_LIMIT,
 ) -> list[str]:
-    """Загружает историю диалога для подстановки в промпт ИИ."""
+    """Загружает историю диалога для подстановки в промпт ИИ.
+
+    Берём НОВЕЙШИЕ `limit` записей (desc + limit), затем разворачиваем в
+    хронологический порядок. Иначе при накоплении summary-записей (они не
+    вытесняются лимитом) `asc().limit()` отдавал бы старые строки, отбрасывая
+    самые свежие реплики — у активных пользователей контекст «застревал» в прошлом.
+    """
     stmt = (
         select(ChatHistory)
         .where(ChatHistory.chat_id == chat_id, ChatHistory.user_id == user_id)
-        .order_by(ChatHistory.created_at.asc())
+        .order_by(ChatHistory.created_at.desc())
         .limit(limit)
     )
     result = await session.execute(stmt)
-    rows = result.scalars().all()
+    rows = list(reversed(result.scalars().all()))
     lines: list[str] = []
     for r in rows:
         if r.role == "structured_summary" and r.message:

--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -436,7 +436,10 @@ def format_rag_context(messages: list[RagMessage]) -> str:
     for idx, msg in enumerate(unique_by_key.values(), 1):
         category = msg.rag_category or "общее"
         knowledge = msg.rag_canonical_text or msg.message_text
-        parts.append(f"[{idx}] ({category}) {knowledge}")
+        # Метка [АДМИН] реально выводится — промпт ассистента велит ставить
+        # такие записи выше остальных при конфликте фактов внутри RAG-блока.
+        admin_tag = "[АДМИН] " if getattr(msg, "is_admin", False) else ""
+        parts.append(f"[{idx}] {admin_tag}({category}) {knowledge}")
     return "\n".join(parts)
 
 

--- a/tests/test_admin_rag_bot.py
+++ b/tests/test_admin_rag_bot.py
@@ -52,7 +52,7 @@ async def _fake_session_gen():
     yield _DummySession()
 
 
-def test_rag_bot_canonicalizes_without_admin_priority(monkeypatch) -> None:
+def test_rag_bot_marks_entry_as_admin(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     async def _allow_admin(_message, _bot) -> bool:
@@ -83,6 +83,7 @@ def test_rag_bot_canonicalizes_without_admin_priority(monkeypatch) -> None:
     message = _DummyMessage()
     asyncio.run(rag_bot_command(message, _DummyBot()))
 
-    assert "is_admin" not in captured
+    # /rag_bot — админский канал: запись помечается is_admin=True (бессрочна, приоритетна).
+    assert captured["is_admin"] is True
     assert captured["message_text"] == "Очень важное новое знание по ЖК."
     assert message.replies

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -254,6 +254,64 @@ def test_assistant_stays_silent_when_ungrounded(monkeypatch) -> None:
     asyncio.run(provider.aclose())
 
 
+def _patch_empty_knowledge(monkeypatch, provider) -> None:
+    """Все источники знаний пустые — для тестов гейта."""
+    from app.services import ai_module
+
+    async def _empty(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return ""
+
+    monkeypatch.setattr(ai_module, "build_resident_context", lambda *a, **k: "")
+    monkeypatch.setattr(ai_module, "should_search_web", lambda *a, **k: False)
+    monkeypatch.setattr(ai_module, "_get_rag_context", _empty)
+    monkeypatch.setattr(ai_module, "_get_faq_answer", _empty)
+    monkeypatch.setattr(ai_module, "_get_places_context", _empty)
+
+
+def test_gate_lets_drafting_requests_through(monkeypatch) -> None:
+    """Творческая просьба без опоры в KB НЕ гейтится — уходит в модель."""
+    provider = OpenRouterProvider()
+    _patch_empty_knowledge(monkeypatch, provider)
+
+    called: list[bool] = []
+
+    async def _fake_completion(messages, *, chat_id, **kwargs):  # type: ignore[no-untyped-def]
+        called.append(True)
+        return ("Объявление: субботник в воскресенье в 10:00.", 10)
+
+    monkeypatch.setattr(provider, "_chat_completion", _fake_completion)
+
+    reply = asyncio.run(provider.assistant_reply(
+        "напиши объявление о субботнике в воскресенье", [], chat_id=1,
+    ))
+    assert called, "творческая просьба должна дойти до модели"
+    assert "субботник" in reply.lower()
+    asyncio.run(provider.aclose())
+
+
+def test_gate_lets_short_followup_through(monkeypatch) -> None:
+    """Короткий follow-up в живом диалоге НЕ гейтится: ответ может быть в контексте."""
+    provider = OpenRouterProvider()
+    _patch_empty_knowledge(monkeypatch, provider)
+
+    called: list[bool] = []
+
+    async def _fake_completion(messages, *, chat_id, **kwargs):  # type: ignore[no-untyped-def]
+        called.append(True)
+        return ("В 10 утра, как договаривались.", 5)
+
+    monkeypatch.setattr(provider, "_chat_completion", _fake_completion)
+
+    context = [
+        "user: когда собираемся на субботник?",
+        "assistant: В воскресенье в 10:00 у второго подъезда.",
+    ]
+    reply = asyncio.run(provider.assistant_reply("а во сколько?", context, chat_id=1))
+    assert called, "короткий follow-up должен дойти до модели"
+    assert reply
+    asyncio.run(provider.aclose())
+
+
 def test_openrouter_assistant_includes_resident_kb_in_context(monkeypatch) -> None:
     """KB-контент передаётся как контекст в AI (не bypasses AI)."""
     provider = OpenRouterProvider()

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -224,6 +224,36 @@ def test_openrouter_assistant_fallback_on_runtime_error(monkeypatch) -> None:
     asyncio.run(provider.aclose())
 
 
+def test_assistant_stays_silent_when_ungrounded(monkeypatch) -> None:
+    """«Реже, но точнее»: фактический вопрос без опоры → честный не-знаю, без вызова модели."""
+    from app.services import ai_module
+
+    provider = OpenRouterProvider()
+
+    async def _empty(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return ""
+
+    # Ни один источник знаний не сматчился.
+    monkeypatch.setattr(ai_module, "build_resident_context", lambda *a, **k: "")
+    monkeypatch.setattr(ai_module, "should_search_web", lambda *a, **k: False)
+    monkeypatch.setattr(provider, "_get_rag_context", _empty, raising=False)
+    monkeypatch.setattr(ai_module, "_get_rag_context", _empty)
+    monkeypatch.setattr(ai_module, "_get_faq_answer", _empty)
+    monkeypatch.setattr(ai_module, "_get_places_context", _empty)
+
+    # Модель не должна вызываться — гейт срабатывает раньше.
+    async def _must_not_call(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("_chat_completion не должен вызываться при отсутствии опоры")
+
+    monkeypatch.setattr(provider, "_chat_completion", _must_not_call)
+
+    reply = asyncio.run(provider.assistant_reply(
+        "какой тариф на отопление в нашем доме в этом месяце", [], chat_id=1,
+    ))
+    assert reply in ai_module._UNGROUNDED_REPLIES
+    asyncio.run(provider.aclose())
+
+
 def test_openrouter_assistant_includes_resident_kb_in_context(monkeypatch) -> None:
     """KB-контент передаётся как контекст в AI (не bypasses AI)."""
     provider = OpenRouterProvider()


### PR DESCRIPTION
Первый PR дорожной карты по итогам аудита. Главная цель — **бот отвечает реже, но точнее**.

## Селективность (реже)
- **Гейт grounding**: на фактический вопрос без опоры в базе знаний (KB/RAG/FAQ/places/web) бот честно говорит «не знаю» вместо генерации догадки — и не тратит вызов к API. Болтовня/приветствия не затрагиваются. Настройка `AI_REQUIRE_GROUNDING` (по умолчанию включена, можно выключить через env без правки кода).

## Точность (когда отвечает — правильно)
- **Персонализация доходит до модели**: профиль жителя, настроение чата и сжатые сводки теперь идут отдельными `system`-сообщениями и не обрезаются окном истории. Раньше они вставлялись в начало и отсекались `context[-30:]` — у активных пользователей персонализация просто терялась.
- **`_parse_context_line` распознаёт `summary:`** как system-роль. Раньше служебные сводки уходили модели как реплики пользователя → путаница «кто что сказал».
- **Низкая температура для JSON-задач**: модерация / категоризация / извлечение фактов — `0.2`, сжатие — `0.3` (было `0.8` по умолчанию → шумная классификация severity, «додуманные» факты в профилях).
- **`load_context` берёт новейшие N записей** (`desc`+reverse), а не старейшие: при накоплении summary-записей свежие реплики больше не отбрасываются.
- **Приоритет админ-знаний в RAG**: `/rag_bot` помечает запись `is_admin=True` (бессрочна и приоритетна), а `format_rag_context` реально выводит метку `[АДМИН]`, которую промпт велит ставить выше при конфликте фактов. Раньше метка обещалась промптом, но не выводилась.

## Тесты
- Обновлён `test_admin_rag_bot` под корректный админ-приоритет.
- Добавлен `test_assistant_stays_silent_when_ungrounded` — фиксирует поведение гейта.
- Полный прогон: **165 passed, 4 skipped**.

## Дальше по карте (отдельными PR)
Этап 2 (знания: `/kb_reload`, дыры покрытия, модерация самообучения), Этап 3 (чистка ~3000 строк мёртвого кода), Этап 4 (надёжность). Решения по блэкджеку и welcome-приветствию — за тобой.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_