### PR TITLE
feat(quiz): анимации (реакции, дротик, 10-секундка) + аудит подсчёта ответов

### DIFF
--- a/app/handlers/quiz.py
+++ b/app/handlers/quiz.py
@@ -110,18 +110,68 @@ async def _safe_send(bot: Bot, text: str) -> Message | None:
         return None
 
 
+async def _safe_edit(bot: Bot, message_id: int | None, text: str) -> None:
+    """Правка сообщения в теме игр; устаревшее/флуд — молча пропускаем."""
+    if message_id is None:
+        return
+    try:
+        await bot.edit_message_text(
+            text, chat_id=settings.forum_chat_id, message_id=message_id
+        )
+    except (TelegramBadRequest, TelegramRetryAfter):
+        pass
+
+
+# Реакции-анимации на ответы игроков: верный — праздник, неверный — раздумье.
+_CORRECT_REACTIONS = ("🎉", "🏆", "⚡", "🔥", "👏")
+_WRONG_REACTION = "🤔"
+
+
+async def _safe_react(bot: Bot, message: Message, emoji: str) -> None:
+    """Ставит эмодзи-реакцию на сообщение игрока (анимация в клиенте Telegram).
+
+    Реакция — best-effort украшение: любые ошибки (флуд, старое сообщение,
+    выключенные реакции в чате) молча глотаем, игру они не трогают.
+    """
+    try:
+        from aiogram.types import ReactionTypeEmoji
+        await bot.set_message_reaction(
+            chat_id=message.chat.id,
+            message_id=message.message_id,
+            reaction=[ReactionTypeEmoji(emoji=emoji)],
+        )
+    except Exception:  # noqa: BLE001 — реакции не должны ронять приём ответов
+        pass
+
+
+async def _send_start_animation(bot: Bot) -> None:
+    """Анимированный дротик 🎯 перед стартом тура — «прицелились, поехали»."""
+    try:
+        await bot.send_dice(
+            settings.forum_chat_id, message_thread_id=settings.topic_games, emoji="🎯"
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
 # --- Тексты тура ---
 
 
-def _question_text(state: q.QuizState) -> str:
+def _question_text(state: q.QuizState, *, warn: bool = False) -> str:
     num = state.index + 1
+    # Знаменатель — фактический размер тура (вопрос мог быть снят при
+    # синхронизации базы; константа «/15» давала «неверный подсчёт» номеров).
+    total = len(state.question_ids)
     hint = q.answer_length_hint(state.current_answer)
-    return (
-        f"❓ Вопрос {num}/{q.QUESTIONS_PER_ROUND}\n"
+    text = (
+        f"❓ Вопрос {num}/{total}\n"
         f"━━━━━━━━━━━━\n"
         f"{state.question_text}\n\n"
         f"💡 Ответ: {hint} • {q.SECONDS_PER_QUESTION} сек"
     )
+    if warn:
+        text += "\n\n⚡ Осталось 10 секунд!"
+    return text
 
 
 def _reveal_text(state: q.QuizState, winner_name: str | None) -> str:
@@ -188,10 +238,26 @@ async def _run_quiz(bot: Bot, chat_id: int) -> None:
                 # Событие чистится при ПОДГОТОВКЕ вопроса (_advance/_launch), а не
                 # здесь — иначе set() от быстрого ответа, пришедший до этого места,
                 # терялся бы, и driver зря ждал полный таймер (потерянное пробуждение).
-                try:
-                    await asyncio.wait_for(_event_for(chat_id).wait(), timeout=remaining)
-                except asyncio.TimeoutError:
-                    pass
+                warn_at = 10.0
+                answered = False
+                if remaining > warn_at + 1:
+                    try:
+                        await asyncio.wait_for(
+                            _event_for(chat_id).wait(), timeout=remaining - warn_at
+                        )
+                        answered = True
+                    except asyncio.TimeoutError:
+                        # Анимация «финишная прямая»: дописываем предупреждение
+                        # в сообщение вопроса, если его ещё никто не забрал.
+                        await _warn_last_seconds(bot, chat_id)
+                if not answered:
+                    try:
+                        await asyncio.wait_for(
+                            _event_for(chat_id).wait(),
+                            timeout=min(remaining, warn_at),
+                        )
+                    except asyncio.TimeoutError:
+                        pass
                 await _close_question(bot, chat_id)
                 continue
 
@@ -217,6 +283,25 @@ def _remaining_seconds(state: q.QuizState) -> float:
     from app.utils.time import ensure_aware
     elapsed = (datetime.now(timezone.utc) - ensure_aware(started)).total_seconds()
     return max(0.0, q.SECONDS_PER_QUESTION - elapsed)
+
+
+async def _warn_last_seconds(bot: Bot, chat_id: int) -> None:
+    """Дописывает «⚡ Осталось 10 секунд!» в сообщение вопроса (если он ещё
+    не взят) — живая динамика без лишних сообщений в теме."""
+    async with _lock_for(chat_id):
+        async for session in get_session():
+            state = await q.load_session(session, chat_id)
+            await session.commit()
+            break
+        else:
+            return
+    if (
+        state is not None
+        and state.phase == "asking"
+        and state.winner_user_id is None
+        and state.board_message_id
+    ):
+        await _safe_edit(bot, state.board_message_id, _question_text(state, warn=True))
 
 
 async def _close_question(bot: Bot, chat_id: int) -> None:
@@ -261,7 +346,11 @@ async def _advance_question(bot: Bot, chat_id: int) -> None:
                 return
             question = await q.get_question(session, state.question_ids[state.index])
             if question is None:
-                # Вопрос пропал из БД — остаёмся в break, driver возьмёт следующий.
+                # Вопрос пропал из БД (синхронизация базы во время тура) —
+                # вычёркиваем из списка, НЕ съедая номер: нумерация остаётся
+                # сплошной («Вопрос 3/14», а не скачок 3→5 из 15).
+                state.question_ids.pop(state.index)
+                state.index -= 1  # следующий заход возьмёт этот же индекс
                 await q.save_session(session, chat_id, settings.topic_games, state)
                 await session.commit()
                 return
@@ -278,7 +367,21 @@ async def _advance_question(bot: Bot, chat_id: int) -> None:
             break
         else:
             return
-    await _safe_send(bot, text)
+    msg = await _safe_send(bot, text)
+    if msg is not None:
+        await _remember_question_message(chat_id, msg.message_id)
+
+
+async def _remember_question_message(chat_id: int, message_id: int) -> None:
+    """Сохраняет message_id вопроса в состоянии — для предупреждения за 10 сек."""
+    async with _lock_for(chat_id):
+        async for session in get_session():
+            state = await q.load_session(session, chat_id)
+            if state is not None and state.phase == "asking":
+                state.board_message_id = message_id
+                await q.save_session(session, chat_id, settings.topic_games, state)
+            await session.commit()
+            return
 
 
 async def _finish_quiz(bot: Bot, chat_id: int) -> None:
@@ -351,8 +454,11 @@ async def _launch_quiz(bot: Bot, chat_id: int) -> str | None:
         f"{q.QUESTIONS_PER_ROUND} вопросов, по {q.SECONDS_PER_QUESTION} сек. "
         "Первый верный ответ забирает вопрос. Поехали!"
     )
+    await _send_start_animation(bot)  # 🎯 анимированный дротик — «прицелились»
     await _safe_send(bot, intro)
-    await _safe_send(bot, text)
+    msg = await _safe_send(bot, text)
+    if msg is not None:
+        await _remember_question_message(chat_id, msg.message_id)
     _start_driver(bot, chat_id)
     return None
 
@@ -369,12 +475,13 @@ def _start_driver(bot: Bot, chat_id: int) -> None:
 
 
 @router.message(_is_games_topic_answer)
-async def on_answer(message: Message) -> None:
+async def on_answer(message: Message, bot: Bot) -> None:
     if message.from_user is None:
         return
     text = message.text or ""
     user_id = message.from_user.id
     chat_id = message.chat.id
+    outcome: str | None = None  # correct | wrong (для реакции вне лока)
 
     async with _lock_for(chat_id):
         async for session in get_session():
@@ -387,7 +494,8 @@ async def on_answer(message: Message) -> None:
                 return
             if not q.check_answer(state.current_answer, text):
                 await session.commit()  # неверно — попытку НЕ жжём (фикс старой версии)
-                return
+                outcome = "wrong"
+                break
             # Первый верный: фиксируем победителя, начисляем монеты, будим driver.
             name = _display_name(message)
             state.winner_user_id = user_id
@@ -400,10 +508,18 @@ async def on_answer(message: Message) -> None:
             stats.coins += q.COINS_PER_CORRECT
             await q.save_session(session, chat_id, settings.topic_games, state)
             await session.commit()
+            outcome = "correct"
             break
         else:
             return
-    _event_for(chat_id).set()  # driver прекращает ждать и закрывает вопрос
+
+    # Реакции и пробуждение driver'а — вне лока (Telegram-вызовы под локом
+    # тормозили бы приём других ответов; см. вечер флуд-контроля блэкджека).
+    if outcome == "correct":
+        _event_for(chat_id).set()  # driver прекращает ждать и закрывает вопрос
+        await _safe_react(bot, message, random.choice(_CORRECT_REACTIONS))
+    elif outcome == "wrong":
+        await _safe_react(bot, message, _WRONG_REACTION)
 
 
 # --- Команды ---

--- a/app/services/quiz.py
+++ b/app/services/quiz.py
@@ -150,17 +150,43 @@ def _variant_matched(variant: str, given_tokens: list[str]) -> bool:
     return all(_token_matches(c, given_tokens) for c in correct_tokens)
 
 
+def _drop_negated(tokens: list[str]) -> list[str]:
+    """Убирает токен, идущий сразу после «не»/«это не»: «это не Париж» не должно
+    засчитываться как «Париж» (жалоба на неверный подсчёт). При этом «не знаю,
+    Париж» остаётся верным — отрицание бьёт только по соседнему слову."""
+    result: list[str] = []
+    skip_next = False
+    for t in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if t in ("не", "ни"):
+            skip_next = True
+            continue
+        result.append(t)
+    return result
+
+
 def check_answer(correct: str, given: str) -> bool:
     """Умеренный матч: опечатки прощаем, числа/даты — точно, лишние слова ок.
 
     Эталон может содержать альтернативы через «/», «;», «или» — достаточно
-    совпасть с любой.
+    совпасть с любой. Слово под отрицанием («не Париж») не засчитывается —
+    кроме эталонов, где «не/ни» часть самого ответа («Ни пуха, ни пера»).
     """
-    given_tokens = [t for t in _tokens(given) if t]
-    if not given_tokens:
+    raw_tokens = [t for t in _tokens(given) if t]
+    if not raw_tokens:
         return False
-    variants = [v for v in _ALT_SPLIT.split(correct) if v.strip()]
-    return any(_variant_matched(v, given_tokens) for v in variants)
+    filtered_tokens = _drop_negated(raw_tokens)
+    for v in _ALT_SPLIT.split(correct):
+        if not v.strip():
+            continue
+        v_tokens = _tokens(v)
+        # Эталон с «не/ни» внутри — отрицание не фильтруем, оно часть ответа.
+        use = raw_tokens if ("не" in v_tokens or "ни" in v_tokens) else filtered_tokens
+        if use and _variant_matched(v, use):
+            return True
+    return False
 
 
 def answer_length_hint(answer: str) -> str:

--- a/tests/test_quiz_accounting.py
+++ b/tests/test_quiz_accounting.py
@@ -1,0 +1,198 @@
+"""Симуляция полного тура с точной бухгалтерией — аудит «подсчёт сделали неверно».
+
+Проверяется всё движение очков и монет: кто сколько верных забрал, монеты за
+ответы, бонус победителя, история QuizRound, итоговая таблица, нумерация
+вопросов при снятом из базы вопросе.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models import Base, QuizQuestion, QuizRound, QuizSession, UserStat
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/quiz.db")
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _prepare():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    async def _get_session():
+        async with factory() as session:
+            yield session
+
+    asyncio.run(_prepare())
+    monkeypatch.setattr("app.handlers.quiz.get_session", _get_session)
+    yield factory
+    asyncio.run(engine.dispose())
+
+
+def _make_bot() -> AsyncMock:
+    """Бот-мок: send_message возвращает объект с настоящим message_id (иначе
+    board_message_id в state_json — AsyncMock, и JSON-сериализация падает)."""
+    bot = AsyncMock()
+    counter = {"n": 0}
+
+    async def _send(*args, **kwargs):
+        counter["n"] += 1
+        return SimpleNamespace(message_id=5000 + counter["n"], chat=SimpleNamespace(id=100))
+
+    bot.send_message = AsyncMock(side_effect=_send)
+    return bot
+
+
+def _msg(text: str, user_id: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        chat=SimpleNamespace(id=100),
+        message_thread_id=42,
+        message_id=1000 + user_id,
+        text=text,
+        from_user=SimpleNamespace(id=user_id, username=f"u{user_id}", full_name=f"U{user_id}"),
+    )
+
+
+def _prime(monkeypatch, seconds=1, brk=0):
+    from app.handlers import quiz as h
+    from app.services import quiz as q
+    monkeypatch.setattr(h.settings, "forum_chat_id", 100)
+    monkeypatch.setattr(h.settings, "topic_games", 42)
+    monkeypatch.setattr(q, "QUESTIONS_PER_ROUND", 3)
+    monkeypatch.setattr(q, "SECONDS_PER_QUESTION", seconds)
+    monkeypatch.setattr(q, "BREAK_SECONDS", brk)
+    monkeypatch.setattr(h.q, "QUESTIONS_PER_ROUND", 3)
+    monkeypatch.setattr(h.q, "SECONDS_PER_QUESTION", seconds)
+    monkeypatch.setattr(h.q, "BREAK_SECONDS", brk)
+    h._chat_locks.clear()
+    h._answer_events.clear()
+    h._running.clear()
+
+
+def test_full_round_exact_accounting(db, monkeypatch) -> None:
+    """Тур из 3 вопросов, 2 игрока: точная сверка очков, монет, истории.
+
+    Сценарий: В1 — Аня ошибается, потом отвечает верно; В2 — Петя верно
+    (Аня после него — не считается); В3 — никто. Итог: Аня 1, Петя 1 —
+    оба победители (+100 каждому).
+    """
+    from app.handlers import quiz as h
+    from app.services import quiz as q
+    from app.services.quiz import COINS_PER_CORRECT, WINNER_BONUS
+
+    _prime(monkeypatch, seconds=2, brk=0)
+
+    async def _run():
+        async with db() as session:
+            for i, (qq, aa) in enumerate([
+                ("Столица Франции?", "Париж"),
+                ("Царь зверей?", "лев"),
+                ("2+2?", "4"),
+            ]):
+                session.add(QuizQuestion(id=i + 1, question=qq, answer=aa))
+            await session.commit()
+
+        bot = _make_bot()
+        reason = await h._launch_quiz(bot, 100)
+        assert reason is None
+        await asyncio.sleep(0.05)
+
+        async def _current_answer() -> str:
+            async for session in h.get_session():
+                state = await h.q.load_session(session, 100)
+                await session.commit()
+                return state.current_answer
+            return ""
+
+        # Вопрос 1 (порядок случайный — отвечаем по фактическому эталону):
+        # Аня ошибается, затем верно; Петя после — уже поздно.
+        answer1 = await _current_answer()
+        await h.on_answer(_msg("явно неверный ответ", 1), bot)   # мимо
+        await h.on_answer(_msg(f"это {answer1}", 1), bot)        # верно, Аня забирает
+        await h.on_answer(_msg(answer1, 2), bot)                 # поздно — забран
+        await _wait_phase(h, "asking", index=1)
+
+        # Вопрос 2: Петя отвечает верно.
+        answer2 = await _current_answer()
+        await h.on_answer(_msg(f"{answer2} конечно", 2), bot)
+        await _wait_phase(h, "asking", index=2)
+
+        # Вопрос 3: никто не отвечает — таймаут (2 сек).
+        await asyncio.wait_for(h._running[100], timeout=15)
+
+        async with db() as session:
+            u1 = await session.get(UserStat, {"user_id": 1, "chat_id": 100})
+            u2 = await session.get(UserStat, {"user_id": 2, "chat_id": 100})
+            rounds = (await session.execute(select(QuizRound))).scalars().all()
+            sessions = (await session.execute(select(QuizSession))).scalars().all()
+            return u1, u2, rounds, sessions
+
+    async def _wait_phase(h, phase: str, index: int) -> None:
+        """Ждём, пока driver продвинет тур до нужного вопроса."""
+        for _ in range(100):
+            await asyncio.sleep(0.05)
+            async for session in __import__("app.handlers.quiz", fromlist=["get_session"]).get_session():
+                state = await h.q.load_session(session, 100)
+                await session.commit()
+                break
+            if state is not None and state.phase == phase and state.index == index:
+                return
+        raise AssertionError(f"тур не дошёл до {phase}/{index}")
+
+    u1, u2, rounds, sessions = asyncio.run(_run())
+
+    # Монеты: ровно 1 верный у каждого + бонус победителя обоим (ничья 1:1).
+    assert u1.coins == 200 + COINS_PER_CORRECT + WINNER_BONUS
+    assert u2.coins == 200 + COINS_PER_CORRECT + WINNER_BONUS
+
+    # История: по строке на участника, оба победители, суммы сходятся.
+    assert len(rounds) == 2
+    for r in rounds:
+        assert r.correct_answers == 1
+        assert r.is_winner is True
+        assert r.coins_awarded == COINS_PER_CORRECT + WINNER_BONUS
+
+    assert sessions == []  # сессия закрыта
+
+
+def test_removed_question_keeps_numbering(db, monkeypatch) -> None:
+    """Вопрос снят из базы во время тура: нумерация сплошная, слот не съеден."""
+    from app.handlers import quiz as h
+    from app.services import quiz as q
+
+    _prime(monkeypatch, seconds=1, brk=0)
+
+    async def _run():
+        async with db() as session:
+            session.add(QuizQuestion(id=1, question="Q1?", answer="a1"))
+            session.add(QuizQuestion(id=3, question="Q3?", answer="a3"))
+            await session.commit()
+        # Сессия вручную: второй вопрос (id=2) не существует.
+        async with db() as session:
+            state = q.QuizState(
+                phase="break", question_ids=[1, 2, 3], index=0,
+                current_answer="a1", question_text="Q1?",
+            )
+            await q.save_session(session, 100, 42, state)
+            await session.commit()
+
+        bot = _make_bot()
+        h._start_driver(bot, 100)
+        await asyncio.wait_for(h._running[100], timeout=15)
+        return bot
+
+    bot = asyncio.run(_run())
+
+    # Заголовки отправленных вопросов: сплошная нумерация из фактического
+    # количества («1/2», «2/2») — без скачка «3/3».
+    texts = [c.args[1] for c in bot.send_message.await_args_list if "Вопрос" in str(c.args[1])]
+    assert any("Вопрос 2/2" in t for t in texts), texts
+    assert not any("/3" in t for t in texts), texts

--- a/tests/test_quiz_driver.py
+++ b/tests/test_quiz_driver.py
@@ -37,6 +37,19 @@ def db(tmp_path, monkeypatch):
     asyncio.run(engine.dispose())
 
 
+def _make_bot() -> AsyncMock:
+    """Бот-мок с настоящим message_id в ответе send_message (для state_json)."""
+    bot = AsyncMock()
+    counter = {"n": 0}
+
+    async def _send(*args, **kwargs):
+        counter["n"] += 1
+        return SimpleNamespace(message_id=5000 + counter["n"], chat=SimpleNamespace(id=100))
+
+    bot.send_message = AsyncMock(side_effect=_send)
+    return bot
+
+
 def _prime(monkeypatch, questions_per_round=2, seconds=1, brk=0):
     from app.handlers import quiz as h
     from app.services import quiz as q
@@ -66,7 +79,7 @@ def test_full_round_completes_without_deadlock(db, monkeypatch) -> None:
             await session.commit()
 
     asyncio.run(_seed())
-    bot = AsyncMock()
+    bot = _make_bot()
 
     async def _run():
         reason = await h._launch_quiz(bot, 100)
@@ -108,7 +121,7 @@ def test_missing_last_question_still_finishes(db, monkeypatch) -> None:
             await session.commit()
 
     asyncio.run(_seed_and_break())
-    bot = AsyncMock()
+    bot = _make_bot()
 
     async def _run():
         h._start_driver(bot, 100)
@@ -136,7 +149,7 @@ def test_correct_answer_ends_question_fast(db, monkeypatch) -> None:
             await session.commit()
 
     asyncio.run(_seed())
-    bot = AsyncMock()
+    bot = _make_bot()
 
     async def _run():
         await h._launch_quiz(bot, 100)
@@ -146,7 +159,7 @@ def test_correct_answer_ends_question_fast(db, monkeypatch) -> None:
             text="Париж",
             from_user=SimpleNamespace(id=7, username="u", full_name="U"),
         )
-        await h.on_answer(msg)
+        await h.on_answer(msg, bot)
         # Если бы пробуждение терялось — тур висел бы 30с. Ждём максимум 5.
         await asyncio.wait_for(h._running[100], timeout=5)
 

--- a/tests/test_quiz_handler.py
+++ b/tests/test_quiz_handler.py
@@ -72,9 +72,9 @@ def test_first_correct_wins_and_awards(db, monkeypatch) -> None:
     asyncio.run(_start_asking(db, "Москва"))
 
     # Первый верный.
-    asyncio.run(h.on_answer(_answer_msg("Москва", user_id=1)))
+    asyncio.run(h.on_answer(_answer_msg("Москва", user_id=1), AsyncMock()))
     # Второй верный в тот же вопрос — уже поздно, вопрос забран.
-    asyncio.run(h.on_answer(_answer_msg("Москва", user_id=2)))
+    asyncio.run(h.on_answer(_answer_msg("Москва", user_id=2), AsyncMock()))
 
     async def _check():
         async with db() as session:
@@ -99,8 +99,8 @@ def test_wrong_answer_does_not_burn_attempt(db, monkeypatch) -> None:
     _prime_topic(monkeypatch)
     asyncio.run(_start_asking(db, "Москва"))
 
-    asyncio.run(h.on_answer(_answer_msg("привет", user_id=1)))  # болтовня
-    asyncio.run(h.on_answer(_answer_msg("Москва", user_id=1)))  # теперь верно
+    asyncio.run(h.on_answer(_answer_msg("привет", user_id=1), AsyncMock()))  # болтовня
+    asyncio.run(h.on_answer(_answer_msg("Москва", user_id=1), AsyncMock()))  # теперь верно
 
     async def _check():
         async with db() as session:
@@ -124,7 +124,7 @@ def test_answer_ignored_outside_asking_phase(db, monkeypatch) -> None:
             await session.commit()
 
     asyncio.run(_prep())
-    asyncio.run(h.on_answer(_answer_msg("Москва", user_id=1)))
+    asyncio.run(h.on_answer(_answer_msg("Москва", user_id=1), AsyncMock()))
 
     async def _check():
         async with db() as session:

--- a/tests/test_quiz_match.py
+++ b/tests/test_quiz_match.py
@@ -28,6 +28,23 @@ def test_typos_forgiven_for_long_words() -> None:
     assert check_answer("Достоевский", "достоевскй") is True
 
 
+def test_negated_answer_not_counted() -> None:
+    """Аудит подсчёта: «это не Париж» не должно засчитываться как «Париж»."""
+    assert check_answer("Париж", "не Париж") is False
+    assert check_answer("Париж", "это не Париж") is False
+    assert check_answer("Париж", "точно не париж") is False
+    # Но отрицание в стороне от ответа — не мешает.
+    assert check_answer("Париж", "не знаю, Париж") is True
+    assert check_answer("Париж", "не уверен но париж") is True
+
+
+def test_answers_containing_negation_still_work() -> None:
+    """Эталоны с «не/ни» внутри («Ни пуха, ни пера») матчатся как раньше."""
+    assert check_answer("Ни пуха, ни пера", "ни пуха ни пера") is True
+    assert check_answer("Москва слезам не верит", "москва слезам не верит") is True
+    assert check_answer("«Рукописи не горят»", "рукописи не горят") is True
+
+
 def test_transposition_counts_as_one_typo() -> None:
     """Дамерау: перестановка соседних букв — типичная опечатка быстрой печати."""
     assert check_answer("сатурация", "сатурцаия") is True


### PR DESCRIPTION
## Анимации

- **Реакции на ответы игроков** (родная анимация Telegram): верный ответ — случайная из 🎉🏆⚡🔥👏, неверный — 🤔. Ставятся вне лока (не тормозят приём других ответов), любые ошибки глотаются — игру не трогают.
- **Анимированный дротик 🎯** (`send_dice`) перед стартом тура — «прицелились, поехали».
- **«⚡ Осталось 10 секунд!»** — дописывается в сообщение вопроса, если его ещё никто не забрал: driver ждёт в две фазы (T−10, потом финал), `message_id` вопроса хранится в состоянии (переживает рестарт).

## Аудит подсчёта («вчера посчитали неверно») — найдено и починено

1. **«это не Париж» засчитывалось как «Париж»** — «лишние слова ок» игнорировало отрицание. Теперь слово под «не/ни» не матчится; эталоны, где отрицание — часть ответа («Ни пуха, ни пера», «Москва слезам не верит», их в базе 11), работают как раньше.
2. **Скачки нумерации вопросов**: вчера было 4 деплоя; синхронизация сида удаляла перефразированные вопросы, и если тур был активен — вопрос молча съедал номер (жители видели «3/15 → 5/15», что выглядит как неверный подсчёт). Снятый вопрос теперь вычёркивается из списка — нумерация сплошная.
3. Знаменатель в шапке вопроса — фактический размер тура, а не константа «/15».

**Сам механизм подсчёта подтверждён корректным**: новая симуляция полного тура (`test_quiz_accounting.py`) сверяет копейка в копейку — неверный ответ не считается, поздний верный не считается, первый верный +15, ничья по очкам → бонус +100 обоим, `QuizRound.coins_awarded` сходится с фактическими начислениями, сессия закрывается. Двойных начислений нет.

## Тесты
Новые: отрицание (и обратные кейсы с «не/ни» в эталоне), точная бухгалтерия полного тура, сплошная нумерация при снятом вопросе. Полный прогон: **288 passed, 4 skipped**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_