### PR TITLE
fix: находки код-ревью — бэкап, сверка мест, петля роста

### DIFF
--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -565,6 +565,44 @@ _UNGROUNDED_REPLIES = (
     "Не уверен и не хочу гадать — таких данных у меня нет.",
 )
 
+# Ссылки на фоновые задачи (fire-and-forget): без сильной ссылки GC может
+# собрать задачу до завершения — asyncio держит на неё лишь слабую ссылку.
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+
+def _spawn_background(coro) -> None:
+    """Запускает корутину в фоне, удерживая ссылку до её завершения."""
+    task = asyncio.get_running_loop().create_task(coro)
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+
+# Служебные обёртки промпта из хендлера (help.py): контекст темы и пометки
+# диалога. Для лога «не знаю»-вопросов нужен чистый вопрос жителя, иначе в
+# дайджест и ключ дедупликации попадёт весь преамбул с чужими репликами.
+_SCAFFOLD_REPLY_MARKER = "[Реплика, на которую отвечаешь]\n"
+_SCAFFOLD_LEADING_BLOCK = re.compile(r"^\s*\[[^\]]*\]\s*\n+")
+_SCAFFOLD_TRAILING_NOTE = re.compile(r"\n?\[[^\]]*\]\s*$")
+
+
+def _strip_prompt_scaffolding(text: str) -> str:
+    """Вынимает исходный вопрос жителя из промпта с преамбулой контекста."""
+    # 1) после «[Реплика, на которую отвечаешь]» идёт сам вопрос (+ возможный
+    #    префикс «[Продолжение диалога...]») — берём хвост после маркера.
+    idx = text.rfind(_SCAFFOLD_REPLY_MARKER)
+    if idx != -1:
+        text = text[idx + len(_SCAFFOLD_REPLY_MARKER):]
+    # 2) снимаем ведущие служебные блоки в квадратных скобках (напр. «Продолжение
+    #    диалога — предыдущий ответ бота: ...»).
+    while True:
+        stripped = _SCAFFOLD_LEADING_BLOCK.sub("", text, count=1)
+        if stripped == text:
+            break
+        text = stripped
+    # 3) снимаем хвостовую служебную пометку («Продолжительный диалог — ...»).
+    text = _SCAFFOLD_TRAILING_NOTE.sub("", text)
+    return text.strip()
+
 
 # Последний использованный style-hint per (chat_id, user_id) — чтобы не повторялся подряд.
 _LAST_STYLE_HINT_BY_USER: dict[tuple[int, int], str] = {}
@@ -1351,11 +1389,11 @@ class AnthropicProvider:
             logger.info("ANSWER_GATE: ungrounded factual question → honest 'не знаю' prompt=%r", safe_prompt[:80])
             # Петля роста: вопрос без ответа копится для еженедельного дайджеста
             # админам (fire-and-forget — ответ жителю не ждёт записи в БД).
+            # Логируем чистый вопрос без служебной преамбулы контекста.
             try:
                 from app.services.unanswered import log_unanswered
-                asyncio.get_running_loop().create_task(
-                    log_unanswered(chat_id, safe_prompt)
-                )
+                clean_q = _strip_prompt_scaffolding(safe_prompt)
+                _spawn_background(log_unanswered(chat_id, clean_q))
             except Exception:
                 pass
             return random.choice(_UNGROUNDED_REPLIES)

--- a/app/services/backup.py
+++ b/app/services/backup.py
@@ -6,6 +6,7 @@ Telegram хранит отправленные файлы бессрочно: в
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sqlite3
 import tempfile
@@ -29,6 +30,23 @@ def _sqlite_path_from_url(database_url: str) -> Path | None:
     return None
 
 
+def _make_backup_copy(src: Path, dst: Path) -> None:
+    """Консистентный снимок SQLite через Online Backup API.
+
+    Синхронно и с блокировкой — выполнять только через asyncio.to_thread,
+    иначе event loop встанет на время копирования. Соединения закрываем явно
+    в finally: контекст-менеджер sqlite3 коммитит, но не закрывает — иначе
+    остаются висящие дескрипторы (утечка).
+    """
+    src_conn = sqlite3.connect(src)
+    dst_conn = sqlite3.connect(dst)
+    try:
+        src_conn.backup(dst_conn)
+    finally:
+        dst_conn.close()
+        src_conn.close()
+
+
 async def send_db_backup(bot: Bot) -> None:
     """Отправляет консистентную копию БД документом в админ-чат (ночной job)."""
     src = _sqlite_path_from_url(settings.database_url)
