### PR TITLE
fix(audit-1): порог RAG, чистый вопрос, тесты перед деплоем, шифробэкап

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,29 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Тесты ПЕРЕД сборкой: прямой push в main (в т.ч. правка через веб-интерфейс)
+  # раньше уезжал в прод непроверенным — quality-gate гонялся только на PR.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run full test suite
+        run: |
+          pytest -q tests/ infra_catalog/tests/
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/app/config.py
+++ b/app/config.py
@@ -108,6 +108,14 @@ class Settings(BaseSettings):
     moderation_training_mode: bool = False
     # Утреннее приветствие с погодой и праздниками (8:00 в General)
     ai_daily_greeting: bool = False
+    # Выбрасывать ли накопившиеся апдейты при старте (разовая расчистка после
+    # долгого простоя). По умолчанию НЕТ — деплой не должен терять сообщения.
+    drop_pending_on_start: bool = False
+    # Ключ шифрования бэкапа БД (Fernet, base64). Генерация:
+    # python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    # Хранить ТОЛЬКО в GitHub Secrets (BOT_ENV). Пусто — бэкап шлётся без
+    # шифрования с предупреждением в caption.
+    backup_encryption_key: str | None = None
     db_logs_retention_days: int = 14
     db_stats_retention_days: int = 45
     google_sheets_spreadsheet_id: str = "1OsPh54Bn5fdkfsEJyKcbYZTcHnue3EWQ"

--- a/app/main.py
+++ b/app/main.py
@@ -1060,7 +1060,12 @@ async def main() -> None:
         polling_attempt = 0
         while True:
             try:
-                await bot.delete_webhook(drop_pending_updates=True)
+                # НЕ выбрасываем накопившиеся сообщения: рестарт/деплой в 20:0x
+                # съедал ответы жителей на викторину и команды. Полный дроп —
+                # только явным флагом (разовая расчистка после долгого простоя).
+                await bot.delete_webhook(
+                    drop_pending_updates=settings.drop_pending_on_start
+                )
                 try:
                     await dp.start_polling(
                         bot,

--- a/app/services/ai_module.py
+++ b/app/services/ai_module.py
@@ -1288,18 +1288,27 @@ class AnthropicProvider:
         self, prompt: str, context: list[str], *, chat_id: int,
         user_id: int | None = None, topic_id: int | None = None,
     ) -> str:
-        safe_prompt = mask_personal_data(prompt)[:1000]
-        if not is_assistant_topic_allowed(safe_prompt):
+        masked_full = mask_personal_data(prompt)
+        # Чистый вопрос жителя (без преамбулы «[Недавние сообщения…]») — по нему
+        # считаются ретрив, гейт, кэш и интент. Раньше всё это считалось по
+        # обрезку [:1000] ПОЛНОГО промпта: в заполненной теме сам вопрос стоит в
+        # хвосте и отрезался целиком — бот отвечал на сообщения соседей.
+        clean_question = _strip_prompt_scaffolding(masked_full)[:1000]
+        # Полный промпт для модели: обрезаем СЛЕВА — страдает старый контекст,
+        # а вопрос в хвосте сохраняется всегда.
+        safe_prompt = masked_full[-3000:]
+        if not is_assistant_topic_allowed(clean_question):
             return random.choice(_FORBIDDEN_TOPIC_REPLIES)
 
         # KB используется как контекст для AI, а не как прямой ответ.
         # Раньше при совпадении KB возвращался сырой текст из JSON без обработки AI,
         # что приводило к шаблонным ответам без учёта контекста вопроса.
         # Теперь AI всегда обрабатывает ответ, а KB предоставляет фактические данные.
+        # Ретрив — по чистому вопросу: контекст темы в запросе только шумел.
 
-        rag_text = await _get_rag_context(chat_id, safe_prompt)
-        faq_answer = await _get_faq_answer(chat_id, safe_prompt)
-        places_context = await _get_places_context(safe_prompt)
+        rag_text = await _get_rag_context(chat_id, clean_question)
+        faq_answer = await _get_faq_answer(chat_id, clean_question)
+        places_context = await _get_places_context(clean_question)
 
         # Статичная (кэшируемая) часть system-промпта.
         # Статичная (кэшируемая) часть: правила + персона + few-shot + ядро KB.
