### PR TITLE
fix(help): бот отзывается на кличку «Жабот» (кириллица), а не только на Telegram-имя «Jabot»

### DIFF
--- a/app/handlers/help.py
+++ b/app/handlers/help.py
@@ -1213,8 +1213,18 @@ def _is_abilities_question(text: str | None) -> bool:
     return any(kw in lowered for kw in _ABILITIES_KEYWORDS)
 
 
+# Клички, на которые бот отзывается в начале сообщения помимо Telegram-имени.
+# Жители зовут его кириллицей («Жабот»), а Telegram first_name — латиницей
+# («Jabot»), поэтому одного first_name мало: без алиасов «Жабот, привет»
+# не распознаётся как обращение и бот молчит.
+_BOT_NAME_ALIASES = (
+    "жабот", "жаботик", "жаб", "жаба",
+    "jabot", "алекс", "alex",
+)
+
+
 def _is_bot_name_called(text: str | None, bot_user: object) -> bool:
-    """Проверяет обращение к боту по имени без @.
+    """Проверяет обращение к боту по имени/кличке без @.
 
     Имя должно быть В НАЧАЛЕ сообщения (позиция обращения), чтобы
     не срабатывать на упоминания вроде "спроси у Жабота" в середине предложения.
@@ -1223,14 +1233,18 @@ def _is_bot_name_called(text: str | None, bot_user: object) -> bool:
         return False
     # Берём только начало сообщения — позиция обращения
     first_part = text[:40].casefold()
+    names = set(_BOT_NAME_ALIASES)
     first_name = getattr(bot_user, "first_name", None)
-    if not first_name:
-        return False
-    name_lower = str(first_name).casefold()
-    # Имя должно быть в самом начале, возможно после пробелов, перед запятой/двоеточием/пробелом
-    pattern = rf"^\s*{re.escape(name_lower)}(?:\s*[,!:\s])"
-    if re.match(pattern, first_part):
-        return True
+    if first_name:
+        names.add(str(first_name).casefold())
+    for name in names:
+        if not name:
+            continue
+        # Имя в самом начале, перед запятой/воскл./двоеточием/пробелом ИЛИ в конце
+        # сообщения (чистое «Жабот»). Так «Жаботина» и «жабры» не срабатывают.
+        pattern = rf"^\s*{re.escape(name)}(?:\s*[,!:.?\s]|$)"
+        if re.match(pattern, first_part):
+            return True
     return False
 
 

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -651,3 +651,22 @@ def test_social_shortcut_only_for_pure_greetings() -> None:
 
     assert _local_social_reply("привет, телефон УК", 1, 1) is None
     assert _local_social_reply("спасибо большое", 1, 1) is not None
+
+
+def test_bot_name_called_recognizes_cyrillic_alias() -> None:
+    """Жители зовут «Жабот» (кириллица), Telegram-имя — «Jabot» (латиница)."""
+    from app.handlers.help import _is_bot_name_called
+
+    class _Profile:
+        first_name = "Jabot"
+        username = "alexjk_bot"
+
+    prof = _Profile()
+    assert _is_bot_name_called("Жабот, привет", prof)
+    assert _is_bot_name_called("Жабот", prof)
+    assert _is_bot_name_called("Жаб, как дела", prof)
+    assert _is_bot_name_called("Jabot, hi", prof)
+    # Не обращение: имя в середине, производные слова
+    assert not _is_bot_name_called("спроси у Жабота потом", prof)
+    assert not _is_bot_name_called("Жаботина сломалась", prof)
+    assert not _is_bot_name_called("привет всем", prof)


### PR DESCRIPTION
## Проблема

Бот не отвечал на «Жабот, привет» ни в форуме («Дом 2»), ни в лог-чате, хотя сам был жив (отбивка #284, оба API зелёные).

Причина: Telegram-имя бота — латиницей **«Jabot»** (сменилось при миграции на новый сервер), а жители зовут его кириллицей — **«Жабот»**. Детектор обращения `_is_bot_name_called` сравнивал начало сообщения только с `first_name`, поэтому «Жабот» (кириллица) ≠ «Jabot» (латиница) → сообщение не распознавалось как обращение, и `mention_help` не срабатывал. По `@username`/реплаем бот бы ответил, но в быту так к нему не обращаются.

## Решение

Добавлен список кличек `_BOT_NAME_ALIASES` (`жабот`, `жаботик`, `жаб`, `жаба`, `jabot`, `алекс`, `alex`) — независимо от Telegram `first_name`. Совпадение проверяется в начале сообщения перед разделителем (`, ! : . ?` или пробел) либо в конце строки, поэтому:
- ✅ «Жабот, привет», «жабот привет», «Жабот», «Жаб, как дела», «Jabot, hi» — распознаются;
- ❌ «Жаботина сломалась», «жабры у рыбы», «спроси у Жабота потом» — не срабатывают.

## Тесты

Добавлен `test_bot_name_called_recognizes_cyrillic_alias`. Полный прогон: **172 passed, 4 skipped**.

## Проверка после деплоя

1. «Жабот, привет» в форуме → живой ответ.
2. «Жабот, привет» в лог-чате → ответ.
3. «Жаботина сломалась» / «спроси у Жабота» → бот НЕ вмешивается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_