### PR TITLE
fix: страйк за мат падал на naive datetime + отключена модерация темы блэкджека

### DIFF
--- a/app/handlers/moderation.py
+++ b/app/handlers/moderation.py
@@ -257,6 +257,14 @@ async def run_moderation(message: Message, bot: Bot) -> int:
     if message.from_user is None or message.text is None:
         return 0
 
+    # В теме блэкджека мат/грубость не отслеживаем: там играют и подкалывают
+    # друг друга, штрафовать за это неуместно (бот тут вообще молчит).
+    if (
+        settings.topic_games is not None
+        and message.message_thread_id == settings.topic_games
+    ):
+        return 0
+
     # Предотвращаем двойную модерацию одного сообщения (mention_help + moderate_message)
     if _is_already_moderated(message.message_id):
         return 0

--- a/app/services/faq.py
+++ b/app/services/faq.py
@@ -9,6 +9,7 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import FrequentQuestion
+from app.utils.time import ensure_aware
 
 logger = logging.getLogger(__name__)
 
@@ -131,8 +132,9 @@ def _is_answer_locked(fq: FrequentQuestion) -> bool:
     и вопрос задавался в последние 30 дней (чтобы устаревшие ответы не блокировались)."""
     from datetime import timedelta
     now = datetime.now(timezone.utc)
-    # Ответ не может быть «залочен», если не спрашивали > 30 дней
-    if fq.last_asked_at and now - fq.last_asked_at > timedelta(days=30):
+    # Ответ не может быть «залочен», если не спрашивали > 30 дней.
+    # last_asked_at из SQLite — naive, приводим к aware перед вычитанием.
+    if fq.last_asked_at and now - ensure_aware(fq.last_asked_at) > timedelta(days=30):
         return False
     return (
         fq.ask_count >= MIN_ASK_COUNT

--- a/app/services/strikes.py
+++ b/app/services/strikes.py
@@ -8,6 +8,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Strike
+from app.utils.time import ensure_aware
 
 
 STRIKE_RESET_DAYS = 30
@@ -23,7 +24,9 @@ async def add_strike(session: AsyncSession, user_id: int, chat_id: int) -> int:
         )
     )
     now = datetime.now(timezone.utc)
-    if oldest and now - oldest > timedelta(days=STRIKE_RESET_DAYS):
+    # SQLite возвращает created_at без tzinfo — приводим к aware, иначе
+    # вычитание naive/aware падает с TypeError (страйк за мат не проставлялся).
+    if oldest and now - ensure_aware(oldest) > timedelta(days=STRIKE_RESET_DAYS):
         await session.execute(
             delete(Strike).where(Strike.user_id == user_id, Strike.chat_id == chat_id)
         )

--- a/tests/moderation_dedup/test_moderation_dedup.py
+++ b/tests/moderation_dedup/test_moderation_dedup.py
@@ -83,6 +83,25 @@ def test_dedup_cache_is_trimmed_when_overflow(monkeypatch) -> None:
     assert len(moderation._MODERATED_MSG_IDS) <= moderation._MODERATED_MSG_IDS_MAX // 2 + 2
 
 
+def test_blackjack_topic_is_not_moderated(monkeypatch) -> None:
+    """В теме блэкджека мат/грубость не отслеживаются — модерация не запускается."""
+    monkeypatch.setattr(moderation.settings, "forum_chat_id", 12345)
+    monkeypatch.setattr(moderation.settings, "topic_games", 42)
+    monkeypatch.setattr(moderation, "is_admin", AsyncMock(return_value=False))
+
+    ai_moderate = AsyncMock(return_value=SimpleNamespace(severity=3, sentiment="toxic"))
+    monkeypatch.setattr(moderation, "get_ai_client", lambda: SimpleNamespace(moderate=ai_moderate))
+    monkeypatch.setattr(moderation.settings, "ai_feature_moderation", True)
+
+    message = _build_message(message_id=2002)
+    message.message_thread_id = 42  # тема блэкджека
+
+    result = asyncio.run(moderation.run_moderation(message, AsyncMock()))
+
+    assert result == 0
+    assert ai_moderate.await_count == 0  # AI-модерация даже не вызывалась
+
+
 def test_prescreen_skips_clean_medium_message() -> None:
     """Чистое сообщение средней длины не требует LLM-модерации."""
     clean = (

--- a/tests/test_strikes_datetime.py
+++ b/tests/test_strikes_datetime.py
@@ -1,0 +1,61 @@
+"""Регресс: страйк за мат не должен падать на naive datetime из SQLite.
+
+Ошибка в проде: TypeError can't subtract offset-naive and offset-aware
+datetimes — SQLite возвращает created_at без tzinfo, а now() был aware.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models import Base, Strike
+from app.services.strikes import STRIKE_RESET_DAYS, add_strike
+
+
+def _make_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _prepare():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_prepare())
+    return engine, factory
+
+
+def test_add_strike_survives_naive_created_at() -> None:
+    """add_strike не падает, когда в БД лежит naive datetime."""
+    engine, factory = _make_factory()
+
+    async def _run() -> int:
+        async with factory() as session:
+            # Свежий страйк с naive-временем (как отдаёт SQLite).
+            session.add(Strike(user_id=1, chat_id=10, created_at=datetime.utcnow()))
+            await session.commit()
+            # Раньше эта строка бросала TypeError.
+            return await add_strike(session, user_id=1, chat_id=10)
+
+    count = asyncio.run(_run())
+    assert count == 2
+    asyncio.run(engine.dispose())
+
+
+def test_add_strike_resets_after_window_with_naive_dt() -> None:
+    """Старые (>30 дней) naive-страйки сбрасываются, а не роняют обработчик."""
+    engine, factory = _make_factory()
+
+    async def _run() -> int:
+        async with factory() as session:
+            old = datetime.utcnow() - timedelta(days=STRIKE_RESET_DAYS + 1)
+            session.add(Strike(user_id=2, chat_id=10, created_at=old))
+            await session.commit()
+            return await add_strike(session, user_id=2, chat_id=10)
+
+    # Старый страйк удалён, остаётся только новый → счётчик 1.
+    count = asyncio.run(_run())
+    assert count == 1
+    asyncio.run(engine.dispose())