@@ -1312,13 +1321,13 @@ class AnthropicProvider:
         if topic_hint:
             dynamic_system_parts.append(topic_hint.lstrip("\n"))
 
-        resident_context = build_resident_context(safe_prompt, context=context)
+        resident_context = build_resident_context(clean_question, context=context)
 
         # Веб-поиск: если вопрос выходит за рамки локальной базы знаний
         web_context = ""
-        if should_search_web(safe_prompt) and not resident_context and not rag_text and not faq_answer:
+        if should_search_web(clean_question) and not resident_context and not rag_text and not faq_answer:
             try:
-                web_results = await search_duckduckgo(safe_prompt)
+                web_results = await search_duckduckgo(clean_question)
                 web_context = format_search_context(web_results)
             except Exception:
                 logger.warning("Веб-поиск при ответе ассистента не удался.")
@@ -1335,18 +1344,18 @@ class AnthropicProvider:
         _answer_cache_allowed = has_factual_context and not context
         # Ключ включает chat_id: ассистент работает и в форуме, и в лог-чате,
         # а RAG/FAQ scoped по чату — иначе ответ из одного чата утечёт в другой.
-        _cache_key = f"{chat_id}|{_normalize_cache_key(safe_prompt)}"
+        _cache_key = f"{chat_id}|{_normalize_cache_key(clean_question)}"
         if _answer_cache_allowed:
             _cached_reply = _cache_get(_cache_key)
             if _cached_reply:
-                logger.info("ANSWER_CACHE: hit chat=%s prompt=%r", chat_id, safe_prompt[:60])
+                logger.info("ANSWER_CACHE: hit chat=%s prompt=%r", chat_id, clean_question[:60])
                 return _cached_reply
 
         # Style-hint по интенту (после вычисления контекста — от него зависит пул).
         # Hint уходит в финальное user-сообщение (не в system), чтобы не ломать
         # prompt caching статичного префикса.
         chosen_hint = _pick_style_hint(
-            safe_prompt,
+            clean_question,
             has_factual_context=has_factual_context,
             chat_id=chat_id,
             user_id=user_id or 0,
@@ -1367,7 +1376,7 @@ class AnthropicProvider:
             "ANSWER_SOURCE: source=%s resident_ctx=%s rag=%s faq=%s places=%s web=%s prompt=%r user_id=%s topic_id=%s",
             _answer_source, bool(resident_context), bool(rag_text), bool(faq_answer),
             bool(places_context), bool(web_context),
-            safe_prompt[:80], user_id, topic_id,
+            clean_question[:80], user_id, topic_id,
         )
 
         # «Реже, но точнее»: фактический вопрос без опоры в базе знаний → честный
@@ -1377,23 +1386,21 @@ class AnthropicProvider:
         # уходят в модель — там точность фактов не нужна, а no_kb_notice ниже
         # всё равно запрещает выдумывать факты о ЖК. Короткий follow-up в живом
         # диалоге тоже пропускаем: ответ может содержаться в контексте беседы.
-        _is_short_followup = bool(context) and len(safe_prompt) < 40
+        _is_short_followup = bool(context) and len(clean_question) < 40
         if (
             settings.ai_require_grounding
             and not has_factual_context
             and not web_context
-            and not _looks_like_smalltalk(safe_prompt)
-            and _asks_local_facts(safe_prompt)
+            and not _looks_like_smalltalk(clean_question)
+            and _asks_local_facts(clean_question)
             and not _is_short_followup
         ):
-            logger.info("ANSWER_GATE: ungrounded factual question → honest 'не знаю' prompt=%r", safe_prompt[:80])
+            logger.info("ANSWER_GATE: ungrounded factual question → honest 'не знаю' prompt=%r", clean_question[:80])
             # Петля роста: вопрос без ответа копится для еженедельного дайджеста
             # админам (fire-and-forget — ответ жителю не ждёт записи в БД).
-            # Логируем чистый вопрос без служебной преамбулы контекста.
             try:
                 from app.services.unanswered import log_unanswered
