### PR TITLE
feat(reliability): ночной бэкап БД в админ-чат + полный прогон тестов в CI

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -22,8 +22,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run subsystem critical tests
+      # Полный прогон: раньше гонялись только 2 подсистемы, и правки через
+      # веб-интерфейс GitHub могли сломать остальное незаметно.
+      - name: Run full test suite
         run: |
-          pytest -q \
-            tests/moderation_dedup/test_moderation_dedup.py \
-            tests/circuit_breaker/test_circuit_breaker.py
+          pytest -q tests/ infra_catalog/tests/

--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,7 @@ from app.services.health import get_health_state, update_heartbeat, update_notic
 from app.services.db_maintenance import cleanup_old_data, optimize_sqlite
 from app.utils.time import now_tz
 from app.services.ai_module import clear_assistant_cache, close_ai_client, get_ai_client, set_ai_admin_notifier
+from app.services.backup import send_db_backup
 from app.services.daily_messages import (
     send_morning_greeting,
     send_presence_morning,
@@ -530,6 +531,10 @@ async def schedule_jobs(bot: Bot) -> AsyncIOScheduler:
     )
     scheduler.add_job(
         send_presence_evening, "cron", hour=21, minute=0, args=[bot],
+    )
+    # Ночной бэкап БД в админ-чат (3:30) — офсайт-копия на случай потери сервера.
+    scheduler.add_job(
+        send_db_backup, "cron", hour=3, minute=30, args=[bot],
     )
     scheduler.start()
     return scheduler