### PR DESCRIPTION
## Проблема

В админ-чат прилетали ошибки:

```
🔴 Ошибка в боте
Тип: TypeError
Сообщение: can't subtract offset-naive and offset-aware datetimes
```

Падение происходило при попытке проставить страйк за мат: `Strike.created_at` из SQLite приходит **без tzinfo** (naive), а `datetime.now(timezone.utc)` — aware. Их вычитание в `add_strike` бросало `TypeError`, из-за чего штраф за мат вообще не проставлялся, а в лог сыпались ошибки.

## Что исправлено

### `app/services/strikes.py`
`add_strike` приводит `oldest` к aware через существующий хелпер `ensure_aware` перед вычитанием. Страйк снова проставляется, ошибка уходит.

### `app/services/faq.py`
Та же ловушка naive/aware в `_is_answer_locked` (`now - fq.last_asked_at`) — тоже через `ensure_aware`, чтобы не повторилось на другом пути.

### `app/handlers/moderation.py`
По просьбе: в теме блэкджека (`settings.topic_games`) мат и грубость больше **не отслеживаются** — `run_moderation` делает ранний `return 0`. Там играют и подкалывают друг друга, штрафовать неуместно (бот в этой теме и так молчит).

## Тесты
- `tests/test_strikes_datetime.py` — `add_strike` не падает на naive datetime и корректно сбрасывает страйки старше 30 дней.
- `tests/moderation_dedup/test_moderation_dedup.py` — сообщение в теме блэкджека не доходит до модерации (AI-модерация не вызывается).
- Полный прогон: 213 passed, 4 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_