-                clean_q = _strip_prompt_scaffolding(safe_prompt)
-                _spawn_background(log_unanswered(chat_id, clean_q))
+                _spawn_background(log_unanswered(chat_id, clean_question))
             except Exception:
                 pass
             return random.choice(_UNGROUNDED_REPLIES)
@@ -1488,7 +1495,7 @@ class AnthropicProvider:
         # ухудшает следование фактам и приводит к шаблонным «фантазиям».
         if has_factual_context:
             temperature = 0.5
-        elif _looks_like_smalltalk(safe_prompt):
+        elif _looks_like_smalltalk(clean_question):
             temperature = 0.75
         else:
             temperature = 0.7

--- a/app/services/backup.py
+++ b/app/services/backup.py
@@ -59,6 +59,7 @@ async def send_db_backup(bot: Bot) -> None:
 
     stamp = datetime.now(ZoneInfo(settings.timezone)).strftime("%Y-%m-%d_%H%M")
     tmp_path: Path | None = None
+    enc_path: Path | None = None
     try:
         # Консистентный снимок через SQLite Online Backup API — обычное копирование
         # файла могло бы поймать базу посреди записи. Само копирование —
@@ -69,19 +70,49 @@ async def send_db_backup(bot: Bot) -> None:
             tmp_path = Path(tmp.name)
         await asyncio.to_thread(_make_backup_copy, src, tmp_path)
 
-        size_mb = tmp_path.stat().st_size / (1024 * 1024)
+        # Шифрование: в БД лежат сообщения и профили жителей — открытым файлом
+        # в общий лог-чат такому ехать нельзя. Ключ — BACKUP_ENCRYPTION_KEY
+        # (Fernet) из секретов; без ключа шлём как раньше, но с предупреждением.
+        send_path = tmp_path
+        filename = f"bot_backup_{stamp}.db"
+        if settings.backup_encryption_key:
+            enc_path = Path(str(tmp_path) + ".enc")
+            await asyncio.to_thread(
+                _encrypt_file, tmp_path, enc_path, settings.backup_encryption_key
+            )
+            send_path = enc_path
+            filename += ".enc"
+            caption = (
+                f"💾 Ночной бэкап БД (зашифрован)\n"
+                "Расшифровка: python -c \"from cryptography.fernet import Fernet;"
+                "import sys;open('bot.db','wb').write(Fernet(open('key.txt','rb')"
+                ".read().strip()).decrypt(open(sys.argv[1],'rb').read()))\" файл.enc"
+            )
+        else:
+            caption = (
+                f"💾 Ночной бэкап БД\n"
+                "⚠️ НЕ зашифрован: задайте BACKUP_ENCRYPTION_KEY в секретах "
+                "(в БД — сообщения и профили жителей)."
+            )
+
+        size_mb = send_path.stat().st_size / (1024 * 1024)
         await bot.send_document(
             settings.admin_log_chat_id,
-            FSInputFile(tmp_path, filename=f"bot_backup_{stamp}.db"),
-            caption=(
-                f"💾 Ночной бэкап БД ({size_mb:.1f} МБ)\n"
-                "Восстановление: скачать файл → положить в data/bot.db → перезапустить бота."
-            ),
+            FSInputFile(send_path, filename=filename),
+            caption=f"{caption}\nРазмер: {size_mb:.1f} МБ",
             disable_notification=True,
         )
         logger.info("BACKUP: копия БД отправлена в админ-чат (%.1f МБ)", size_mb)
     except Exception:
         logger.warning("BACKUP: не удалось отправить копию БД.", exc_info=True)
     finally:
-        if tmp_path is not None:
-            tmp_path.unlink(missing_ok=True)
+        for p in (tmp_path, enc_path):
+            if p is not None:
+                p.unlink(missing_ok=True)
+
+
+def _encrypt_file(src: Path, dst: Path, key: str) -> None:
+    """Fernet-шифрование файла (синхронно — звать через to_thread)."""
+    from cryptography.fernet import Fernet
+
+    dst.write_bytes(Fernet(key.encode()).encrypt(src.read_bytes()))

