### PR TITLE
fix(quiz): викторина не стартовала (сид не виден на сервере) + авто-импорт вопросов

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY data/ ./data/
 # Копируем KB и seed в отдельную директорию, чтобы bind mount data/ не перекрывал их
 COPY data/resident_kb.json ./kb/resident_kb.json
 COPY data/places_seed.json ./kb/places_seed.json
+COPY data/quiz_questions.json ./kb/quiz_questions.json
 
 RUN mkdir -p /app/data
 

--- a/app/handlers/quiz.py
+++ b/app/handlers/quiz.py
@@ -500,13 +500,23 @@ async def announce_quiz_soon(bot: Bot) -> None:
 
 
 async def start_quiz_auto(bot: Bot) -> None:
-    """20:00 ежедневно: автозапуск тура."""
+    """20:00 ежедневно: автозапуск тура. Отказ — ГРОМКО в админ-чат: молчаливый
+    logger.info уже привёл к «анонс был, игры не было» (пустой пул вопросов
+    из-за bind mount data/ — файл сида не был виден на сервере)."""
     if settings.topic_games is None:
         return
     try:
         reason = await _launch_quiz(bot, settings.forum_chat_id)
         if reason:
-            logger.info("QUIZ: автозапуск пропущен — %s", reason)
+            logger.warning("QUIZ: автозапуск пропущен — %s", reason)
+            try:
+                await bot.send_message(
+                    settings.admin_log_chat_id,
+                    f"⚠️ Викторина в 20:00 НЕ запустилась: {reason}\n"
+                    "Пул вопросов: /quiz_import <url> или проверь seed_quiz в логах.",
+                )
+            except (TelegramBadRequest, TelegramRetryAfter):
+                pass
     except Exception:
         logger.warning("QUIZ: автозапуск упал.", exc_info=True)
 

--- a/app/main.py
+++ b/app/main.py
@@ -843,6 +843,11 @@ async def on_startup_warmup(bot: Bot) -> None:
         logger.exception("Ошибка seed викторины.")
     logger.info("⏱ seed_quiz: %.2fs", _time.monotonic() - _step_t)
 
+    # ── Одноразовый авто-импорт вопросов с сайтов владельца (в фон) ──────────
+    # Работает только на сервере (интернет); под MigrationFlag — один раз.
+    from app.services.quiz_import import auto_import_startup
+    _run_background_task(auto_import_startup(bot), name="startup_quiz_autoimport")
+
     # ── Google Sheets — в фон ────────────────────────────────────────────────
     _run_background_task(_sync_places_from_sheets(), name="startup_sync_places")
 

--- a/app/services/quiz_import.py
+++ b/app/services/quiz_import.py
@@ -142,3 +142,72 @@ async def import_from_url(session: AsyncSession, url: str, *, chat_id: int) -> t
     added = await insert_new_questions(session, pairs)
     total = int(await session.scalar(select(func.count()).select_from(QuizQuestion)) or 0)
     return len(pairs), added, total
+
+
+# --- Одноразовый авто-импорт при старте (сайты владельца) ---
+
+# Сайты с вопросами от владельца. При добавлении новых — поднять версию флага,
+# чтобы деплой прошёлся по списку ещё раз.
+AUTO_IMPORT_URLS = (
+    "https://raznoeinteresnoe.ru/квиз-примеры-вопросов-с-ответами/",
+    "https://olganevskaya.com/вопросы-от-сайта-квизбаза-архив/",
+    "https://quizvopros.ru",
+    "https://viktorinavopros.ru",
+)
+AUTO_IMPORT_FLAG = "quiz_autoimport_v1"
+
+
+async def auto_import_startup(bot) -> None:
+    """Фоновая задача старта: одноразово (под MigrationFlag) импортирует вопросы
+    со всех сайтов владельца и отчитывается в админ-чат.
+
+    Работает на сервере, где есть интернет (окружение сборки заблокировано).
+    Ошибки отдельных сайтов не прерывают остальные.
+    """
+    from app.config import settings
+    from app.db import get_session
+    from app.models import MigrationFlag
+
+    async for session in get_session():
+        flag = await session.get(MigrationFlag, AUTO_IMPORT_FLAG)
+        if flag is not None:
+            return
+        break
+    else:
+        return
+
+    lines: list[str] = []
+    total_added = 0
+    total_in_base = 0
+    for url in AUTO_IMPORT_URLS:
+        try:
+            async for session in get_session():
+                extracted, added, total_in_base = await import_from_url(
+                    session, url, chat_id=settings.admin_log_chat_id
+                )
+                await session.commit()
+                break
+            else:
+                continue
+            total_added += added
+            lines.append(f"✅ {url[:55]} — извлечено {extracted}, новых {added}")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("QUIZ autoimport: %s — %s", url, exc)
+            lines.append(f"⚠️ {url[:55]} — {str(exc)[:80]}")
+
+    # Флаг ставим после прохода (даже частично неудачного): повторный деплой не
+    # будет долбить сайты; добить конкретный сайт можно вручную /quiz_import.
+    async for session in get_session():
+        session.add(MigrationFlag(key=AUTO_IMPORT_FLAG))
+        await session.commit()
+        break
+
+    report = (
+        f"🧠 Авто-импорт вопросов викторины: +{total_added} новых, "
+        f"в базе {total_in_base}.\n\n" + "\n".join(lines)
+        + "\n\nДобавить ещё: /quiz_import <ссылка>"
+    )
+    try:
+        await bot.send_message(settings.admin_log_chat_id, report)
+    except Exception:  # noqa: BLE001
+        logger.info("QUIZ autoimport: отчёт не отправился.\n%s", report)

