### PR TITLE
feat(quiz): парсер обходит страницы-каталоги (посты + пагинация)

### DIFF
--- a/scripts/parse_quiz_page.py
+++ b/scripts/parse_quiz_page.py
@@ -134,6 +134,32 @@ def filter_valid(pairs: list[dict]) -> tuple[list[dict], list[str]]:
     return valid, rejected
 
 
+def extract_post_links(html: str) -> list[str]:
+    """Ссылки на посты со страницы-каталога (WordPress: заголовки статей) +
+    пагинация «Older Posts». Каталог сам пар не содержит — только анонсы."""
+    links: list[str] = []
+    seen: set[str] = set()
+    try:
+        from bs4 import BeautifulSoup
+        soup = BeautifulSoup(html, "html.parser")
+        # Заголовки статей и кнопки «Read Post».
+        for sel in ("h2.entry-title a", "a.continue-reading", "h1.entry-title a"):
+            for a in soup.select(sel):
+                href = a.get("href")
+                if href and href.startswith("http") and href not in seen:
+                    seen.add(href)
+                    links.append(href)
+        # Пагинация «Older Posts» — чтобы обойти весь раздел.
+        for a in soup.select("div.link-prev a, a.next, .blog-nav a"):
+            href = a.get("href")
+            if href and href.startswith("http") and href not in seen:
+                seen.add(href)
+                links.append(href)
+    except Exception:
+        pass
+    return links
+
+
 def _read_source(src: str) -> str:
     if src.startswith("http"):
         import httpx
@@ -145,18 +171,50 @@ def _read_source(src: str) -> str:
     return Path(src).read_text(encoding="utf-8")
 
 
-if __name__ == "__main__":
+def _is_pagination(url: str) -> bool:
+    return "/page/" in url
+
+
+def crawl(sources: list[str], max_pages: int = 60) -> list[dict]:
+    """Обходит источники: файл/URL с парами берётся как есть; страница-каталог
+    раскрывается в посты (и пагинацию) с вежливой паузой между запросами."""
+    import time
+
     all_pairs: list[dict] = []
-    for src in sys.argv[1:]:
+    queue = list(sources)
+    visited: set[str] = set()
+    fetched = 0
+    while queue and fetched < max_pages:
+        src = queue.pop(0)
+        if src in visited:
+            continue
+        visited.add(src)
         try:
             html = _read_source(src)
         except Exception as exc:  # noqa: BLE001
             print(f"⚠️ {src}: {exc}", file=sys.stderr)
             continue
+        fetched += 1
         found = parse_page(html)
-        print(f"{src}: найдено пар {len(found)}", file=sys.stderr)
-        all_pairs.extend(found)
+        if found:
+            print(f"{src}: пар {len(found)}", file=sys.stderr)
+            all_pairs.extend(found)
+        else:
+            # Пар нет — возможно, это каталог: раскрываем посты и пагинацию.
+            links = extract_post_links(html)
+            posts = [u for u in links if not _is_pagination(u)]
+            pages = [u for u in links if _is_pagination(u)]
+            if links:
+                print(f"{src}: каталог — постов {len(posts)}, пагинация {len(pages)}",
+                      file=sys.stderr)
+            queue.extend(posts + pages)
+        if src.startswith("http"):
+            time.sleep(1.0)  # вежливая пауза
+    return all_pairs
 
+
+if __name__ == "__main__":
+    all_pairs = crawl(sys.argv[1:])
     valid, rejected = filter_valid(all_pairs)
     for line in rejected:
         print("отсеяно:", line, file=sys.stderr)

--- a/tests/test_quiz_parser.py
+++ b/tests/test_quiz_parser.py
@@ -92,3 +92,48 @@ def test_plain_text_without_html() -> None:
     page = "1. Дважды два?\nОтветы\n1. Четыре."
     pairs = parse_page(page)
     assert pairs == [{"question": "Дважды два?", "answer": "Четыре", "category": "квиз"}]
+
+
+_CATEGORY_HTML = """
+<article><h2 class="entry-title"><a href="https://site.ru/post-1/">Пост 1</a></h2>
+<a class="continue-reading" href="https://site.ru/post-1/">Read Post</a></article>
+<article><h2 class="entry-title"><a href="https://site.ru/post-2/">Пост 2</a></h2></article>
+<div class="blog-nav"><div class="link-prev">
+<a href="https://site.ru/category/x/page/2/">Older Posts</a></div></div>
+"""
+
+
+def test_extract_post_links_from_category() -> None:
+    """Каталог WordPress: ссылки постов из заголовков + пагинация, без дублей."""
+    from scripts.parse_quiz_page import extract_post_links
+
+    links = extract_post_links(_CATEGORY_HTML)
+    assert links == [
+        "https://site.ru/post-1/",
+        "https://site.ru/post-2/",
+        "https://site.ru/category/x/page/2/",
+    ]
+
+
+def test_crawl_follows_category_to_posts(monkeypatch) -> None:
+    """Обход: каталог → посты → пары; пагинация тоже посещается."""
+    import scripts.parse_quiz_page as pq
+
+    pages = {
+        "https://site.ru/category/x/": _CATEGORY_HTML,
+        "https://site.ru/post-1/": "1. Столица Франции?\nОтветы\n1. Париж.",
+        "https://site.ru/post-2/": "1. Царь зверей?\nОтветы\n1. Лев.",
+        "https://site.ru/category/x/page/2/": "<p>пусто</p>",
+    }
+    visited = []
+
+    def _fake_read(src):
+        visited.append(src)
+        return pages[src]
+
+    monkeypatch.setattr(pq, "_read_source", _fake_read)
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    pairs = pq.crawl(["https://site.ru/category/x/"])
+    assert {p["answer"] for p in pairs} == {"Париж", "Лев"}
+    assert "https://site.ru/category/x/page/2/" in visited  # пагинация обойдена


### PR DESCRIPTION
## Контекст

Владелец прислал живой HTML категории `quizvopros.ru/category/вопросы-текстовые/` (у него доступ есть, HTTP 200; из окружения сборки — 403). Это страница-каталог: в ней только анонсы, обрезанные «[…]», а сами пары «вопрос-ответ» лежат внутри постов («Часть 100», «Часть 099»…).

## Что добавлено в парсер (`scripts/parse_quiz_page.py`)

- **`extract_post_links`** — извлекает ссылки постов из каталога WordPress (заголовки `entry-title`, кнопки `continue-reading`) плюс пагинацию «Older Posts», без дублей. Проверено на реальном HTML владельца: 10 постов + страница 2.
- **`crawl`** — очередь обхода: источник с парами берётся как есть; каталог раскрывается в посты и пагинацию. Лимит страниц (60), вежливая пауза 1с между сетевыми запросами.
- Всё остальное без изменений: пары сопоставляются по номерам, ответы-абзацы отсеивает игровой валидатор.

## Как пользоваться (одна команда там, где сайты открываются)
```
python -m scripts.parse_quiz_page "https://quizvopros.ru/category/вопросы-текстовые/"
```
→ обойдёт раздел (посты + пагинация) и выдаст готовый JSON валидных пар для вливания в `data/quiz_questions.json`. Работает и по сохранённым файлам/вставленному тексту.

## Тесты
Новые: извлечение ссылок из каталога (посты + пагинация, дедуп), обход каталог→посты→пары с посещением пагинации (сетевой слой замокан). Полный прогон: **282 passed, 4 skipped**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_