--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -327,13 +327,22 @@ async def get_all_rag_messages(session: AsyncSession, chat_id: int) -> list[RagM
     return list(result.scalars().all())
 
 
+# Порог релевантности: документы с lexical_score ниже — НЕ опора для ответа.
+# Без порога любой вопрос получал топ-8 «фактов» (даже про шлагбаум на вопрос
+# о катке) → гейт от галлюцинаций никогда не срабатывал, а петля
+# «не знаю»-вопросов не наполнялась. Порог сравнивается с lexical_score ДО
+# бонуса is_admin (+0.08), иначе нерелевантные админ-записи просачивались бы.
+MIN_RAG_RELEVANCE = 0.05
+
+
 def rank_rag_messages(
     messages: list[RagMessage],
     *,
     query: str,
     top_k: int | None = None,
 ) -> list[RagMessage]:
-    """Ранжирует RAG-сообщения по TF-IDF релевантности и приоритету админских записей."""
+    """Ранжирует RAG-сообщения по TF-IDF релевантности и приоритету админских
+    записей. Нерелевантные (ниже MIN_RAG_RELEVANCE) отбрасываются полностью."""
     if not messages:
         return []
 
@@ -361,6 +370,8 @@ def rank_rag_messages(
         decay = _time_decay_factor(msg.created_at)
         # Итоговый score: tfidf + мягкое совпадение токенов, затем time_decay
         lexical_score = 0.75 * tfidf_score + 0.25 * overlap_score
+        if lexical_score < MIN_RAG_RELEVANCE:
+            continue  # не про этот вопрос — в опору не идёт
         final_score = lexical_score * (0.7 + 0.3 * decay)
         # Админские записи важны, но не должны подавлять релевантность запроса.
         if msg.is_admin:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ gspread==6.1.4
 google-auth==2.37.0
 pytest==8.1.1
 pymorphy3==2.0.6
+cryptography==41.0.7

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -1,0 +1,80 @@
+"""Регрессии аудита-1: порог RAG, чистый вопрос, шифрование бэкапа."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+
+def _rag_msg(text: str, *, is_admin: bool = False):
+    return SimpleNamespace(
+        message_text=text,
+        rag_canonical_text=None,
+        is_admin=is_admin,
+        created_at=datetime.now(timezone.utc),
+        rag_category=None,
+        rag_semantic_key=None,
+    )
+
+
+def test_rag_drops_irrelevant_documents() -> None:
+    """Главный фикс аудита: нерелевантные записи НЕ попадают в опору.
+
+    Раньше на любой вопрос возвращался топ-8 (даже про шлагбаум на вопрос о
+    катке) → гейт от галлюцинаций никогда не срабатывал.
+    """
+    from app.services.rag import rank_rag_messages
+
+    messages = [
+        _rag_msg("Шлагбаум открывается через приложение УК", is_admin=True),
+        _rag_msg("Пропуск на автомобиль оформляется у диспетчера"),
+        _rag_msg("Показания счётчиков подают до 25 числа"),
+    ]
+    # Вопрос совсем не про это — опора должна быть ПУСТОЙ.
+    ranked = rank_rag_messages(messages, query="где ближайший каток залить лёд")
+    assert ranked == []
+
+
+def test_rag_keeps_relevant_documents() -> None:
+    from app.services.rag import rank_rag_messages
+
+    messages = [
+        _rag_msg("Шлагбаум открывается через приложение УК", is_admin=True),
+        _rag_msg("Показания счётчиков подают до 25 числа"),
+    ]
+    ranked = rank_rag_messages(messages, query="как открыть шлагбаум")
+    assert len(ranked) >= 1
+    assert "Шлагбаум" in ranked[0].message_text
+
+
+def test_clean_question_survives_long_context() -> None:
+    """Вопрос жителя в конце длинного промпта не должен отрезаться."""
+    from app.services.ai_module import _strip_prompt_scaffolding
+
+    context_lines = "\n".join(f"- сосед {i}: бла-бла-бла что-то про погоду" for i in range(30))
+    full_prompt = (
+        "[Недавние сообщения в этой теме — контекст беседы]\n"
+        f"{context_lines}\n\n"
+        "[Реплика, на которую отвечаешь]\n"
+        "Где ближайшая аптека?"
+    )
+    assert len(full_prompt) > 1000  # раньше [:1000] отрезал вопрос целиком
+    clean = _strip_prompt_scaffolding(full_prompt)
+    assert clean == "Где ближайшая аптека?"
+
+
+def test_backup_encrypt_roundtrip(tmp_path) -> None:
+    """Шифрование бэкапа: файл расшифровывается тем же ключом."""
+    from cryptography.fernet import Fernet
+
+    from app.services.backup import _encrypt_file
+
+    key = Fernet.generate_key().decode()
+    src = tmp_path / "bot.db"
+    src.write_bytes(b"sqlite fake data \x00\x01")
+    dst = tmp_path / "bot.db.enc"
+    _encrypt_file(src, dst, key)
+
+    assert dst.read_bytes() != src.read_bytes()  # реально зашифровано
+    decrypted = Fernet(key.encode()).decrypt(dst.read_bytes())
+    assert decrypted == src.read_bytes()

--- a/tests/test_rag_knowledge_base.py
+++ b/tests/test_rag_knowledge_base.py
@@ -86,10 +86,11 @@ def test_rag_message_is_available_immediately_after_save() -> None:
     assert messages[0] == "Шлагбаум открывается через приложение УК."
 
 
-def test_rag_ranking_keeps_all_knowledge_base_records() -> None:
+def test_rag_ranking_drops_irrelevant_records() -> None:
+    """Аудит-фикс: нерелевантные записи НЕ идут в опору. Раньше запись про лифт
+    попадала в контекст вопроса о шлагбауме, и гейт от галлюцинаций молчал."""
     messages = asyncio.run(_prepare_messages())
-    assert len(messages) == 2
-    assert "Для заявки по лифту пишите в топик Жалобы." in messages
+    assert messages == ["Шлагбаум открывается через приложение УК."]
 
 
 def test_rag_systematization_merges_similar_messages_in_context() -> None:


### PR DESCRIPTION
Первый PR по итогам большого аудита — критичные багфиксы.

## 1. Гейт от галлюцинаций был фактически мёртв 🔥
`rank_rag_messages` не имел порога релевантности: на **любой** вопрос возвращался топ-8 записей (про шлагбаум — на вопрос о катке), `has_factual_context` всегда True → гейт «честного не знаю» не срабатывал никогда, а петля «не знаю»-вопросов не наполнялась (дайджест пуст). Добавлен `MIN_RAG_RELEVANCE` — отсечение **до** бонуса `is_admin`, иначе нерелевантные админ-записи просачивались бы. Старый тест, закреплявший баг («запись про лифт остаётся в опоре вопроса о шлагбауме»), переписан на правильную семантику.

## 2. Вопрос жителя отрезался обрезкой промпта 🔥
`safe_prompt = prompt[:1000]`, а вопрос стоит в **хвосте** после контекста темы (~1300 симв.) — в активной теме бот отвечал на сообщения соседей; кэш, FAQ-ключи и интент считались по обрезку. Теперь: `clean_question` (через существующий `_strip_prompt_scaffolding`) — для ретрива, гейта, кэша, style-хинтов и логов; полный промпт модели обрезается **слева** `[-3000:]` — вопрос в хвосте не теряется. Бонус: ретрив по чистому вопросу заметно точнее.

## 3. Деплой без тестов
`build.yml`: job `test` (полный pytest) перед `build`→`deploy`. Прямой push в main (включая правку через веб-интерфейс) больше не уезжает в прод непроверенным.

## 4. Рестарт съедал сообщения
`drop_pending_updates=True` на каждом старте выбрасывал всё накопившееся (деплой в 20:0x стоил игрокам ответов на викторину). Теперь дроп только по явному флагу `DROP_PENDING_ON_START` (по умолчанию выключен).

## 5. Бэкап БД с данными жителей — теперь шифруется
Fernet-ключ `BACKUP_ENCRYPTION_KEY` из секретов (генерация: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"` — добавить в BOT_ENV). Без ключа бэкап шлётся как раньше, но с предупреждением в caption. Инструкция расшифровки — в caption. `cryptography` в requirements.

## Тесты
`test_audit_fixes.py`: нерелевантный RAG → пустая опора, релевантный остаётся; чистый вопрос выживает при длинном контексте; шифрование round-trip. Полный прогон: **292 passed, 4 skipped**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELkR37S8HHb1a1LjUwPcUt)_