@@ -43,13 +61,13 @@ async def send_db_backup(bot: Bot) -> None:
     tmp_path: Path | None = None
     try:
         # Консистентный снимок через SQLite Online Backup API — обычное копирование
-        # файла могло бы поймать базу посреди записи.
+        # файла могло бы поймать базу посреди записи. Само копирование —
+        # блокирующее, поэтому уводим его в отдельный поток, чтобы не морозить loop.
         with tempfile.NamedTemporaryFile(
             prefix=f"bot_backup_{stamp}_", suffix=".db", delete=False
         ) as tmp:
             tmp_path = Path(tmp.name)
-        with sqlite3.connect(src) as src_conn, sqlite3.connect(tmp_path) as dst_conn:
-            src_conn.backup(dst_conn)
+        await asyncio.to_thread(_make_backup_copy, src, tmp_path)
 
         size_mb = tmp_path.stat().st_size / (1024 * 1024)
         await bot.send_document(

--- a/app/services/place_verify.py
+++ b/app/services/place_verify.py
@@ -25,6 +25,7 @@ from app.models import Place
 logger = logging.getLogger(__name__)
 
 _TIMEOUT = 10
+_CONCURRENCY = 5  # одновременных проверок URL — вежливо к источникам, но не последовательно
 _URL_RE = re.compile(r"https?://[^\s;,)]+")
 # Маркеры закрытия в карточках Яндекс.Карт / 2GIS / зумерских справочников
 _CLOSED_MARKERS = (
@@ -80,14 +81,20 @@ async def verify_places(bot: Bot) -> None:
             return
 
         suspicions: list[str] = []
+        sem = asyncio.Semaphore(_CONCURRENCY)
+
+        async def _guarded(place: Place) -> tuple[Place, str | None]:
+            async with sem:
+                return place, await _check_place(client, place)
+
         async with httpx.AsyncClient(
             timeout=httpx.Timeout(_TIMEOUT), follow_redirects=True,
         ) as client:
-            for place in places:
-                reason = await _check_place(client, place)
-                if reason:
-                    suspicions.append(f"• {place.name} ({place.category}): {reason}")
-                await asyncio.sleep(1.0)  # вежливая пауза между запросами
+            results = await asyncio.gather(*(_guarded(p) for p in places))
+
+        for place, reason in results:
+            if reason:
+                suspicions.append(f"• {place.name} ({place.category}): {reason}")
 
         if not suspicions:
             logger.info("PLACE_VERIFY: %d мест проверено, подозрений нет.", len(places))

--- a/tests/test_place_verify.py
+++ b/tests/test_place_verify.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from app.services.place_verify import _CLOSED_MARKERS, _first_url
+import asyncio
+
+from app.services.place_verify import _CLOSED_MARKERS, _CONCURRENCY, _first_url
 
 
 def test_first_url_extracts_from_mixed_source() -> None:
@@ -10,6 +12,54 @@ def test_first_url_extracts_from_mixed_source() -> None:
         "https://pochta.ru/offices/142718"
     assert _first_url("Yandex Maps / 2GIS (Измайлово, 12А)") is None
     assert _first_url(None) is None
+
+
+def test_verify_places_runs_concurrently(monkeypatch) -> None:
+    """Сверка идёт пачками (Semaphore), а не строго последовательно.
+
+    Регресс: раньше 100+ мест проверялись по одному с паузой 1с — минуты
+    блокировки. Проверяем, что одновременно активно >1 проверки.
+    """
+    from types import SimpleNamespace
+
+    from app.services import place_verify
+
+    places = [
+        SimpleNamespace(name=f"p{i}", category="c", source="https://ex/a", is_active=True)
+        for i in range(_CONCURRENCY * 2)
+    ]
+
+    active = 0
+    max_active = 0
+
+    async def _fake_check(client, place):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.02)
+        active -= 1
+        return None
+
+    async def _fake_session():
+        class _Res:
+            def scalars(self_inner):
+                return SimpleNamespace(all=lambda: places)
+
+        class _Sess:
+            async def execute(self_inner, *a, **k):
+                return _Res()
+
+        yield _Sess()
+
+    monkeypatch.setattr(place_verify, "_check_place", _fake_check)
+    monkeypatch.setattr(place_verify, "get_session", _fake_session)
+
+    bot = SimpleNamespace(
+        send_message=lambda *a, **k: asyncio.sleep(0),
+    )
+    asyncio.run(place_verify.verify_places(bot))
+    assert max_active > 1, "проверки должны идти параллельно"
+    assert max_active <= _CONCURRENCY, "но не больше лимита семафора"
 
 
 def test_closed_markers_match_real_phrases() -> None:

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -1,0 +1,56 @@
+"""Регрессии по код-ревью: чистый вопрос в петле роста и фоновые задачи."""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.services.ai_module import (
+    _BACKGROUND_TASKS,
+    _spawn_background,
+    _strip_prompt_scaffolding,
+)
+
+
+def test_strip_scaffolding_returns_bare_question() -> None:
+    """Служебная преамбула контекста темы вырезается — остаётся вопрос жителя."""
+    prompt = (
+        "[Недавние сообщения в этой теме — контекст беседы]\n"
+        "- сосед: опять шлагбаум не работает\n"
+        "- другой сосед: да, стоит колом\n\n"
+        "[Реплика, на которую отвечаешь]\n"
+        "Куда звонить если шлагбаум сломался?"
+    )
+    assert _strip_prompt_scaffolding(prompt) == "Куда звонить если шлагбаум сломался?"
+
+
+def test_strip_scaffolding_removes_dialog_prefix_and_trailing_note() -> None:
+    prompt = (
+        "[Реплика, на которую отвечаешь]\n"
+        "[Продолжение диалога — предыдущий ответ бота: привет]\n\n"
+        "А где ближайшая почта?\n"
+        "[Продолжительный диалог — после ответа предложи итог]"
+    )
+    assert _strip_prompt_scaffolding(prompt) == "А где ближайшая почта?"
+
+
+def test_strip_scaffolding_passthrough_plain_question() -> None:
+    """Без преамбулы вопрос не меняется."""
+    assert _strip_prompt_scaffolding("Где аптека?") == "Где аптека?"
+
+
+def test_spawn_background_keeps_reference_until_done() -> None:
+    """Фоновая задача держится в наборе, пока не завершится (иначе GC съест)."""
+
+    async def _run() -> bool:
+        done = asyncio.Event()
+
+        async def _job() -> None:
+            done.set()
+
+        _spawn_background(_job())
+        assert _BACKGROUND_TASKS, "ссылка на задачу должна удерживаться"
+        await done.wait()
+        await asyncio.sleep(0)  # даём done_callback снять ссылку
+        return True
+
+    assert asyncio.run(_run())


### PR DESCRIPTION
## Что и зачем

Правки по итогам код-ревью — три реальных дефекта в фоновых сервисах.

### `app/services/backup.py`
- Копирование SQLite через Online Backup API было **синхронным** и морозило event loop на время снимка. Вынес в `asyncio.to_thread`.
- Контекст-менеджер `sqlite3.connect` коммитит, но **не закрывает** соединение — оставались висящие дескрипторы. Теперь оба соединения закрываются явно в `finally` (хелпер `_make_backup_copy`).

### `app/services/place_verify.py`
- Еженедельная сверка URL шла строго **последовательно** с паузой 1с между запросами — на 100+ местах это минуты работы. Заменил на параллельные пачки через `asyncio.Semaphore(5)` + `gather`.

### `app/services/ai_module.py`
- В петлю роста («не знаю»-вопросы) писался **весь промпт с преамбулой** контекста темы (чужие реплики соседей) — засоряло дайджест и ключ дедупликации. Добавил `_strip_prompt_scaffolding`, который вынимает чистый вопрос жителя.
- Фоновая задача `create_task(log_unanswered(...))` не удерживалась ссылкой — GC мог собрать её до завершения. Добавил `_BACKGROUND_TASKS` + `_spawn_background`.

## Тесты
- `tests/test_review_fixes.py` — вырезание преамбулы и удержание фоновой задачи.
- `tests/test_place_verify.py` — проверка, что сверка идёт параллельно, но в пределах лимита семафора.
- Полный прогон: 210 passed, 4 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_