--- a/app/services/backup.py
+++ b/app/services/backup.py
@@ -1,0 +1,69 @@
+"""Почему: ночной бэкап SQLite в админ-чат — офсайт-копия на случай потери сервера.
+
+Telegram хранит отправленные файлы бессрочно: восстановление = скачать документ
+из лог-чата и положить на место data/bot.db.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from aiogram import Bot
+from aiogram.types import FSInputFile
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _sqlite_path_from_url(database_url: str) -> Path | None:
+    """Извлекает путь к файлу из sqlite-URL; None для не-SQLite БД."""
+    for prefix in ("sqlite+aiosqlite:///", "sqlite:///"):
+        if database_url.startswith(prefix):
+            return Path(database_url[len(prefix):])
+    return None
+
+
+async def send_db_backup(bot: Bot) -> None:
+    """Отправляет консистентную копию БД документом в админ-чат (ночной job)."""
+    src = _sqlite_path_from_url(settings.database_url)
+    if src is None:
+        logger.info("BACKUP: пропущен — база не SQLite (%s...)", settings.database_url[:20])
+        return
+    if not src.exists():
+        logger.warning("BACKUP: файл БД не найден: %s", src)
+        return
+
+    stamp = datetime.now(ZoneInfo(settings.timezone)).strftime("%Y-%m-%d_%H%M")
+    tmp_path: Path | None = None
+    try:
+        # Консистентный снимок через SQLite Online Backup API — обычное копирование
+        # файла могло бы поймать базу посреди записи.
+        with tempfile.NamedTemporaryFile(
+            prefix=f"bot_backup_{stamp}_", suffix=".db", delete=False
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+        with sqlite3.connect(src) as src_conn, sqlite3.connect(tmp_path) as dst_conn:
+            src_conn.backup(dst_conn)
+
+        size_mb = tmp_path.stat().st_size / (1024 * 1024)
+        await bot.send_document(
+            settings.admin_log_chat_id,
+            FSInputFile(tmp_path, filename=f"bot_backup_{stamp}.db"),
+            caption=(
+                f"💾 Ночной бэкап БД ({size_mb:.1f} МБ)\n"
+                "Восстановление: скачать файл → положить в data/bot.db → перезапустить бота."
+            ),
+            disable_notification=True,
+        )
+        logger.info("BACKUP: копия БД отправлена в админ-чат (%.1f МБ)", size_mb)
+    except Exception:
+        logger.warning("BACKUP: не удалось отправить копию БД.", exc_info=True)
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)

--- a/tests/test_ai_module.py
+++ b/tests/test_ai_module.py
@@ -402,6 +402,10 @@ def _patch_completion_env(monkeypatch, provider, create_fn) -> None:
 
     monkeypatch.setattr("app.services.ai_module.settings.ai_key", "test-key", raising=False)
     monkeypatch.setattr("app.services.ai_module.settings.ai_fallback_model", "claude-haiku-4-5", raising=False)
+    # Герметичность: основная модель провайдера фиксируется ОТЛИЧНОЙ от fallback —
+    # иначе результат зависит от env AI_MODEL (retry на fallback не происходит,
+    # когда основная модель уже равна fallback).
+    monkeypatch.setattr(provider, "_model", "claude-test-primary", raising=False)
     monkeypatch.setattr("app.services.ai_module._can_use_remote_ai", _allow)
     monkeypatch.setattr("app.services.ai_module._add_remote_usage", _fake_add_usage)
     monkeypatch.setattr(provider._client.messages, "create", create_fn)

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,43 @@
+"""Тесты ночного бэкапа БД."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from unittest.mock import AsyncMock
+
+from app.services.backup import _sqlite_path_from_url, send_db_backup
+
+
+def test_sqlite_path_from_url() -> None:
+    assert str(_sqlite_path_from_url("sqlite+aiosqlite:///app/data/bot.db")) == "app/data/bot.db"
+    assert str(_sqlite_path_from_url("sqlite:///data/x.db")) == "data/x.db"
+    assert _sqlite_path_from_url("postgresql://user@host/db") is None
+
+
+def test_send_db_backup_sends_document(tmp_path, monkeypatch) -> None:
+    # Готовим маленькую живую SQLite-базу
+    db_file = tmp_path / "bot.db"
+    with sqlite3.connect(db_file) as conn:
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        conn.execute("INSERT INTO t (v) VALUES ('data')")
+
+    from app.config import settings
+    monkeypatch.setattr(settings, "database_url", f"sqlite+aiosqlite:///{db_file}")
+
+    bot = AsyncMock()
+    asyncio.run(send_db_backup(bot))
+
+    assert bot.send_document.await_count == 1
+    args, kwargs = bot.send_document.await_args
+    assert args[0] == settings.admin_log_chat_id
+    assert "бэкап" in kwargs.get("caption", "").lower()
+
+
+def test_send_db_backup_skips_non_sqlite(monkeypatch) -> None:
+    from app.config import settings
+    monkeypatch.setattr(settings, "database_url", "postgresql://u@h/db")
+
+    bot = AsyncMock()
+    asyncio.run(send_db_backup(bot))
+    assert bot.send_document.await_count == 0


### PR DESCRIPTION
## Бэкап БД

SQLite хранит всё ценное (страйки, RAG-знания, историю диалогов, монеты) и живёт только на сервере — при потере сервера данные пропадают безвозвратно (прецедент уже был).

- `app/services/backup.py`: каждую ночь в **3:30** бот отправляет копию базы документом в админ-лог-чат (без звука).
- Копия консистентная — через SQLite Online Backup API, а не голое копирование файла посреди записи.
- Восстановление: скачать файл из чата → положить в `data/bot.db` → перезапустить бота.
- Не-SQLite БД: job тихо пропускается.

## Полный CI

Quality Gate гонял только 2 подсистемы (moderation_dedup, circuit_breaker) — остальные ~180 тестов не проверялись на PR. Теперь прогоняется весь suite: `tests/` + `infra_catalog/tests/` (187 тестов, локально 183 passed / 4 skipped).

## Тесты
Новые: извлечение пути из sqlite-URL, отправка документа в админ-чат, скип для не-SQLite.

## Проверка после деплоя
Завтра в 3:30 в лог-чате появится файл `bot_backup_<дата>.db` с подписью-инструкцией.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_