### PR TITLE
feat(reliability): атомарные лимиты, RAG из hot-path, корректный shutdown

### DIFF
--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -447,8 +447,10 @@ async def _apply_strike_threshold(bot: Bot, message: Message, user_id: int, stri
             await clear_strikes(session, user_id, settings.forum_chat_id)
             await session.commit()
         await _warn_user(message, "слишком много нарушений — бан.", bot)
-    elif strike_count >= 3:
-        # Мут 24ч
+    elif strike_count == 3:
+        # Мут 24ч ровно на 3-м страйке. Точное сравнение (не >=): при гонке
+        # двух конкурентных страйков счётчик даёт 3 и 4 — мут не задваивается.
+        # 4-й страйк — только предупреждение, эскалация дальше на 5-м (бан).
         until = datetime.now(timezone.utc) + timedelta(hours=24)
         permissions = ChatPermissions(can_send_messages=False)
         await safe_call(

--- a/app/main.py
+++ b/app/main.py
@@ -477,6 +477,20 @@ async def cleanup_blackjack_commands(bot: Bot) -> None:
             pass
 
 
+async def _systematize_rag_job() -> None:
+    """Ночная систематизация RAG-базы (категории, канонические тексты)."""
+    try:
+        from app.services.rag import systematize_rag
+        async for session in get_session():
+            changed = await systematize_rag(session, settings.forum_chat_id)
+            if changed:
+                await session.commit()
+            logger.info("RAG систематизация: обновлено %s записей.", changed)
+            return
+    except Exception:
+        logger.exception("Ошибка ночной систематизации RAG.")
+
+
 async def cleanup_database() -> None:
     """Удаляет старые техданные и уменьшает размер SQLite-файла."""
     stats: dict[str, int] | None = None
@@ -562,6 +576,14 @@ async def schedule_jobs(bot: Bot) -> AsyncIOScheduler:
         "cron",
         hour=4,
         minute=20,
+    )
+    # Систематизация RAG вынесена из hot-path ответа ассистента (см. _get_rag_context):
+    # перезапись категорий/канонических текстов — раз в ночь, а не на каждый вопрос.
+    scheduler.add_job(
+        _systematize_rag_job,
+        "cron",
+        hour=4,
+        minute=40,
     )
     scheduler.add_job(
         _sync_places_from_sheets,
@@ -1029,8 +1051,12 @@ async def main() -> None:
                 )
                 break  # API ошибка (неверный токен) — ретраи бесполезны
     finally:
+        # aiogram сам ловит SIGTERM/SIGINT (handle_signals=True в start_polling)
+        # и корректно останавливает polling; здесь — только освобождение ресурсов.
+        # wait=False: не ждём завершения бегущих джоб, чтобы docker stop
+        # укладывался в stop_grace_period и не получал SIGKILL.
         if scheduler is not None:
-            scheduler.shutdown()
+            scheduler.shutdown(wait=False)
         await close_ai_client()
         await bot.session.close()
 

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -19,7 +19,7 @@ from sqlalchemy import select
 from app.config import settings
 from app.db import get_session
 from app.models import Place
-from app.services.ai_usage import add_usage, can_consume_ai, get_usage_stats
+from app.services.ai_usage import add_tokens, add_usage, get_usage_stats, try_reserve_request
 from app.services.faq import get_faq_answer
 from app.services.resident_kb import build_resident_answer, build_resident_context, search_resident_kb
 from app.services.web_search import format_search_context, search_duckduckgo, should_search_web
@@ -834,6 +834,7 @@ class AnthropicProvider:
         temperature: float,
         response_format: dict | None,
         fallback_model: str,
+        request_reserved: bool = False,
     ) -> tuple[str, int]:
         """Единая точка вызова Anthropic Messages API. Возвращает (текст, токены).
         SDK сам ретраит 429/5xx (max_retries); здесь — один retry на fallback-модель
@@ -897,15 +898,28 @@ class AnthropicProvider:
                 raise RuntimeError("AI вернул пустой текст")
             usage = getattr(response, "usage", None)
             tokens = 0
+            cache_read = 0
+            cache_write = 0
             if usage is not None:
                 tokens = int(getattr(usage, "input_tokens", 0) or 0) + int(
                     getattr(usage, "output_tokens", 0) or 0
                 )
-            await _add_remote_usage(chat_id, tokens)
+                cache_read = int(getattr(usage, "cache_read_input_tokens", 0) or 0)
+                cache_write = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
+            if request_reserved:
+                # Запрос уже учтён атомарным резервом — дописываем только токены.
+                await _add_remote_tokens(chat_id, tokens)
+            else:
+                await _add_remote_usage(chat_id, tokens)
             if used_fallback and model_id == self._model and current_model != self._model:
                 logger.warning("AI model switched to fallback for runtime stability: %r", current_model)
                 self._model = current_model
-            logger.info("AI response <- tokens=%s chat_id=%s", tokens, chat_id)
+            # cache_read=0 при повторных запросах → prompt caching не работает
+            # (например, статичный префикс короче минимума модели).
+            logger.info(
+                "AI response <- tokens=%s cache_read=%s cache_write=%s chat_id=%s",
+                tokens, cache_read, cache_write, chat_id,
+            )
             return content, tokens
 
     async def _chat_completion(
@@ -920,10 +934,12 @@ class AnthropicProvider:
     ) -> tuple[str, int]:
         if not settings.ai_key:
             raise RuntimeError("AI_KEY не задан")
+        request_reserved = False
         if not bypass_limit:
             allowed, reason = await _can_use_remote_ai(chat_id)
             if not allowed:
                 raise RuntimeError(f"AI лимит: {reason or 'превышен'}")
+            request_reserved = True
         model_id = self._model if model is None else _normalize_model_id(model)
         return await self._messages_create(
             model_id,
@@ -933,6 +949,7 @@ class AnthropicProvider:
             temperature=temperature,
             response_format=response_format,
             fallback_model=_normalize_model_id(settings.ai_fallback_model),
+            request_reserved=request_reserved,
         )
 
     async def _chat_completion_with_model(
@@ -1986,14 +2003,16 @@ async def _get_faq_answer(chat_id: int, query: str) -> str | None:
 
 
 async def _get_rag_context(chat_id: int, query: str) -> str:
-    """Подгружает весь RAG-контекст, ранжируя его по релевантности запроса."""
+    """Подгружает весь RAG-контекст, ранжируя его по релевантности запроса.
+
+    Только чтение: систематизация (перезапись категорий/канонических текстов)
+    вынесена в ночную джобу планировщика — записи в БД на каждом ответе
+    ассистента давали лишнюю латентность в hot-path.
+    """
     try:
-        from app.services.rag import build_rag_context, systematize_rag
+        from app.services.rag import build_rag_context
 
         async for session in get_session():
-            changed = await systematize_rag(session, chat_id)
-            if changed:
-                await session.commit()
             return await build_rag_context(session, chat_id=chat_id, query=query, top_k=8)
     except Exception as exc:
         logger.warning("RAG search failed: %s", exc)
@@ -2179,9 +2198,10 @@ reload_profanity_runtime()
 
 
 async def _can_use_remote_ai(chat_id: int) -> tuple[bool, str | None]:
+    """Атомарно резервирует запрос в счёт дневного лимита (проверка+инкремент одной операцией)."""
     date_key = now_tz().date().isoformat()
     async for session in get_session():
-        allowed, reason = await can_consume_ai(
+        allowed, reason = await try_reserve_request(
             session,
             date_key=date_key,
             chat_id=chat_id,
@@ -2193,9 +2213,18 @@ async def _can_use_remote_ai(chat_id: int) -> tuple[bool, str | None]:
 
 
 async def _add_remote_usage(chat_id: int, tokens: int) -> None:
+    """Полный учёт (запрос + токены) — для путей без предварительного резерва."""
     date_key = now_tz().date().isoformat()
     async for session in get_session():
         await add_usage(session, date_key=date_key, chat_id=chat_id, tokens_used=tokens)
+        return
+
+
+async def _add_remote_tokens(chat_id: int, tokens: int) -> None:
+    """Только токены — запрос уже учтён резервом в _can_use_remote_ai."""
+    date_key = now_tz().date().isoformat()
+    async for session in get_session():
+        await add_tokens(session, date_key=date_key, chat_id=chat_id, tokens_used=tokens)
         return
 
 

--- a/app/services/ai_usage.py
+++ b/app/services/ai_usage.py
@@ -62,6 +62,77 @@ async def can_consume_ai(
     return True, None
 
 
+async def try_reserve_request(
+    session: AsyncSession,
+    *,
+    date_key: str,
+    chat_id: int,
+    request_limit: int,
+    token_limit: int,
+) -> tuple[bool, str | None]:
+    """Атомарно резервирует один AI-запрос в счёт дневного лимита.
+
+    Проверка и инкремент — одна UPDATE-операция с условием в WHERE, поэтому
+    параллельные корутины не могут все пройти проверку до первой записи
+    (у прежней пары «проверить → после ответа записать» была эта гонка).
+    """
+    now_utc = datetime.now(timezone.utc).isoformat()
+    try:
+        await session.execute(
+            text(
+                "INSERT OR IGNORE INTO ai_usage (date_key, chat_id, request_count, tokens_used, updated_at) "
+                "VALUES (:dk, :cid, 0, 0, :ts)"
+            ),
+            {"dk": date_key, "cid": chat_id, "ts": now_utc},
+        )
+        result = await session.execute(
+            text(
+                "UPDATE ai_usage SET request_count = request_count + 1, updated_at = :ts "
+                "WHERE date_key = :dk AND chat_id = :cid "
+                "AND request_count < :req_limit "
+                "AND (:tok_limit <= 0 OR tokens_used < :tok_limit) "
+                "RETURNING request_count"
+            ),
+            {
+                "dk": date_key, "cid": chat_id, "ts": now_utc,
+                "req_limit": request_limit, "tok_limit": token_limit,
+            },
+        )
+        row = result.fetchone()
+        await session.commit()
+        if row is None:
+            return False, "достигнут дневной лимит AI"
+        return True, None
+    except OperationalError as exc:
+        logger.warning("Не удалось зарезервировать AI-запрос: %s", exc)
+        await session.rollback()
+        # fail-open: при сбое БД не блокируем бота
+        return True, None
+
+
+async def add_tokens(
+    session: AsyncSession,
+    *,
+    date_key: str,
+    chat_id: int,
+    tokens_used: int,
+) -> None:
+    """Добавляет только токены (запрос уже зарезервирован try_reserve_request)."""
+    now_utc = datetime.now(timezone.utc).isoformat()
+    try:
+        await session.execute(
+            text(
+                "UPDATE ai_usage SET tokens_used = tokens_used + :t, updated_at = :ts "
+                "WHERE date_key = :dk AND chat_id = :cid"
+            ),
+            {"t": max(0, tokens_used), "ts": now_utc, "dk": date_key, "cid": chat_id},
+        )
+        await session.commit()
+    except OperationalError as exc:
+        logger.warning("Не удалось записать токены AI: %s", exc)
+        await session.rollback()
+
+
 async def add_usage(
     session: AsyncSession,
     *,

--- a/tests/test_ai_usage_reserve.py
+++ b/tests/test_ai_usage_reserve.py
@@ -1,0 +1,68 @@
+"""Тесты атомарного резервирования дневного лимита AI-запросов."""
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db import Base
+from app.services.ai_usage import add_tokens, get_usage_stats, try_reserve_request
+
+
+async def _run_reserve_scenario() -> tuple[list[bool], int, int]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    results: list[bool] = []
+    async with session_factory() as session:
+        # Лимит 3 запроса: первые три резерва проходят, четвёртый — отказ.
+        for _ in range(4):
+            allowed, _reason = await try_reserve_request(
+                session, date_key="2026-07-08", chat_id=42,
+                request_limit=3, token_limit=0,
+            )
+            results.append(allowed)
+
+        # Токены дописываются к уже зарезервированным запросам.
+        await add_tokens(session, date_key="2026-07-08", chat_id=42, tokens_used=150)
+        stats = await get_usage_stats(session, date_key="2026-07-08", chat_id=42)
+
+    await engine.dispose()
+    return results, stats.requests_used, stats.tokens_used
+
+
+def test_reserve_enforces_request_limit_atomically() -> None:
+    results, requests_used, tokens_used = asyncio.run(_run_reserve_scenario())
+    assert results == [True, True, True, False]
+    assert requests_used == 3  # отказ не инкрементирует счётчик
+    assert tokens_used == 150
+
+
+async def _run_token_limit_scenario() -> bool:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with session_factory() as session:
+        allowed, _ = await try_reserve_request(
+            session, date_key="2026-07-08", chat_id=7,
+            request_limit=100, token_limit=100,
+        )
+        assert allowed
+        await add_tokens(session, date_key="2026-07-08", chat_id=7, tokens_used=100)
+        # Токен-лимит исчерпан — следующий резерв должен отклониться.
+        allowed, _ = await try_reserve_request(
+            session, date_key="2026-07-08", chat_id=7,
+            request_limit=100, token_limit=100,
+        )
+    await engine.dispose()
+    return allowed
+
+
+def test_reserve_respects_token_limit() -> None:
+    assert asyncio.run(_run_token_limit_scenario()) is False


### PR DESCRIPTION
Четвёртый (финальный по текущему плану) PR — надёжность из аудита.

## Что сделано

**Атомарный дневной лимит AI.** Раньше проверка лимита шла до запроса, а инкремент — после ответа: параллельные корутины проходили проверку до первой записи и лимит перекрывался. Теперь резерв — одна атомарная операция (`INSERT OR IGNORE` + условный `UPDATE … RETURNING`, по образцу уже проверенного счётчика). Токены дописываются отдельной операцией после ответа. Пути без лимита (`ai_tasks` с cost-limit) не изменились.

**`systematize_rag` из горячего пути.** `_get_rag_context` больше не перезаписывает категории/канонические тексты на каждый вопрос ассистента (лишние коммиты + латентность) — только читает. Систематизация выполняется ночной джобой в 4:40 (+ ручной `/rag_sync` остался).

**Страйки без задвоения.** Мут срабатывает ровно на 3-м страйке (`==` вместо `>=`): при гонке двух конкурентных страйков счётчик даёт 3 и 4 — мут один. Эскалация: 3 → мут 24ч, 5 → бан (без изменений).

**Корректная остановка.** `scheduler.shutdown(wait=False)` — при `docker stop` не ждём бегущих джоб и укладываемся в `stop_grace_period` (SIGTERM aiogram уже обрабатывает сам через `handle_signals`).

**Наблюдаемость prompt caching.** В лог ответа добавлены `cache_read`/`cache_write` из usage Anthropic — теперь видно, работает ли кэш префикса (постоянный `cache_read=0` = статичная часть промпта короче минимума модели).

## Тесты
2 новых теста атомарного резерва (лимит запросов, лимит токенов). Полный прогон: **164 passed, 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_