--- a/tests/test_quiz_import.py
+++ b/tests/test_quiz_import.py
@@ -13,8 +13,11 @@ from app.services.quiz_import import _parse_pairs, insert_new_questions
 
 
 @pytest.fixture()
-def db():
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+def db(tmp_path):
+    # Файловая БД (как на проде), а не :memory: — паттерн «async for session…
+    # break» закрывает генераторы отложенно, и с in-memory каждая новая сессия
+    # может получить СВОЮ пустую базу. С файлом все соединения видят одно.
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/quiz_test.db")
     factory = async_sessionmaker(engine, expire_on_commit=False)
 
     async def _prepare():
@@ -81,6 +84,48 @@ def test_insert_dedups_against_existing(db) -> None:
     added, total = asyncio.run(_run())
     assert added == 1  # только Рим
     assert total == 2
+
+
+def test_auto_import_runs_once_and_survives_failures(db, monkeypatch) -> None:
+    """Авто-импорт: одноразовый (MigrationFlag), падение сайта не рушит проход."""
+    from unittest.mock import AsyncMock
+
+    from app.models import MigrationFlag
+    from app.services import quiz_import as qi
+
+    async def _get_session():
+        async with db() as session:
+            yield session
+
+    monkeypatch.setattr("app.db.get_session", _get_session)
+
+    calls = {"n": 0}
+
+    async def _fake_import(session, url, *, chat_id):
+        calls["n"] += 1
+        if "olganevskaya" in url:
+            raise RuntimeError("сайт лёг")
+        return 10, 5, 100
+
+    monkeypatch.setattr(qi, "import_from_url", _fake_import)
+    bot = AsyncMock()
+
+    # Оба запуска в одном event loop: in-memory SQLite не переживает смену
+    # loop'а (артефакт теста; на проде БД — файл).
+    async def _run_twice():
+        await qi.auto_import_startup(bot)
+        first = calls["n"]
+        await qi.auto_import_startup(bot)  # флаг стоит — сайты не дёргаются
+        async with db() as session:
+            flag = await session.get(MigrationFlag, qi.AUTO_IMPORT_FLAG)
+        return first, calls["n"], flag
+
+    first, second, flag = asyncio.run(_run_twice())
+    assert first == len(qi.AUTO_IMPORT_URLS)  # прошёл по всем, включая упавший
+    assert second == first  # повторный запуск ничего не импортировал
+    assert flag is not None
+    report = bot.send_message.await_args.args[1]
+    assert "⚠️" in report and "✅" in report  # и успехи, и ошибка в отчёте
 
 
 def test_insert_dedups_within_batch(db) -> None:


### PR DESCRIPTION
## Диагноз «анонс был, игры не было»

На сервере docker-compose монтирует `./data:/app/data` — и этот bind mount **перекрывает** папку `data/` из образа. Файл вопросов `data/quiz_questions.json` оказался не виден → сид загрузил **0 вопросов** → автозапуск в 20:00 отказал («недостаточно вопросов в базе») → отказ ушёл только в `logger.info`, и никто его не увидел. Анонс в 19:55 от пула вопросов не зависит — поэтому «отбивки были».

Ровно для этой ситуации у `resident_kb.json` и `places_seed.json` есть копия в `kb/` (не перекрывается mount'ом) — а для quiz-файла её не было.

## Фиксы

1. **Dockerfile**: `COPY data/quiz_questions.json ./kb/quiz_questions.json` — фоллбек `seed_quiz` теперь его находит. Сегодня после деплоя пул наполнится и в 20:00 викторина стартует.
2. **Громкий отказ**: `start_quiz_auto` при невозможности запуска шлёт причину в **админ-чат** (молчаливый лог уже стоил пропущенного вечера).
3. **Авто-импорт вопросов при старте** (ответ на «сделай сам»): одноразовая фоновая задача (под `MigrationFlag`) — бот сам проходит по 4 сайтам владельца (raznoeinteresnoe.ru, olganevskaya.com, quizvopros.ru, viktorinavopros.ru), скачивает страницы, извлекает пары своим ИИ и отчитывается в админ-чат. Падение одного сайта не рушит проход по остальным. Работает на сервере, где есть интернет (окружение сборки заблокировано egress-политикой).

## Тесты
- Авто-импорт: одноразовость (флаг), устойчивость к падению сайта, отчёт содержит и успехи, и ошибки.
- Фикстура — файловая БД во временной папке: in-memory SQLite ловила артефакт отложенного закрытия async-генераторов (каждая сессия получала свою пустую базу), с файлом — как на проде.
- Полный прогон: **274 passed, 4 skipped**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_